### PR TITLE
Ensure that class ProtectionDomain cannot be accessed inside the sandbox.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# General build files
+**/build/*
+
+.gradle
+
 # DJVM-specific files
 **/tmp/
 *.log
@@ -11,3 +16,7 @@
 
 **/out/
 
+# vim
+*.swp
+*.swn
+*.swo

--- a/djvm/src/main/java/sandbox/java/lang/System.java
+++ b/djvm/src/main/java/sandbox/java/lang/System.java
@@ -2,7 +2,7 @@ package sandbox.java.lang;
 
 import net.corda.djvm.SandboxRuntimeContext;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("unused")
 public final class System extends Object {
 
     private System() {}

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.fail
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Type
@@ -71,7 +72,7 @@ abstract class TestBase {
 
         @JvmField
         val DETERMINISTIC_RT: Path = Paths.get(
-                System.getProperty("deterministic-rt.path") ?: throw AssertionError("deterministic-rt.path property not set"))
+                System.getProperty("deterministic-rt.path") ?: fail("deterministic-rt.path property not set"))
 
         private lateinit var parentConfiguration: SandboxConfiguration
         lateinit var parentClassLoader: SandboxClassLoader
@@ -156,7 +157,7 @@ abstract class TestBase {
      */
     fun sandbox(
         vararg options: Any,
-        pinnedClasses: Set<java.lang.Class<*>> = emptySet(),
+        pinnedClasses: Set<Class<*>> = emptySet(),
         minimumSeverityLevel: Severity = Severity.WARNING,
         enableTracing: Boolean = true,
         action: SandboxRuntimeContext.() -> Unit


### PR DESCRIPTION
The `ProtectionDomain` allows us to determine the source location of a `class` file, e.g. the URL of the JAR that contains it. This could theoretically allow us to determine whether or not we are running inside the sandbox. But regardless, there's no obvious way to map/wrap/transform a `java.security.ProtectionDomain` instance anyway so block this gap off.