### PR TITLE
CORDA-3045: Tighten rules around ClassLoader usage.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -12,7 +12,7 @@ import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.SourceClassLoader
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import sandbox.net.corda.djvm.costing.RUNTIME_ACCOUNTER_NAME
+import sandbox.RUNTIME_ACCOUNTER_NAME
 import java.io.Closeable
 import java.io.IOException
 import java.lang.reflect.Modifier
@@ -127,7 +127,6 @@ class AnalysisConfiguration private constructor(
          * They should already exist within the sandbox namespace.
          */
         private val MANDATORY_PINNED_CLASSES: Set<String> = setOf(
-            RUNTIME_ACCOUNTER_NAME,
             ruleViolationError,
             thresholdViolationError
         )
@@ -166,6 +165,7 @@ class AnalysisConfiguration private constructor(
         ).sandboxed() + setOf(
             "sandbox/Task",
             "sandbox/TaskTypes",
+            RUNTIME_ACCOUNTER_NAME,
             "sandbox/java/lang/Character\$Cache",
             "sandbox/java/lang/DJVM",
             "sandbox/java/lang/DJVMException",

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -2,7 +2,6 @@ package net.corda.djvm.analysis
 
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.ruleViolationError
-import net.corda.djvm.code.thresholdViolationError
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.ClassModule
 import net.corda.djvm.references.Member
@@ -127,8 +126,7 @@ class AnalysisConfiguration private constructor(
          * They should already exist within the sandbox namespace.
          */
         private val MANDATORY_PINNED_CLASSES: Set<String> = setOf(
-            ruleViolationError,
-            thresholdViolationError
+            ruleViolationError
         )
 
         /**

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -12,7 +12,7 @@ import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.SourceClassLoader
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import sandbox.net.corda.djvm.costing.RuntimeCostAccounter
+import sandbox.net.corda.djvm.costing.RUNTIME_ACCOUNTER_NAME
 import java.io.Closeable
 import java.io.IOException
 import java.lang.reflect.Modifier
@@ -127,7 +127,7 @@ class AnalysisConfiguration private constructor(
          * They should already exist within the sandbox namespace.
          */
         private val MANDATORY_PINNED_CLASSES: Set<String> = setOf(
-            RuntimeCostAccounter.TYPE_NAME,
+            RUNTIME_ACCOUNTER_NAME,
             ruleViolationError,
             thresholdViolationError
         )

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -6,7 +6,7 @@ import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import sandbox.net.corda.djvm.costing.RuntimeCostAccounter
+import sandbox.net.corda.djvm.costing.RUNTIME_ACCOUNTER_NAME
 
 /**
  * Helper functions for emitting code to a method body.
@@ -282,7 +282,7 @@ class EmitterModule(
      * Emit instruction for invoking a method on the static runtime cost accounting and instrumentation object.
      */
     fun invokeInstrumenter(methodName: String, methodSignature: String) {
-        invokeStatic(RuntimeCostAccounter.TYPE_NAME, methodName, methodSignature)
+        invokeStatic(RUNTIME_ACCOUNTER_NAME, methodName, methodSignature)
     }
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -6,7 +6,7 @@ import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import sandbox.net.corda.djvm.costing.RUNTIME_ACCOUNTER_NAME
+import sandbox.RUNTIME_ACCOUNTER_NAME
 
 /**
  * Helper functions for emitting code to a method body.

--- a/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
@@ -1,9 +1,9 @@
 @file:JvmName("Types")
 package net.corda.djvm.code
 
+import net.corda.djvm.costing.ThresholdViolationError
 import org.objectweb.asm.Type
 import sandbox.java.lang.DJVMException
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import sandbox.net.corda.djvm.rules.RuleViolationError
 
 /**

--- a/djvm/src/main/kotlin/net/corda/djvm/costing/ThresholdViolationError.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/costing/ThresholdViolationError.kt
@@ -1,4 +1,4 @@
-package sandbox.net.corda.djvm.costing
+package net.corda.djvm.costing
 
 /**
  * Exception thrown when a sandbox threshold is violated. This will kill the current thread and consequently exit the

--- a/djvm/src/main/kotlin/net/corda/djvm/costing/TypedRuntimeCost.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/costing/TypedRuntimeCost.kt
@@ -1,7 +1,6 @@
 package net.corda.djvm.costing
 
 import net.corda.djvm.utilities.loggerFor
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
 
 /**
  * Cost metric to be used in a sandbox environment. The metric has a threshold and a mechanism for reporting violations.

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
@@ -3,8 +3,8 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.code.*
 import net.corda.djvm.code.instructions.CodeLabel
 import net.corda.djvm.code.instructions.TryCatchBlock
+import net.corda.djvm.costing.ThresholdViolationError
 import org.objectweb.asm.Label
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
 
 /**
  * Rule that checks for attempted catches of [ThreadDeath], [ThresholdViolationError],

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteClassMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteClassMethods.kt
@@ -45,6 +45,13 @@ object RewriteClassMethods : Emitter {
                 } else if (instruction.memberName == "getProtectionDomain" && instruction.descriptor == "()Ljava/security/ProtectionDomain;") {
                     throwException<RuleViolationError>("Disallowed reference to API; ${memberFormatter.format(instruction.member)}")
                     preventDefault()
+                } else if (instruction.memberName == "getClassLoader" && instruction.descriptor == "()Ljava/lang/ClassLoader;") {
+                    invokeStatic(
+                        owner = "sandbox/java/lang/DJVM",
+                        name = "getClassLoader",
+                        descriptor = "(Ljava/lang/Class;)Ljava/lang/ClassLoader;"
+                    )
+                    preventDefault()
                 }
 
                 INVOKESTATIC -> if (instruction.memberName == "forName") {

--- a/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
+++ b/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
@@ -1,6 +1,6 @@
 @file:JvmName("RuntimeCostAccounter")
 @file:Suppress("unused")
-package sandbox.net.corda.djvm.costing
+package sandbox
 
 import net.corda.djvm.SandboxRuntimeContext
 
@@ -16,13 +16,7 @@ import net.corda.djvm.SandboxRuntimeContext
 /**
  * A static instance of the sandbox context which is used to keep track of the costs.
  */
-private val context: SandboxRuntimeContext
-    get() = SandboxRuntimeContext.instance
-
-/**
- * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
- */
-const val RUNTIME_ACCOUNTER_NAME: String = "sandbox/net/corda/djvm/costing/RuntimeCostAccounter"
+private val context: SandboxRuntimeContext = SandboxRuntimeContext.instance
 
 /**
  * Known / estimated allocation costs.

--- a/djvm/src/main/kotlin/sandbox/Task.kt
+++ b/djvm/src/main/kotlin/sandbox/Task.kt
@@ -7,6 +7,11 @@ import sandbox.java.lang.unsandbox
 
 typealias SandboxFunction<TInput, TOutput> = sandbox.java.util.function.Function<TInput, TOutput>
 
+/**
+ * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
+ */
+const val RUNTIME_ACCOUNTER_NAME: String = "sandbox/RuntimeCostAccounter"
+
 internal fun isEntryPoint(elt: StackTraceElement): Boolean {
     return elt.className == "sandbox.Task" && elt.methodName == "apply"
 }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -63,7 +63,7 @@ fun Throwable.escapeSandbox(): kotlin.Throwable {
         val escaping = if (Type.getInternalName(javaClass) in JVM_EXCEPTIONS) {
             // We map these exceptions to their equivalent JVM classes.
             @Suppress("unchecked_cast")
-            val escapingType = Class.forName(sandboxedName.fromSandboxPackage()) as Class<out kotlin.Throwable>
+            val escapingType = loadBootstrapClass(sandboxedName.fromSandboxPackage()) as Class<out kotlin.Throwable>
             try {
                 escapingType.getDeclaredConstructor(kotlin.String::class.java).newInstance(String.fromDJVM(message))
             } catch (e: NoSuchMethodException) {
@@ -107,6 +107,7 @@ internal fun Class<*>.toDJVMType(): Class<*> = loadSandboxClass(name.toSandboxPa
 internal fun Class<*>.fromDJVMType(): Class<*> = loadSandboxClass(name.fromSandboxPackage())
 
 private fun loadSandboxClass(name: kotlin.String): Class<*> = Class.forName(name, false, systemClassLoader)
+private fun loadBootstrapClass(name: kotlin.String): Class<*> = Class.forName(name, true, null)
 
 private fun kotlin.String.toSandboxPackage(): kotlin.String {
     return if (startsWith(SANDBOX_PREFIX)) {

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -219,8 +219,8 @@ val systemClassLoader: ClassLoader get() {
  * against users loading classes from outside the sandbox.
  */
 @Throws(ClassNotFoundException::class)
-fun classForName(className: kotlin.String, initialize: kotlin.Boolean, classLoader: ClassLoader): Class<*> {
-    return Class.forName(toSandbox(className), initialize, classLoader)
+fun classForName(className: kotlin.String, initialize: kotlin.Boolean, classLoader: ClassLoader?): Class<*> {
+    return Class.forName(toSandbox(className), initialize, classLoader ?: systemClassLoader)
 }
 
 @Throws(ClassNotFoundException::class)

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -43,9 +43,8 @@ fun Any.sandbox(): Any {
         // means that they're used "as is". So prevent the user
         // from passing bad instances into the sandbox through the
         // front door!
-        is Class<*> -> throw RuleViolationError("Cannot sandbox ${toString()}}").sanitise()
+        is Class<*>, is Constructor<*> -> throw RuleViolationError("Cannot sandbox $this").sanitise()
         is ClassLoader -> throw RuleViolationError("Cannot sandbox a ClassLoader").sanitise()
-        is Constructor<*> -> throw RuleViolationError("Cannot sandbox a Constructor").sanitise()
 
         // Default behaviour...
         else -> this

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -215,6 +215,22 @@ val systemClassLoader: ClassLoader get() {
 }
 
 /**
+ * Filter function for [Class.getClassLoader].
+ */
+@Suppress("unused_parameter")
+fun getClassLoader(type: Class<*>): ClassLoader {
+    /**
+     * We expect [Class.getClassLoader] to return one of the following:
+     * - [net.corda.djvm.rewiring.SandboxClassLoader] for sandbox classes
+     * - the application class loader for pinned classes
+     * - null for basic Java classes.
+     *
+     * So "don't do that". Always return the sandbox classloader instead.
+     */
+    return systemClassLoader
+}
+
+/**
  * Replacement function for Class<*>.forName(String, boolean, ClassLoader) which protects
  * against users loading classes from outside the sandbox.
  */

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -272,6 +272,7 @@ fun toSandbox(className: kotlin.String): kotlin.String {
 private val bannedClasses = setOf(
     "^java\\.lang\\.DJVM(.*)?\$".toRegex(),
     "^net\\.corda\\.djvm\\..*\$".toRegex(),
+    "^RuntimeCostAccounter\$".toRegex(),
     "^Task(.*)?\$".toRegex()
 )
 

--- a/djvm/src/main/kotlin/sandbox/net/corda/djvm/costing/RuntimeCostAccounter.kt
+++ b/djvm/src/main/kotlin/sandbox/net/corda/djvm/costing/RuntimeCostAccounter.kt
@@ -1,8 +1,8 @@
+@file:JvmName("RuntimeCostAccounter")
+@file:Suppress("unused")
 package sandbox.net.corda.djvm.costing
 
 import net.corda.djvm.SandboxRuntimeContext
-import net.corda.djvm.costing.RuntimeCostSummary
-import org.objectweb.asm.Type
 
 /**
  * Class for keeping a tally on various runtime metrics, like number of jumps, allocations, invocations, etc. The
@@ -12,99 +12,87 @@ import org.objectweb.asm.Type
  * Note that the accounter also has thresholds for the various metrics that it is keeping track of, and that it will
  * terminate any sandboxed functions that breach these constraints.
  */
-@Suppress("unused")
-object RuntimeCostAccounter {
 
-    /**
-     * A static instance of the sandbox context which is used to keep track of the costs.
-     */
-    private val context: SandboxRuntimeContext
-        get() = SandboxRuntimeContext.instance
+/**
+ * A static instance of the sandbox context which is used to keep track of the costs.
+ */
+private val context: SandboxRuntimeContext
+    get() = SandboxRuntimeContext.instance
 
-    /**
-     * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
-     */
-    @JvmField
-    val TYPE_NAME: String = Type.getInternalName(this::class.java)
+/**
+ * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
+ */
+const val RUNTIME_ACCOUNTER_NAME: String = "sandbox/net/corda/djvm/costing/RuntimeCostAccounter"
 
-    /**
-     * Known / estimated allocation costs.
-     */
-    private val allocationCosts = mapOf(
-            "java/lang/Object" to 8,
-            "sandbox/java/lang/Object" to 8
-    )
+/**
+ * Known / estimated allocation costs.
+ */
+private val allocationCosts = mapOf(
+        "java/lang/Object" to 8,
+        "sandbox/java/lang/Object" to 8
+)
 
-    /**
-     * Re-throw exception if it is of type [ThreadDeath] or [VirtualMachineError].
-     */
-    @JvmStatic
-    fun checkCatch(exception: Throwable) {
-        when (exception) {
-            is ThreadDeath, is VirtualMachineError -> throw exception
-        }
+/**
+ * Re-throw exception if it is of type [ThreadDeath] or [VirtualMachineError].
+ */
+fun checkCatch(exception: Throwable) {
+    when (exception) {
+        is ThreadDeath, is VirtualMachineError -> throw exception
     }
-
-    /**
-     * Record a jump operation.
-     */
-    @JvmStatic
-    fun recordJump() =
-            context.runtimeCosts.jumpCost.increment()
-
-    /**
-     * Record a memory allocation operation.
-     *
-     * @param typeName The class name of the object being instantiated.
-     */
-    @JvmStatic
-    fun recordAllocation(typeName: String) {
-        // TODO Derive better size estimates for complex types.
-        // Resources worth taking a look at:
-        // - https://github.com/DimitrisAndreou/memory-measurer
-        // - https://stackoverflow.com/questions/9368764/calculate-size-of-object-in-java
-        val size = allocationCosts.getOrDefault(typeName, 16)
-        context.runtimeCosts.allocationCost.increment(size)
-    }
-
-    /**
-     * Record an array allocation operation.
-     *
-     * @param length The number of elements in the array.
-     * @param typeName The class name of the array element type.
-     */
-    @JvmStatic
-    fun recordArrayAllocation(length: Int, typeName: String) {
-        require(length >= 0) { "Length must be a positive integer" }
-        val size = allocationCosts.getOrDefault(typeName, 16)
-        context.runtimeCosts.allocationCost.increment(length * size)
-    }
-
-    /**
-     * Record an array allocation operation.
-     *
-     * @param length The number of elements in the array.
-     * @param typeSize The size of the array element type.
-     */
-    @JvmStatic
-    fun recordArrayAllocation(length: Int, typeSize: Int) {
-        require(length >= 0) { "Length must be a positive integer" }
-        require(typeSize > 0) { "Type size must be a positive integer" }
-        context.runtimeCosts.allocationCost.increment(length * typeSize)
-    }
-
-    /**
-     * Record a method call.
-     */
-    @JvmStatic
-    fun recordInvocation() =
-            context.runtimeCosts.invocationCost.increment()
-
-    /**
-     * The accumulated cost of exception throws that have been made.
-     */
-    @JvmStatic
-    fun recordThrow() =
-            context.runtimeCosts.throwCost.increment()
-
 }
+
+/**
+ * Record a jump operation.
+ */
+fun recordJump() =
+        context.runtimeCosts.jumpCost.increment()
+
+/**
+ * Record a memory allocation operation.
+ *
+ * @param typeName The class name of the object being instantiated.
+ */
+fun recordAllocation(typeName: String) {
+    // TODO Derive better size estimates for complex types.
+    // Resources worth taking a look at:
+    // - https://github.com/DimitrisAndreou/memory-measurer
+    // - https://stackoverflow.com/questions/9368764/calculate-size-of-object-in-java
+    val size = allocationCosts.getOrDefault(typeName, 16)
+    context.runtimeCosts.allocationCost.increment(size)
+}
+
+/**
+ * Record an array allocation operation.
+ *
+ * @param length The number of elements in the array.
+ * @param typeName The class name of the array element type.
+ */
+fun recordArrayAllocation(length: Int, typeName: String) {
+    require(length >= 0) { "Length must be a positive integer" }
+    val size = allocationCosts.getOrDefault(typeName, 16)
+    context.runtimeCosts.allocationCost.increment(length * size)
+}
+
+/**
+ * Record an array allocation operation.
+ *
+ * @param length The number of elements in the array.
+ * @param typeSize The size of the array element type.
+ */
+fun recordArrayAllocation(length: Int, typeSize: Int) {
+    require(length >= 0) { "Length must be a positive integer" }
+    require(typeSize > 0) { "Type size must be a positive integer" }
+    context.runtimeCosts.allocationCost.increment(length * typeSize)
+}
+
+/**
+ * Record a method call.
+ */
+fun recordInvocation() =
+        context.runtimeCosts.invocationCost.increment()
+
+/**
+ * The accumulated cost of exception throws that have been made.
+ */
+fun recordThrow() =
+        context.runtimeCosts.throwCost.increment()

--- a/djvm/src/test/java/greymalkin/PureEvil.java
+++ b/djvm/src/test/java/greymalkin/PureEvil.java
@@ -1,0 +1,12 @@
+package greymalkin;
+
+public final class PureEvil {
+    static {
+        System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString() {
+        return "Victory is mine!";
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/Utilities.java
+++ b/djvm/src/test/java/net/corda/djvm/Utilities.java
@@ -1,6 +1,6 @@
 package net.corda.djvm;
 
-import sandbox.net.corda.djvm.costing.ThresholdViolationError;
+import net.corda.djvm.costing.ThresholdViolationError;
 import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 /**

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -5,7 +5,6 @@ import net.corda.djvm.TestBase;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rewiring.SandboxClassLoader;
 import org.junit.jupiter.api.Test;
-import sandbox.net.corda.djvm.costing.RuntimeCostAccounter;
 import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 import java.util.function.Function;
@@ -144,7 +143,7 @@ class MaliciousClassLoaderTest extends TestBase {
         @Override
         public ClassLoader apply(String input) {
             // A pinned class belongs to the application classloader.
-            return RuntimeCostAccounter.class.getClassLoader();
+            return RuleViolationError.class.getClassLoader();
         }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -1,0 +1,130 @@
+package net.corda.djvm.execution;
+
+import greymalkin.PureEvil;
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import net.corda.djvm.rewiring.SandboxClassLoader;
+import org.junit.jupiter.api.Test;
+import sandbox.net.corda.djvm.rules.RuleViolationError;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.Utilities.*;
+import static net.corda.djvm.SandboxType.JAVA;
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaliciousClassLoaderTest extends TestBase {
+    MaliciousClassLoaderTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testWithAnEvilClassLoader() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(NoSuchMethodError.class, () -> WithJava.run(executor, ActOfEvil.class, PureEvil.class.getName()));
+            assertThat(ex)
+                .hasMessageContaining("sandbox.java.lang.System.currentTimeMillis()J")
+                .hasNoCause();
+            return null;
+        });
+    }
+
+    public static class ActOfEvil implements Function<String, String> {
+        @Override
+        public String apply(String className) {
+            ClassLoader evilLoader = new ClassLoader() {
+                @Override
+                public Class<?> loadClass(String className, boolean resolve) {
+                    throwRuleViolationError();
+                    return null;
+                }
+
+                @Override
+                protected Class<?> findClass(String className) {
+                    throwRuleViolationError();
+                    return null;
+                }
+            };
+            try {
+                Class<?> evilClass = Class.forName(className, true, evilLoader);
+                return evilClass.newInstance().toString();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+        }
+    }
+
+    @Test
+    void testWithEvilParentClassLoader() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, ActOfEvilParent.class, PureEvil.class.getName()));
+            assertThat(ex)
+                .hasMessage("Disallowed reference to API; java.lang.ClassLoader(ClassLoader)")
+                .hasNoCause();
+            return null;
+        });
+    }
+
+    public static class ActOfEvilParent implements Function<String, String> {
+        @Override
+        public String apply(String className) {
+            ClassLoader evilLoader = new ClassLoader(null) {
+                @Override
+                public Class<?> loadClass(String className, boolean resolve) {
+                    throwRuleViolationError();
+                    return null;
+                }
+
+                @Override
+                protected Class<?> findClass(String className) {
+                    throwRuleViolationError();
+                    return null;
+                }
+            };
+            try {
+                Class<?> evilClass = Class.forName(className, true, evilLoader);
+                return evilClass.newInstance().toString();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IllegalStateException(e.getMessage(), e);
+            }
+        }
+    }
+
+    @Test
+    void testAccessingParentClassLoader() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, ClassLoader> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ClassLoader result = WithJava.run(executor, GetParentClassLoader.class, "").getResult();
+            assertThat(result)
+                .isExactlyInstanceOf(SandboxClassLoader.class)
+                // The IsolatedTask creates its very own SandboxClassLoader, but
+                // it will still share the same parent SandboxClassLoader as here.
+                .extracting(ClassLoader::getParent)
+                .isExactlyInstanceOf(SandboxClassLoader.class)
+                .isEqualTo(ctx.getClassLoader().getParent());
+            return null;
+        });
+    }
+
+    public static class GetParentClassLoader implements Function<String, ClassLoader> {
+        @Override
+        public ClassLoader apply(String input) {
+            ClassLoader parent = ClassLoader.getSystemClassLoader();
+
+            // In theory, this will iterate up the ClassLoader chain
+            // until it locates the DJVM's application ClassLoader.
+            while (parent.getClass().getClassLoader() != null && parent.getParent() != null) {
+                parent = parent.getParent();
+            }
+            return parent;
+        }
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -4,7 +4,9 @@ import net.corda.djvm.TestBase;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rewiring.SandboxClassLoadingException;
 import org.junit.jupiter.api.Test;
+import sandbox.net.corda.djvm.rules.RuleViolationError;
 
+import java.lang.reflect.Constructor;
 import java.util.function.Function;
 
 import static net.corda.djvm.SandboxType.JAVA;
@@ -60,6 +62,62 @@ class MaliciousClassTest extends TestBase {
         @SuppressWarnings("unused")
         protected Object fromDJVM() {
             throw new IllegalStateException("MUHAHAHAHAHAHA!!!");
+        }
+    }
+
+    @Test
+    void testPassingClassIntoSandboxIsForbidden() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Class<?>, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilClass.class, String.class));
+            assertThat(ex)
+                .hasMessageContaining("Cannot sandbox class java.lang.String");
+            return null;
+        });
+    }
+
+    public static class EvilClass implements Function<Class<?>, String> {
+        @Override
+        public String apply(Class<?> clazz) {
+            return clazz.getName();
+        }
+    }
+
+    @Test
+    void testPassingConstructorIntoSandboxIsForbidden() throws NoSuchMethodException {
+        Constructor<?> constructor = getClass().getDeclaredConstructor();
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<Constructor<?>, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilConstructor.class, constructor));
+            assertThat(ex)
+                .hasMessageContaining("Cannot sandbox a Constructor");
+            return null;
+        });
+    }
+
+    public static class EvilConstructor implements Function<Constructor<?>, String> {
+        @Override
+        public String apply(Constructor<?> constructor) {
+            return constructor.getName();
+        }
+    }
+
+    @Test
+    void testPassingClassLoaderIntoSandboxIsForbidden() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<ClassLoader, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilClassLoader.class, classLoader));
+            assertThat(ex)
+                .hasMessageContaining("Cannot sandbox a ClassLoader");
+            return null;
+        });
+    }
+
+    public static class EvilClassLoader implements Function<ClassLoader, String> {
+        @Override
+        public String apply(ClassLoader classLoader) {
+            return classLoader.toString();
         }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -90,7 +90,7 @@ class MaliciousClassTest extends TestBase {
             SandboxExecutor<Constructor<?>, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilConstructor.class, constructor));
             assertThat(ex)
-                .hasMessageContaining("Cannot sandbox a Constructor");
+                .hasMessageContaining("Cannot sandbox " + constructor);
             return null;
         });
     }

--- a/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
@@ -3,7 +3,6 @@ package net.corda.djvm.costing
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import kotlin.concurrent.thread
 
 class RuntimeCostTest {

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -705,7 +705,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     class DefineNewClass : Function<String, Class<*>> {
         override fun apply(input: String): Class<*> {
             val data = ByteArray(0)
-            val cl = object : ClassLoader(this::class.java.classLoader) {
+            val cl = object : ClassLoader() {
                 fun define(): Class<*> {
                     return super.defineClass(input, data, 0, data.size)
                 }
@@ -726,7 +726,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
 
     class LoadNewClass : Function<String, Class<*>> {
         override fun apply(input: String): Class<*> {
-            val cl = object : ClassLoader(this::class.java.classLoader) {
+            val cl = object : ClassLoader() {
                 fun load(): Class<*> {
                     return super.loadClass(input)
                 }
@@ -747,7 +747,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
 
     class FindClass : Function<String, Class<*>> {
         override fun apply(input: String): Class<*> {
-            val cl = object : ClassLoader(this::class.java.classLoader) {
+            val cl = object : ClassLoader() {
                 fun find(): Class<*> {
                     return super.findClass(input)
                 }

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -619,6 +619,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = [
+        "RuntimeCostAccounter",
         "java.lang.DJVM",
         "java.lang.DJVMException",
         "java.lang.DJVMThrowableWrapper"

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -8,13 +8,13 @@ import net.corda.djvm.TestBase
 import net.corda.djvm.Utilities.*
 import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.assertions.AssertionExtensions.withProblem
+import net.corda.djvm.costing.ThresholdViolationError
 import net.corda.djvm.rewiring.SandboxClassLoadingException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
 import sandbox.net.corda.djvm.rules.RuleViolationError
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -206,7 +206,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
             return try {
                 throwThresholdViolationError()
                 Int.MIN_VALUE // Should not reach here
-            } catch (exception: ThresholdViolationError) {
+            } catch (exception: Error) {
                 1
             }
         }

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -4,10 +4,11 @@ import foo.bar.sandbox.*
 import net.corda.djvm.SandboxType.KOTLIN
 import net.corda.djvm.TestBase
 import net.corda.djvm.assertions.AssertionExtensions.assertThat
+import net.corda.djvm.costing.ThresholdViolationError
 import net.corda.djvm.execution.ExecutionProfile
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
-import sandbox.net.corda.djvm.costing.ThresholdViolationError
+import sandbox.net.corda.djvm.rules.RuleViolationError
 import java.nio.file.Paths
 import java.util.*
 
@@ -154,8 +155,8 @@ class ClassRewriterTest : TestBase(KOTLIN) {
 
     @Test
     fun `test pinned class is owned by application classloader`() = parentedSandbox {
-        val violationClass = loadClass<ThresholdViolationError>().type
-        assertThat(violationClass).isEqualTo(ThresholdViolationError::class.java)
+        val violationClass = loadClass<RuleViolationError>().type
+        assertThat(violationClass).isEqualTo(RuleViolationError::class.java)
     }
 }
 


### PR DESCRIPTION
We should not allow sandboxed code to obtain a reference to the DJVM's _own_ `ClassLoader`, because this might be used (somehow) to break out of the sandbox. So we do two things:
- Ensure that `ClassLoader.getParent()` always returns `null`.
- Restrict access to `ClassLoader` constructors! Arguably we don't expect sandboxed code to need to create new `ClassLoader` objects _at all_, but we can _tolerate_ the no-argument constructor for now.
- Convert `RuntimeCostAccounter` into a template class.
- Unpin `ThresholdViolationError` class.