### PR TITLE
Add support for java.lang.StrictMath and its native methods.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/Runtime.java
+++ b/djvm/src/main/java/sandbox/java/lang/Runtime.java
@@ -18,6 +18,10 @@ public final class Runtime extends Object {
         return 1;
     }
 
+    public long maxMemory() {
+        return Long.MAX_VALUE;
+    }
+
     public void loadLibrary(String libraryName) {}
 
     public void load(String fileName) {}

--- a/djvm/src/main/java/sandbox/java/lang/StrictMath.java
+++ b/djvm/src/main/java/sandbox/java/lang/StrictMath.java
@@ -1,0 +1,274 @@
+package sandbox.java.lang;
+
+@SuppressWarnings("unused")
+public final class StrictMath {
+    private StrictMath() {
+    }
+
+    public static final double E = java.lang.StrictMath.E;
+    public static final double PI = java.lang.StrictMath.PI;
+
+    public static double sin(double x) {
+        return java.lang.StrictMath.sin(x);
+    }
+
+    public static double cos(double x) {
+        return java.lang.StrictMath.cos(x);
+    }
+
+    public static double tan(double x) {
+        return java.lang.StrictMath.tan(x);
+    }
+
+    public static double asin(double x) {
+        return java.lang.StrictMath.asin(x);
+    }
+
+    public static double acos(double x) {
+        return java.lang.StrictMath.acos(x);
+    }
+
+    public static double atan(double x) {
+        return java.lang.StrictMath.atan(x);
+    }
+
+    public static double toRadians(double degrees) {
+        return java.lang.StrictMath.toRadians(degrees);
+    }
+
+    public static double toDegrees(double radians) {
+        return java.lang.StrictMath.toDegrees(radians);
+    }
+
+    public static double exp(double x) {
+        return java.lang.StrictMath.exp(x);
+    }
+
+    public static double log(double x) {
+        return java.lang.StrictMath.log(x);
+    }
+
+    public static double log10(double x) {
+        return java.lang.StrictMath.log10(x);
+    }
+
+    public static double sqrt(double x) {
+        return java.lang.StrictMath.sqrt(x);
+    }
+
+    public static double cbrt(double x) {
+        return java.lang.StrictMath.cbrt(x);
+    }
+
+    public static double IEEEremainder(double x, double y) {
+        return java.lang.StrictMath.IEEEremainder(x, y);
+    }
+
+    public static double ceil(double x) {
+        return java.lang.StrictMath.ceil(x);
+    }
+
+    public static double floor(double x) {
+        return java.lang.StrictMath.floor(x);
+    }
+
+    public static double rint(double x) {
+        return java.lang.StrictMath.rint(x);
+    }
+
+    public static double atan2(double y, double x) {
+        return java.lang.StrictMath.atan2(y, x);
+    }
+
+    public static double pow(double x, double y) {
+        return java.lang.StrictMath.pow(x, y);
+    }
+
+    public static int round(float x) {
+        return java.lang.StrictMath.round(x);
+    }
+
+    public static long round(double x) {
+        return java.lang.StrictMath.round(x);
+    }
+
+    public static int addExact(int x, int y) {
+        return java.lang.StrictMath.addExact(x, y);
+    }
+
+    public static long addExact(long x, long y) {
+        return java.lang.StrictMath.addExact(x, y);
+    }
+
+    public static int subtractExact(int x, int y) {
+        return java.lang.StrictMath.subtractExact(x, y);
+    }
+
+    public static long subtractExact(long x, long y) {
+        return java.lang.StrictMath.subtractExact(x, y);
+    }
+
+    public static int multiplyExact(int x, int y) {
+        return java.lang.StrictMath.multiplyExact(x, y);
+    }
+
+    public static long multiplyExact(long x, long y) {
+        return java.lang.StrictMath.multiplyExact(x, y);
+    }
+
+    public static int toIntExact(long x) {
+        return java.lang.StrictMath.toIntExact(x);
+    }
+
+    public static int floorDiv(int x, int y) {
+        return java.lang.StrictMath.floorDiv(x, y);
+    }
+
+    public static long floorDiv(long x, long y) {
+        return java.lang.StrictMath.floorDiv(x, y);
+    }
+
+    public static int floorMod(int x, int y) {
+        return java.lang.StrictMath.floorMod(x, y);
+    }
+
+    public static long floorMod(long x, long y) {
+        return java.lang.StrictMath.floorMod(x, y);
+    }
+
+    public static int abs(int x) {
+        return java.lang.StrictMath.abs(x);
+    }
+
+    public static long abs(long x) {
+        return java.lang.StrictMath.abs(x);
+    }
+
+    public static float abs(float x) {
+        return java.lang.StrictMath.abs(x);
+    }
+
+    public static double abs(double x) {
+        return java.lang.StrictMath.abs(x);
+    }
+
+    public static int max(int x, int y) {
+        return java.lang.StrictMath.max(x, y);
+    }
+
+    public static long max(long x, long y) {
+        return java.lang.StrictMath.max(x, y);
+    }
+
+    public static float max(float x, float y) {
+        return java.lang.StrictMath.max(x, y);
+    }
+
+    public static double max(double x, double y) {
+        return java.lang.StrictMath.max(x, y);
+    }
+
+    public static int min(int x, int y) {
+        return java.lang.StrictMath.min(x, y);
+    }
+
+    public static long min(long x, long y) {
+        return java.lang.StrictMath.min(x, y);
+    }
+
+    public static float min(float x, float y) {
+        return java.lang.StrictMath.min(x, y);
+    }
+
+    public static double min(double x, double y) {
+        return java.lang.StrictMath.min(x, y);
+    }
+
+    public static double ulp(double x) {
+        return java.lang.StrictMath.ulp(x);
+    }
+
+    public static float ulp(float x) {
+        return java.lang.StrictMath.ulp(x);
+    }
+
+    public static double signum(double x) {
+        return java.lang.StrictMath.signum(x);
+    }
+
+    public static float signum(float x) {
+        return java.lang.StrictMath.signum(x);
+    }
+
+    public static double sinh(double x) {
+        return java.lang.StrictMath.sinh(x);
+    }
+
+    public static double cosh(double x) {
+        return java.lang.StrictMath.cosh(x);
+    }
+
+    public static double tanh(double x) {
+        return java.lang.StrictMath.tanh(x);
+    }
+
+    public static double hypot(double x, double y) {
+        return java.lang.StrictMath.hypot(x, y);
+    }
+
+    public static double expm1(double x) {
+        return java.lang.StrictMath.expm1(x);
+    }
+
+    public static double log1p(double x) {
+        return java.lang.StrictMath.log1p(x);
+    }
+
+    public static double copySign(double magnitude, double sign) {
+        return java.lang.StrictMath.copySign(magnitude, sign);
+    }
+
+    public static float copySign(float magnitude, float sign) {
+        return java.lang.StrictMath.copySign(magnitude, sign);
+    }
+
+    public static int getExponent(float x) {
+        return java.lang.StrictMath.getExponent(x);
+    }
+
+    public static int getExponent(double x) {
+        return java.lang.StrictMath.getExponent(x);
+    }
+
+    public static double nextAfter(double start, double direction) {
+        return java.lang.StrictMath.nextAfter(start, direction);
+    }
+
+    public static float nextAfter(float start, double direction) {
+        return java.lang.StrictMath.nextAfter(start, direction);
+    }
+
+    public static double nextUp(double x) {
+        return java.lang.StrictMath.nextUp(x);
+    }
+
+    public static float nextUp(float x) {
+        return java.lang.StrictMath.nextUp(x);
+    }
+
+    public static double nextDown(double x) {
+        return java.lang.StrictMath.nextDown(x);
+    }
+
+    public static float nextDown(float x) {
+        return java.lang.StrictMath.nextDown(x);
+    }
+
+    public static double scalb(double x, int scaleFactor) {
+        return java.lang.StrictMath.scalb(x, scaleFactor);
+    }
+
+    public static float scalb(float x, int scaleFactor) {
+        return java.lang.StrictMath.scalb(x, scaleFactor);
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -142,6 +142,7 @@ class AnalysisConfiguration private constructor(
             java.lang.Number::class.java,
             java.lang.Runtime::class.java,
             java.lang.Short::class.java,
+            java.lang.StrictMath::class.java,
             java.lang.String::class.java,
             java.lang.String.CASE_INSENSITIVE_ORDER::class.java,
             java.lang.System::class.java,

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
@@ -49,10 +49,6 @@ object DisallowCatchingBlacklistedExceptions : Emitter {
         }
     }
 
-    private val handlers = mutableSetOf<Label>()
-
-    private fun isExceptionHandler(label: Label) = label in handlers
-
     /**
      * We need to invoke this emitter before the [HandleExceptionUnwrapper]
      * so that we don't unwrap exceptions we don't want to catch.


### PR DESCRIPTION
Allow the native methods of `java.lang.StrictMath` within the sandbox by wrapping them inside a template class.