### PR TITLE
Seal the DJVM jar artifacts to preserve the sandbox integrity.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -50,6 +50,10 @@ shadowJar {
     classifier ''
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
 
+    manifest {
+        attributes('Sealed': true)
+    }
+
     // These particular classes are only needed to "bootstrap"
     // the compilation of the other sandbox classes. At runtime,
     // we will generate better versions from deterministic-rt.jar.

--- a/djvm/cli/build.gradle
+++ b/djvm/cli/build.gradle
@@ -32,7 +32,8 @@ shadowJar {
             'Automatic-Module-Name': 'net.corda.djvm.cli',
             'Main-Class': 'net.corda.djvm.tools.cli.Program',
             'Build-Date': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-            'Class-Path': 'tmp/'
+            'Class-Path': 'tmp/',
+            'Sealed': true
         )
     }
 }


### PR DESCRIPTION
Seal the DJVM jars so that applications cannot provide their own versions of the template `sandbox.*` classes or tamper with the DJVM's working.