### PR TITLE
CORDA-3045: Remove the final pinned class.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/Object.java
+++ b/djvm/src/main/java/sandbox/java/lang/Object.java
@@ -1,7 +1,6 @@
 package sandbox.java.lang;
 
 import org.jetbrains.annotations.NotNull;
-import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 public class Object {
 
@@ -56,7 +55,7 @@ public class Object {
         try {
             return DJVM.fromDJVMType(type);
         } catch (ClassNotFoundException e) {
-            throw new RuleViolationError(e.getMessage());
+            throw DJVM.fail(e.getMessage());
         }
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -22,6 +22,7 @@ import java.nio.file.Path
 import java.security.SecureRandom
 import java.security.Security
 import java.util.*
+import java.util.Collections.unmodifiableSet
 import kotlin.Comparator
 
 /**
@@ -522,6 +523,10 @@ class AnalysisConfiguration private constructor(
         private fun Set<Class<*>>.sandboxed(): Set<String> = map(Companion::sandboxed).toSet()
         private fun Iterable<Member>.mapByClassName(): Map<String, List<Member>>
                       = groupBy(Member::className).mapValues(Map.Entry<String, List<Member>>::value)
+        private fun <T> unmodifiable(items: Set<T>): Set<T> {
+            return if (items.isEmpty()) emptySet() else unmodifiableSet(items)
+        }
+
         private fun EmitterModule.returnResourceBundle() {
             invokeStatic(
                 owner = "sandbox/java/lang/DJVM",
@@ -582,7 +587,7 @@ class AnalysisConfiguration private constructor(
                     .map(Member::reference)
                     .toSet()
             )
-            val pinnedClasses = MANDATORY_PINNED_CLASSES + additionalPinnedClasses
+            val pinnedClasses = unmodifiable(MANDATORY_PINNED_CLASSES + additionalPinnedClasses)
             val classResolver = ClassResolver(pinnedClasses, TEMPLATE_CLASSES, actualWhitelist, SANDBOX_PREFIX)
 
             return AnalysisConfiguration(

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -1,7 +1,6 @@
 package net.corda.djvm.analysis
 
 import net.corda.djvm.code.EmitterModule
-import net.corda.djvm.code.ruleViolationError
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.ClassModule
 import net.corda.djvm.references.Member
@@ -126,12 +125,10 @@ class AnalysisConfiguration private constructor(
         const val SANDBOX_PREFIX: String = "sandbox/"
 
         /**
-         * These class must belong to the application class loader.
+         * These classes must belong to the application class loader.
          * They should already exist within the sandbox namespace.
          */
-        private val MANDATORY_PINNED_CLASSES: Set<String> = setOf(
-            ruleViolationError
-        )
+        private val MANDATORY_PINNED_CLASSES: Set<String> = emptySet()
 
         /**
          * These classes will be duplicated into every sandbox's

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -190,7 +190,27 @@ class EmitterModule(
         methodVisitor.visitInsn(ATHROW)
     }
 
+    @Suppress("unused")
     inline fun <reified T : Throwable> throwException(message: String) = throwException(T::class.java, message)
+
+    /**
+     * Emits an instruction to throw [net.corda.djvm.rules.RuleViolationError].
+     */
+    fun throwRuleViolationError(message: String) {
+        methodVisitor.visitLdcInsn(message)
+        invokeStatic(
+            owner = "sandbox/java/lang/DJVM",
+            name = "fail",
+            descriptor = "(Ljava/lang/String;)Ljava/lang/Error;"
+        )
+
+        // This instruction is actually never reached because
+        // DJVM.fail() does not return. But pretending to throw
+        // the exception that it will never receive from fail()
+        // closes off this functions's byte-code in a way that
+        // the Verifier can always accept.
+        methodVisitor.visitInsn(ATHROW)
+    }
 
     /**
      * Attempt to cast the object on the top of the stack to the given class.

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -6,7 +6,6 @@ import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
-import sandbox.RUNTIME_ACCOUNTER_NAME
 
 /**
  * Helper functions for emitting code to a method body.

--- a/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
@@ -21,6 +21,11 @@ const val EMIT_AFTER_INVOKE: Int = EMIT_DEFAULT + 2
 const val OBJECT_NAME = "java/lang/Object"
 const val THROWABLE_NAME = "java/lang/Throwable"
 
+/**
+ * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
+ */
+const val RUNTIME_ACCOUNTER_NAME: String = "sandbox/RuntimeCostAccounter"
+
 val ruleViolationError: String = Type.getInternalName(RuleViolationError::class.java)
 val thresholdViolationError: String = Type.getInternalName(ThresholdViolationError::class.java)
 val djvmException: String = Type.getInternalName(DJVMException::class.java)
@@ -34,5 +39,5 @@ val String.asResourcePath: String get() = this.replace('.', '/')
 val String.emptyAsNull: String? get() = if (isEmpty()) null else this
 
 inline fun <reified T> Emitter.getMemberContext(context: EmitterContext): T? {
-    return context.getMemberContext(this) as T?
+    return context.getMemberContext(this) as? T
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/Types.kt
@@ -2,9 +2,9 @@
 package net.corda.djvm.code
 
 import net.corda.djvm.costing.ThresholdViolationError
+import net.corda.djvm.rules.RuleViolationError
 import org.objectweb.asm.Type
 import sandbox.java.lang.DJVMException
-import sandbox.net.corda.djvm.rules.RuleViolationError
 
 /**
  * These are the priorities for executing [Emitter] instances.

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/RuleViolationError.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/RuleViolationError.kt
@@ -1,4 +1,4 @@
-package sandbox.net.corda.djvm.rules
+package net.corda.djvm.rules
 
 /**
  * Exception thrown when a sandbox rule is violated at runtime.

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
@@ -7,7 +7,6 @@ import net.corda.djvm.code.Instruction
 import net.corda.djvm.code.instructions.MemberAccessInstruction
 import net.corda.djvm.formatting.MemberFormatter
 import org.objectweb.asm.Opcodes.*
-import sandbox.net.corda.djvm.rules.RuleViolationError
 
 /**
  * Some non-deterministic APIs belong to pinned classes and so cannot be stubbed out.
@@ -55,7 +54,7 @@ object DisallowNonDeterministicMethods : Emitter {
     }
 
     private fun EmitterModule.forbid(instruction: MemberAccessInstruction) {
-        throwException<RuleViolationError>("Disallowed reference to API; ${memberFormatter.format(instruction.member)}")
+        throwRuleViolationError("Disallowed reference to API; ${memberFormatter.format(instruction.member)}")
         preventDefault()
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowOverriddenSandboxPackage.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowOverriddenSandboxPackage.kt
@@ -11,7 +11,7 @@ object DisallowOverriddenSandboxPackage : ClassRule() {
 
     override fun validate(context: RuleContext, clazz: ClassRepresentation) = context.validate {
         fail("Cannot load class explicitly defined in the 'sandbox' root package; ${clazz.name}") given
-                (clazz.name !in context.pinnedClasses && clazz.name.startsWith("sandbox/"))
+                isSandboxClass(clazz.name)
     }
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/MemberRuleEnforcer.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/MemberRuleEnforcer.kt
@@ -3,7 +3,6 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.formatting.MemberFormatter
 import net.corda.djvm.references.MemberInformation
-import sandbox.net.corda.djvm.rules.RuleViolationError
 
 class MemberRuleEnforcer(private val member: MemberInformation) {
     companion object {
@@ -12,11 +11,11 @@ class MemberRuleEnforcer(private val member: MemberInformation) {
 
     fun forbidNativeMethod(emitter: EmitterModule): Unit = with(emitter) {
         lineNumber(0)
-        throwException<RuleViolationError>("Native method has been deleted; ${memberFormatter.format(member)}")
+        throwRuleViolationError("Native method has been deleted; ${memberFormatter.format(member)}")
     }
 
     fun forbidReflection(emitter: EmitterModule): Unit = with(emitter) {
         lineNumber(0)
-        throwException<RuleViolationError>("Disallowed reference to reflection API; ${memberFormatter.format(member)}")
+        throwRuleViolationError("Disallowed reference to reflection API; ${memberFormatter.format(member)}")
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteClassMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/RewriteClassMethods.kt
@@ -6,7 +6,6 @@ import net.corda.djvm.code.Instruction
 import net.corda.djvm.code.instructions.MemberAccessInstruction
 import net.corda.djvm.formatting.MemberFormatter
 import org.objectweb.asm.Opcodes.*
-import sandbox.net.corda.djvm.rules.RuleViolationError
 
 /**
  * The enum-related methods on [Class] all require that enums use [java.lang.Enum]
@@ -43,7 +42,7 @@ object RewriteClassMethods : Emitter {
                         descriptor = "(Ljava/lang/Class;)[Ljava/lang/Object;")
                     preventDefault()
                 } else if (instruction.memberName == "getProtectionDomain" && instruction.descriptor == "()Ljava/security/ProtectionDomain;") {
-                    throwException<RuleViolationError>("Disallowed reference to API; ${memberFormatter.format(instruction.member)}")
+                    throwRuleViolationError("Disallowed reference to API; ${memberFormatter.format(instruction.member)}")
                     preventDefault()
                 } else if (instruction.memberName == "getClassLoader" && instruction.descriptor == "()Ljava/lang/ClassLoader;") {
                     invokeStatic(

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -23,11 +23,15 @@ import kotlin.streams.toList
 
 /**
  * Class loader to manage an optional JAR of replacement Java APIs.
- * @param bootstrapJar The location of the JAR containing the Java APIs.
  */
-class BootstrapClassLoader(
-    bootstrapJar: Path
-) : URLClassLoader(resolvePaths(listOf(bootstrapJar)), null) {
+class BootstrapClassLoader private constructor(
+    jarPaths: List<Path>
+) : URLClassLoader(resolvePaths(jarPaths), null) {
+    /**
+     * @param bootstrapJar The location of the JAR containing the Java APIs.
+     */
+    constructor(bootstrapJar: Path) : this(listOf(bootstrapJar))
+    constructor() : this(emptyList())
 
     /**
      * Only search our own jars for the given resource.
@@ -49,6 +53,12 @@ class SourceClassLoader(
 ) : URLClassLoader(resolvePaths(paths), null) {
     private companion object {
         private val logger = loggerFor<SourceClassLoader>()
+    }
+
+    override fun close() {
+        bootstrap.use {
+            super.close()
+        }
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/validation/RuleContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/validation/RuleContext.kt
@@ -43,12 +43,6 @@ open class RuleContext(
         get() = analysisContext.configuration.whitelist
 
     /**
-     * Classes that have been explicitly defined in the sandbox namespace.
-     */
-    val pinnedClasses: Set<String>
-        get() = analysisContext.configuration.pinnedClasses
-
-    /**
      * Utilities for dealing with classes.
      */
     val classModule: ClassModule
@@ -59,6 +53,11 @@ open class RuleContext(
      */
     val memberModule: MemberModule
         get() = analysisContext.configuration.memberModule
+
+    /**
+     * Check whether the class has been explicitly defined in the sandbox namespace.
+     */
+    fun isSandboxClass(className: String): Boolean = analysisContext.configuration.isSandboxClass(className)
 
     /**
      * Set up and execute a rule validation block.

--- a/djvm/src/main/kotlin/sandbox/Task.kt
+++ b/djvm/src/main/kotlin/sandbox/Task.kt
@@ -7,11 +7,6 @@ import sandbox.java.lang.unsandbox
 
 typealias SandboxFunction<TInput, TOutput> = sandbox.java.util.function.Function<TInput, TOutput>
 
-/**
- * The type name of the [RuntimeCostAccounter] class; referenced from instrumentors.
- */
-const val RUNTIME_ACCOUNTER_NAME: String = "sandbox/RuntimeCostAccounter"
-
 internal fun isEntryPoint(elt: StackTraceElement): Boolean {
     return elt.className == "sandbox.Task" && elt.methodName == "apply"
 }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -5,13 +5,13 @@ package sandbox.java.lang
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration.Companion.JVM_EXCEPTIONS
 import net.corda.djvm.analysis.ExceptionResolver.Companion.getDJVMException
+import net.corda.djvm.rules.RuleViolationError
 import net.corda.djvm.rules.implementation.*
 import org.objectweb.asm.Opcodes.ACC_ENUM
 import org.objectweb.asm.Type
 import sandbox.isEntryPoint
 import sandbox.java.io.*
 import sandbox.java.util.*
-import sandbox.net.corda.djvm.rules.RuleViolationError
 import java.lang.reflect.Constructor
 
 private const val SANDBOX_PREFIX = "sandbox."
@@ -44,8 +44,8 @@ fun Any.sandbox(): Any {
         // means that they're used "as is". So prevent the user
         // from passing bad instances into the sandbox through the
         // front door!
-        is Class<*>, is Constructor<*> -> throw RuleViolationError("Cannot sandbox $this").sanitise()
-        is ClassLoader -> throw RuleViolationError("Cannot sandbox a ClassLoader").sanitise()
+        is Class<*>, is Constructor<*> -> throw RuleViolationError("Cannot sandbox $this").sanitise(1)
+        is ClassLoader -> throw RuleViolationError("Cannot sandbox a ClassLoader").sanitise(1)
 
         // Default behaviour...
         else -> this
@@ -54,7 +54,7 @@ fun Any.sandbox(): Any {
 
 fun kotlin.Throwable.escapeSandbox(): kotlin.Throwable {
     val sandboxed = (this as? DJVMException)?.throwable ?: sandboxedExceptions.remove(this)
-    return sandboxed?.escapeSandbox() ?: sanitise()
+    return sandboxed?.escapeSandbox() ?: sanitise(0)
 }
 
 fun Throwable.escapeSandbox(): kotlin.Throwable {
@@ -84,16 +84,30 @@ fun Throwable.escapeSandbox(): kotlin.Throwable {
                 initCause(it.escapeSandbox())
             }
             stackTrace = copyFromDJVM(this@escapeSandbox.stackTrace)
+            sanitise(0)
             this@escapeSandbox.suppressed.forEach {
                 addSuppressed(it.escapeSandbox())
             }
         }
     } catch (e: Exception) {
-        RuleViolationError(e.message).sanitise()
+        RuleViolationError(e.message).sanitise(1)
     }
 }
 
 private fun Array<*>.fromDJVMArray(): Array<*> = Object.fromDJVM(this)
+
+/**
+ * Throws a [RuleViolationError] to exit the sandbox.
+ * This function never returns, and we can inform the
+ * caller not to expect us to by invoking it via:
+ *
+ *     throw DJVM.fail("message")
+ */
+fun fail(message: kotlin.String): Error {
+    // Discard the first stack frame so that
+    // our invoker's frame is on top.
+    throw RuleViolationError(message).sanitise(1)
+}
 
 /**
  * Use [Class.forName] so that we can also fetch classes for arrays of primitive types.
@@ -207,7 +221,7 @@ fun hashCode(obj: Any?): Int {
         obj is Object -> obj.hashCode()
         obj != null -> System.identityHashCode(obj)
         else -> // Throw the same exception that the JVM would throw in this case.
-            throw NullPointerException().sanitise()
+            throw NullPointerException().sanitise(1)
     }
 }
 
@@ -272,7 +286,7 @@ fun loadClass(classLoader: ClassLoader, className: kotlin.String): Class<*> {
 @Throws(ClassNotFoundException::class)
 fun toSandbox(className: kotlin.String): kotlin.String {
     if (bannedClasses.any { it.matches(className) }) {
-        throw ClassNotFoundException(className).sanitise()
+        throw ClassNotFoundException(className).sanitise(1)
     }
     return SANDBOX_PREFIX + className
 }
@@ -329,7 +343,7 @@ fun fromDJVM(t: Throwable?): kotlin.Throwable {
                     .newInstance(t) as kotlin.Throwable
             }
         } catch (e: Exception) {
-            RuleViolationError(e.message).sanitise()
+            RuleViolationError(e.message).sanitise(1)
         }
     }
 }
@@ -356,16 +370,16 @@ fun catch(t: kotlin.Throwable): Throwable {
     try {
         return t.toDJVMThrowable()
     } catch (e: Exception) {
-        throw RuleViolationError(e.message).sanitise()
+        throw RuleViolationError(e.message).sanitise(1)
     }
 }
 
 /**
  * Clean up exception stack trace for throwing.
  */
-private fun <T: kotlin.Throwable> T.sanitise(): T {
+private fun <T: kotlin.Throwable> T.sanitise(firstIndex: Int): T {
     stackTrace = stackTrace.let {
-        it.sliceArray(1 until findEntryPointIndex(it))
+        it.sliceArray(firstIndex until findEntryPointIndex(it))
     }
     return this
 }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -260,7 +260,10 @@ fun getClassLoader(type: Class<*>): ClassLoader {
  * Replacement function for [ClassLoader.getSystemResourceAsStream].
  */
 fun getSystemResourceAsStream(name: kotlin.String): InputStream? {
-    return InputStream.toDJVM(systemClassLoader.getResourceAsStream(name))
+    // Read system resources from the classloader that contains the Java APIs.
+    // I'd prefer to use this class's own classloader really, except that Kotlin
+    // cannot provide me with the .class for this "file".
+    return InputStream.toDJVM(sandboxThrowable.classLoader.getResourceAsStream(name))
 }
 
 /**

--- a/djvm/src/test/java/net/corda/djvm/Utilities.java
+++ b/djvm/src/test/java/net/corda/djvm/Utilities.java
@@ -1,7 +1,7 @@
 package net.corda.djvm;
 
 import net.corda.djvm.costing.ThresholdViolationError;
-import sandbox.net.corda.djvm.rules.RuleViolationError;
+import net.corda.djvm.rules.RuleViolationError;
 
 /**
  * Pin this {@link Utilities} class inside the sandbox to allow

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -2,10 +2,11 @@ package net.corda.djvm.execution;
 
 import greymalkin.PureEvil;
 import net.corda.djvm.TestBase;
+import net.corda.djvm.Utilities;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rewiring.SandboxClassLoader;
+import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
-import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 import java.util.function.Function;
 
@@ -143,7 +144,7 @@ class MaliciousClassLoaderTest extends TestBase {
         @Override
         public ClassLoader apply(String input) {
             // A pinned class belongs to the application classloader.
-            return RuleViolationError.class.getClassLoader();
+            return Utilities.class.getClassLoader();
         }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -3,8 +3,8 @@ package net.corda.djvm.execution;
 import net.corda.djvm.TestBase;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rewiring.SandboxClassLoadingException;
+import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
-import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 import java.lang.reflect.Constructor;
 import java.util.function.Function;

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -3,9 +3,9 @@ package net.corda.djvm.execution;
 import net.corda.djvm.TestBase;
 import net.corda.djvm.Utilities;
 import net.corda.djvm.WithJava;
+import net.corda.djvm.rules.RuleViolationError;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import sandbox.net.corda.djvm.rules.RuleViolationError;
 
 import static net.corda.djvm.SandboxType.JAVA;
 import static net.corda.djvm.Utilities.*;

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -92,7 +92,7 @@ abstract class TestBase(type: SandboxType) {
                 emptyList(),
                 Whitelist.MINIMAL,
                 bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT),
-                additionalPinnedClasses = setOf(
+                pinnedClasses = setOf(
                     Utilities::class.java
                 ).map(Type::getInternalName).toSet()
             )
@@ -199,7 +199,7 @@ abstract class TestBase(type: SandboxType) {
                 AnalysisConfiguration.createRoot(
                     classPaths = classPaths,
                     whitelist = whitelist,
-                    additionalPinnedClasses = pinnedTestClasses,
+                    pinnedClasses = pinnedTestClasses,
                     minimumSeverityLevel = minimumSeverityLevel,
                     bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
                 ).use { analysisConfiguration ->

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -6,9 +6,9 @@ import net.corda.djvm.TestBase
 import net.corda.djvm.assertions.AssertionExtensions.assertThat
 import net.corda.djvm.costing.ThresholdViolationError
 import net.corda.djvm.execution.ExecutionProfile
+import net.corda.djvm.rules.RuleViolationError
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
-import sandbox.net.corda.djvm.rules.RuleViolationError
 import java.nio.file.Paths
 import java.util.*
 
@@ -154,9 +154,17 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test pinned class is owned by application classloader`() = parentedSandbox {
-        val violationClass = loadClass<RuleViolationError>().type
-        assertThat(violationClass).isEqualTo(RuleViolationError::class.java)
+    fun `test rule violation error cannot be loaded`() = parentedSandbox {
+        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+            .isThrownBy { loadClass<RuleViolationError>() }
+            .withMessageContaining("Class file not found; net/corda/djvm/rules/RuleViolationError.class")
+    }
+
+    @Test
+    fun `test threshold violation error cannot be loaded`() = parentedSandbox {
+        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+            .isThrownBy { loadClass<ThresholdViolationError>() }
+            .withMessageContaining("Class file not found; net/corda/djvm/costing/ThresholdViolationError.class")
     }
 }
 


### PR DESCRIPTION
- Stop mapping the `RuleViolationError` exception into the `sandbox.*` package space because it leaks the application classloader into the sandbox. Pinned classes can now be locked down as a "testing" feature.
- Fix a bug where the static `SandboxRuntimeContext` reference inside `RuntimeCostAccounter` could become stale. This will be better fixed by [CORDA-2877](https://r3-cev.atlassian.net/browse/CORDA-2877).
- Simplify the `BootstrapClassLoader`/`SourceClassLoader` configuration when creating sandboxes.