### PR TITLE
Ensure that method-specific definition rules are not also accidentally applied to fields.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
@@ -31,4 +31,6 @@ data class Member(
         val exceptions: MutableSet<String> = mutableSetOf(),
         val value: Any? = null,
         val body: List<MethodBody> = emptyList()
-) : MemberInformation, EntityWithAccessFlag
+) : MemberInformation, EntityWithAccessFlag {
+    val isMethod: Boolean = signature[0] == '('
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
@@ -15,13 +15,13 @@ import java.lang.reflect.Modifier
 object AlwaysUseNonSynchronizedMethods : MemberRule(), MemberDefinitionProvider {
 
     override fun validate(context: RuleContext, member: Member) = context.validate {
-        if (isConcrete(context.clazz)) {
+        if (member.isMethod && isConcrete(context.clazz)) {
             trace("Synchronization specifier will be ignored") given ((member.access and ACC_SYNCHRONIZED) == 0)
         }
     }
 
     override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        isConcrete(context.clazz) -> member.copy(access = member.access and ACC_SYNCHRONIZED.inv())
+        member.isMethod && isConcrete(context.clazz) -> member.copy(access = member.access and ACC_SYNCHRONIZED.inv())
         else -> member
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
@@ -17,13 +17,13 @@ import java.lang.reflect.Modifier
 object AlwaysUseStrictFloatingPointArithmetic : MemberRule(), MemberDefinitionProvider {
 
     override fun validate(context: RuleContext, member: Member) = context.validate {
-        if (isConcrete(context.clazz)) {
+        if (member.isMethod && isConcrete(context.clazz)) {
             trace("Strict floating-point arithmetic will be applied") given ((member.access and ACC_STRICT) == 0)
         }
     }
 
     override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        isConcrete(context.clazz) -> member.copy(access = member.access or ACC_STRICT)
+        member.isMethod && isConcrete(context.clazz) -> member.copy(access = member.access or ACC_STRICT)
         else -> member
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutNativeMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutNativeMethods.kt
@@ -14,7 +14,7 @@ import java.lang.reflect.Modifier
 object StubOutNativeMethods : MemberDefinitionProvider {
 
     override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        isNative(member) -> member.copy(
+        member.isMethod && isNative(member) -> member.copy(
             access = member.access and ACC_NATIVE.inv(),
             body = member.body + if (isForStubbing(member)) ::writeStubMethodBody else ::writeExceptionMethodBody
         )

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
@@ -13,7 +13,7 @@ import sandbox.net.corda.djvm.rules.RuleViolationError
 object StubOutReflectionMethods : MemberDefinitionProvider {
 
     override fun define(context: AnalysisRuntimeContext, member: Member): Member = when {
-        isConcreteApi(member) && isReflection(member) -> member.copy(body = member.body + ::writeMethodBody)
+        member.isMethod && isConcreteApi(member) && isReflection(member) -> member.copy(body = member.body + ::writeMethodBody)
         else -> member
     }
 


### PR DESCRIPTION
Some of these `ACC_xxx` flags have different meanings, depending on whether they're applied to methods or fields. So ensure that we're only modifying the byte-code as we intend.