### PR TITLE
Reject classes that implement internal DJVM-specific methods.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/Boolean.java
+++ b/djvm/src/main/java/sandbox/java/lang/Boolean.java
@@ -59,7 +59,7 @@ public final class Boolean extends Object implements Comparable<Boolean>, Serial
 
     @Override
     @NotNull
-    java.lang.Boolean fromDJVM() {
+    protected java.lang.Boolean fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Byte.java
+++ b/djvm/src/main/java/sandbox/java/lang/Byte.java
@@ -74,7 +74,7 @@ public final class Byte extends Number implements Comparable<Byte> {
 
     @Override
     @NotNull
-    java.lang.Byte fromDJVM() {
+    protected java.lang.Byte fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Character.java
+++ b/djvm/src/main/java/sandbox/java/lang/Character.java
@@ -114,7 +114,7 @@ public final class Character extends Object implements Comparable<Character>, Se
 
     @Override
     @NotNull
-    java.lang.Character fromDJVM() {
+    protected java.lang.Character fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
@@ -31,7 +31,7 @@ final class DJVMThrowableWrapper extends Throwable {
 
     @Override
     @NotNull
-    final java.lang.Throwable fromDJVM() {
+    final protected java.lang.Throwable fromDJVM() {
         return throwable;
     }
 }

--- a/djvm/src/main/java/sandbox/java/lang/Double.java
+++ b/djvm/src/main/java/sandbox/java/lang/Double.java
@@ -88,7 +88,7 @@ public final class Double extends Number implements Comparable<Double> {
 
     @Override
     @NotNull
-    java.lang.Double fromDJVM() {
+    protected java.lang.Double fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Enum.java
+++ b/djvm/src/main/java/sandbox/java/lang/Enum.java
@@ -28,7 +28,7 @@ public abstract class Enum<E extends Enum<E>> extends Object implements Comparab
 
     @Override
     @NotNull
-    final java.lang.Enum<?> fromDJVM() {
+    final protected java.lang.Enum<?> fromDJVM() {
         throw new UnsupportedOperationException("Dummy implementation");
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Float.java
+++ b/djvm/src/main/java/sandbox/java/lang/Float.java
@@ -50,7 +50,7 @@ public final class Float extends Number implements Comparable<Float> {
 
     @Override
     @NotNull
-    java.lang.Float fromDJVM() {
+    protected java.lang.Float fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Integer.java
+++ b/djvm/src/main/java/sandbox/java/lang/Integer.java
@@ -82,7 +82,7 @@ public final class Integer extends Number implements Comparable<Integer> {
 
     @Override
     @NotNull
-    java.lang.Integer fromDJVM() {
+    protected java.lang.Integer fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Long.java
+++ b/djvm/src/main/java/sandbox/java/lang/Long.java
@@ -78,7 +78,7 @@ public final class Long extends Number implements Comparable<Long> {
 
     @Override
     @NotNull
-    java.lang.Long fromDJVM() {
+    protected java.lang.Long fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Object.java
+++ b/djvm/src/main/java/sandbox/java/lang/Object.java
@@ -22,7 +22,7 @@ public class Object {
     }
 
     @NotNull
-    java.lang.Object fromDJVM() {
+    protected java.lang.Object fromDJVM() {
         return this;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Short.java
+++ b/djvm/src/main/java/sandbox/java/lang/Short.java
@@ -60,7 +60,7 @@ public final class Short extends Number implements Comparable<Short> {
 
     @Override
     @NotNull
-    java.lang.Short fromDJVM() {
+    protected java.lang.Short fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -187,7 +187,7 @@ public final class String extends Object implements Comparable<String>, CharSequ
 
     @Override
     @NotNull
-    java.lang.String fromDJVM() {
+    protected java.lang.String fromDJVM() {
         return value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/Throwable.java
+++ b/djvm/src/main/java/sandbox/java/lang/Throwable.java
@@ -160,7 +160,7 @@ public class Throwable extends Object implements Serializable {
 
     @Override
     @NotNull
-    java.lang.Throwable fromDJVM() {
+    protected java.lang.Throwable fromDJVM() {
         return DJVM.fromDJVM(this);
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -36,6 +36,7 @@ class SandboxConfiguration private constructor(
             AlwaysUseStrictFloatingPointArithmetic,
             DisallowDynamicInvocation,
             DisallowOverriddenSandboxPackage,
+            DisallowSandboxMethods,
             DisallowUnsupportedApiVersions
         ))
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -287,7 +287,7 @@ class AnalysisConfiguration private constructor(
          */
         private val STITCHED_CLASSES: Map<String, List<Member>> = listOf(
             object : MethodBuilder(
-                access = ACC_FINAL,
+                access = ACC_FINAL or ACC_PROTECTED,
                 className = sandboxed(Enum::class.java),
                 memberName = "fromDJVM",
                 descriptor = "()Ljava/lang/Enum;",
@@ -302,7 +302,7 @@ class AnalysisConfiguration private constructor(
              .build(),
 
             object : MethodBuilder(
-                access = ACC_BRIDGE or ACC_SYNTHETIC,
+                access = ACC_BRIDGE or ACC_SYNTHETIC or ACC_PROTECTED,
                 className = sandboxed(Enum::class.java),
                 memberName = "fromDJVM",
                 descriptor = "()Ljava/lang/Object;"

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowSandboxMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowSandboxMethods.kt
@@ -1,0 +1,16 @@
+package net.corda.djvm.rules.implementation
+
+import net.corda.djvm.references.Member
+import net.corda.djvm.rules.MemberRule
+import net.corda.djvm.validation.RuleContext
+
+object DisallowSandboxMethods : MemberRule() {
+    override fun validate(context: RuleContext, member: Member) = context.validate {
+        fail("Class is not allowed to implement toDJVMString()") given (
+            member.memberName == "toDJVMString" && member.descriptor == "()Ljava/lang/String;"
+        )
+        fail("Class is not allowed to implement fromDJVM${member.descriptor}") given (
+            member.memberName == "fromDJVM" && member.descriptor.startsWith("()")
+        )
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -1,0 +1,60 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import net.corda.djvm.rewiring.SandboxClassLoadingException;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaliciousClassTest extends TestBase {
+    @Test
+    void testImplementingToDJVMString() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(SandboxClassLoadingException.class, () -> WithJava.run(executor, EvilToString.class, ""));
+            assertThat(ex)
+                .hasMessageContaining("Class is not allowed to implement toDJVMString()");
+            return null;
+        });
+    }
+
+    public static class EvilToString implements Function<String, String> {
+        @Override
+        public String apply(String s) {
+            return toString();
+        }
+
+        @SuppressWarnings("unused")
+        public String toDJVMString() {
+            throw new IllegalStateException("MUHAHAHAHAHAHA!!!");
+        }
+    }
+
+    @Test
+    void testImplementingFromDJVM() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Object, Object> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(SandboxClassLoadingException.class, () -> WithJava.run(executor, EvilFromDJVM.class, null));
+            assertThat(ex)
+                .hasMessageContaining("Class is not allowed to implement fromDJVM()");
+            return null;
+        });
+    }
+
+    public static class EvilFromDJVM implements Function<Object, Object> {
+        @Override
+        public Object apply(Object obj) {
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        protected Object fromDJVM() {
+            throw new IllegalStateException("MUHAHAHAHAHAHA!!!");
+        }
+    }
+}


### PR DESCRIPTION
Do not load classes that implement methds `toDJVMString()` or `fromDJVM()` because these methods have special significance inside the sandbox.