### PR TITLE
CORDA-2871: Allow DJVM to analyse classes on-the-fly.

### DIFF
--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -56,7 +56,7 @@ abstract class ClassCommand : CommandBase() {
 
     private lateinit var classLoader: ClassLoader
 
-    protected var executor = SandboxExecutor<Any, Any>(SandboxConfiguration.DEFAULT)
+    protected var executor = SandboxExecutor<Any, Any>(SandboxConfiguration.DEFAULT, validating = true)
 
     abstract fun processClasses(classes: List<Class<*>>)
 
@@ -194,7 +194,7 @@ abstract class ClassCommand : CommandBase() {
     }
 
     private fun createExecutor(configuration: SandboxConfiguration) {
-        executor = SandboxExecutor(configuration)
+        executor = SandboxExecutor(configuration, validating = true)
     }
 
     private fun <T> Boolean.emptyListIfTrueOtherwiseNull(): List<T>? = when (this) {

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/DeterministicSandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/DeterministicSandboxExecutor.kt
@@ -14,7 +14,7 @@ import java.util.function.Function
  */
 class DeterministicSandboxExecutor<TInput, TOutput>(
         configuration: SandboxConfiguration
-) : SandboxExecutor<TInput, TOutput>(configuration) {
+) : SandboxExecutor<TInput, TOutput>(configuration, false) {
 
     /**
      * Short-hand for running a [Function] in a sandbox by its type reference.

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
@@ -56,7 +56,7 @@ class IsolatedTask(
                 else -> null
             }
         } ?: MessageCollection()
-        return Result(threadName, output, costs, messages, exception)
+        return Result(threadName, output, costs, messages.acceptProvisional(), exception)
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
@@ -76,9 +76,10 @@ class MessageCollection(
     /**
      * Accept all provisional messages.
      */
-    fun acceptProvisional() {
+    fun acceptProvisional(): MessageCollection {
         addAll(provisional)
         clearProvisional()
+        return this
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -166,7 +166,16 @@ private val homeDirectory: Path
  * Does [name] exist within any of the packages reserved for Java itself?
  */
 private fun isJvmInternal(name: String): Boolean = name.startsWith("java/")
-        || name.startsWith("javax/")
-        || name.startsWith("com/sun/")
         || name.startsWith("sun/")
+        || name.startsWith("com/sun/")
+        || isJavaxInternal(name)
         || name.startsWith("jdk/")
+
+private fun isJavaxInternal(name: String): Boolean {
+    return name.startsWith("javax/") && name.substring("javax/".length).run {
+        startsWith("activation/")
+            || startsWith("crypto/")
+            || startsWith("security/")
+            || startsWith("xml/")
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import sandbox.net.corda.djvm.rules.RuleViolationError
 import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.function.Function
 import java.util.stream.Collectors.*
 
@@ -344,16 +345,16 @@ class SandboxExecutorTest : TestBase() {
 
     @Test
     fun `can load and execute code that uses IO`() = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<Int, Int>(configuration)
+        val contractExecutor = DeterministicSandboxExecutor<String, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
-                .isThrownBy { contractExecutor.run<TestIO>(0) }
-                .withCauseInstanceOf(SandboxClassLoadingException::class.java)
-                .withMessageContaining("Class file not found; java/nio/file/Files.class")
+            .isThrownBy { contractExecutor.run<TestIO>("test.dat") }
+            .withCauseInstanceOf(SandboxClassLoadingException::class.java)
+            .withMessageContaining("Class file not found; java/nio/file/Paths.class")
     }
 
-    class TestIO : Function<Int, Int> {
-        override fun apply(input: Int): Int {
-            val file = Files.createTempFile("test", ".dat")
+    class TestIO : Function<String, Int> {
+        override fun apply(input: String): Int {
+            val file = Paths.get(input)
             Files.newBufferedWriter(file).use {
                 it.write("Hello world!")
             }


### PR DESCRIPTION
Allow DJVM to analyse classes on-the-fly instead of trying to do everything up-front. Not every referenced class is guaranteed to exist, but we're not going to be executing every code path either.