### PR TITLE
Include DJVM's GPLv2+CPE licence file inside CLI's ZIP distribution.

### DIFF
--- a/djvm/cli/build.gradle
+++ b/djvm/cli/build.gradle
@@ -45,6 +45,7 @@ task shadowZip(type: Zip) {
     archiveBaseName = djvmName
     archiveClassifier = ''
 
+    from(rootProject.file('LICENSE'))
     from(shadowJar) {
         rename "$djvmName-(.*).jar", "${djvmName}.jar"
     }


### PR DESCRIPTION
Ensure we distribute modified OpenJDK code _with_ its licence.