### PR TITLE
CORDA-3067: Reimplement AtomicInteger and ReentrantLock for use inside the sandbox.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 jar.enabled = false
 
 shadowJar {
-    baseName 'corda-djvm'
+    archiveBaseName = 'corda-djvm'
     classifier ''
     reproducibleFileOrder = true
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
@@ -79,6 +79,7 @@ shadowJar {
     exclude 'sandbox/java/lang/StackTraceElement.class'
     exclude 'sandbox/java/lang/StringBuffer.class'
     exclude 'sandbox/java/lang/StringBuilder.class'
+    exclude 'sandbox/java/lang/Thread.class'
     exclude 'sandbox/java/lang/ref/ReferenceQueue.class'
     exclude 'sandbox/java/nio/charset/Charset.class'
     exclude 'sandbox/java/nio/charset/spi/**'
@@ -86,9 +87,12 @@ shadowJar {
     exclude 'sandbox/java/security/PrivilegedExceptionAction.class'
     exclude 'sandbox/java/util/concurrent/ConcurrentMap.class'
     exclude 'sandbox/java/util/concurrent/ConcurrentHashMap\$CollectionView.class'
+    exclude 'sandbox/java/util/concurrent/TimeUnit.class'
     exclude 'sandbox/java/util/concurrent/atomic/AtomicIntegerFieldUpdater.class'
     exclude 'sandbox/java/util/concurrent/atomic/AtomicLongFieldUpdater.class'
     exclude 'sandbox/java/util/concurrent/atomic/AtomicReferenceFieldUpdater.class'
+    exclude 'sandbox/java/util/concurrent/locks/Condition.class'
+    exclude 'sandbox/java/util/concurrent/locks/Lock.class'
     exclude 'sandbox/java/util/function/**'
     exclude 'sandbox/java/util/*List*.class'
     exclude 'sandbox/java/util/*Map*.class'
@@ -96,6 +100,7 @@ shadowJar {
     exclude 'sandbox/java/util/Collection.class'
     exclude 'sandbox/java/util/Comparator.class'
     exclude 'sandbox/java/util/Currency.class'
+    exclude "sandbox/java/util/Date.class"
     exclude 'sandbox/java/util/Enumeration.class'
     exclude 'sandbox/java/util/Hashtable.class'
     exclude 'sandbox/java/util/Iterator.class'
@@ -119,7 +124,7 @@ publish {
     dependenciesFrom(configurations.shadow) {
         defaultScope = 'compile'
     }
-    name shadowJar.baseName
+    name shadowJar.archiveBaseName.get()
 }
 
 idea {

--- a/djvm/src/main/java/sandbox/java/lang/Thread.java
+++ b/djvm/src/main/java/sandbox/java/lang/Thread.java
@@ -1,0 +1,8 @@
+package sandbox.java.lang;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.lang.Thread}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.ReentrantLock}.
+ */
+public class Thread extends sandbox.java.lang.Object {
+}

--- a/djvm/src/main/java/sandbox/java/util/ArrayList.java
+++ b/djvm/src/main/java/sandbox/java/util/ArrayList.java
@@ -1,0 +1,86 @@
+package sandbox.java.util;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.ArrayList}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.ReentrantLock}.
+ */
+public class ArrayList<T> extends sandbox.java.lang.Object implements List<T> {
+    private static final String UNSUPPORTED = "Dummy class - not implemented";
+    private final java.util.List<T> list;
+
+    public ArrayList(int initialCapacity) {
+        list = new java.util.ArrayList<>(initialCapacity);
+    }
+
+    public ArrayList() {
+        list = new java.util.ArrayList<>();
+    }
+
+    @Override
+    @NotNull
+    public Iterator<T> iterator() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public boolean add(T item) {
+        return list.add(item);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> collect) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object obj) {
+        return list.contains(obj);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> collect) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public boolean remove(Object obj) {
+        return list.remove(obj);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collect) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collect) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return list.toArray();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        return list.toArray(a);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/Date.java
+++ b/djvm/src/main/java/sandbox/java/util/Date.java
@@ -1,0 +1,17 @@
+package sandbox.java.util;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Comparable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.Date}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.ReentrantLock}.
+ */
+public class Date extends sandbox.java.lang.Object implements java.io.Serializable, Cloneable, Comparable<Date> {
+    private static final String NOT_IMPLEMENTED = "Dummy class - not implemented";
+
+    @Override
+    public int compareTo(@NotNull Date o) {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/TimeUnit.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/TimeUnit.java
@@ -1,0 +1,8 @@
+package sandbox.java.util.concurrent;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.concurrent.TimeUnit}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.ReentrantLock}.
+ */
+public enum TimeUnit {
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicInteger.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicInteger.java
@@ -1,0 +1,143 @@
+package sandbox.java.util.concurrent.atomic;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Number;
+import sandbox.java.util.function.IntBinaryOperator;
+import sandbox.java.util.function.IntUnaryOperator;
+
+import java.io.Serializable;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class AtomicInteger extends Number implements Serializable {
+    private int value;
+
+    public AtomicInteger(int initialValue) {
+        value = initialValue;
+    }
+
+    public AtomicInteger() {
+    }
+
+    public final int get() {
+        return value;
+    }
+
+    public final void set(int newValue) {
+        value = newValue;
+    }
+
+    public final void lazySet(int newValue) {
+        value = newValue;
+    }
+
+    public final int getAndSet(int newValue) {
+        int oldValue = value;
+        value = newValue;
+        return oldValue;
+    }
+
+    public final boolean compareAndSet(int expectedValue, int newValue) {
+        if (value == expectedValue) {
+            value = newValue;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public final boolean weakCompareAndSet(int expectedValue, int newValue) {
+        return compareAndSet(expectedValue, newValue);
+    }
+
+    public final int getAndIncrement() {
+        int oldValue = value;
+        ++value;
+        return oldValue;
+    }
+
+    public final int getAndDecrement() {
+        int oldValue = value;
+        --value;
+        return oldValue;
+    }
+
+    public final int getAndAdd(int delta) {
+        int oldValue = value;
+        value += delta;
+        return oldValue;
+    }
+
+    public final int incrementAndGet() {
+        return ++value;
+    }
+
+    public final int decrementAndGet() {
+        return --value;
+    }
+
+    public final int addAndGet(int delta) {
+        return (value += delta);
+    }
+
+    public final int getAndUpdate(IntUnaryOperator updater) {
+        int oldValue = value;
+        value = updater.applyAsInt(oldValue);
+        return oldValue;
+    }
+
+    public final int updateAndGet(IntUnaryOperator updater) {
+        return (value = updater.applyAsInt(value));
+    }
+
+    public final int getAndAccumulate(int x, IntBinaryOperator accumulator) {
+        int oldValue = value;
+        value = accumulator.applyAsInt(oldValue, x);
+        return oldValue;
+    }
+
+    public final int accumulateAndGet(int x, IntBinaryOperator accumulator) {
+        return (value = accumulator.applyAsInt(value, x));
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double) value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float) value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long) value;
+    }
+
+    @Override
+    public int intValue() {
+        return value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short) value;
+    }
+
+    @Override
+    public byte byteValue() {
+        return (byte) value;
+    }
+
+    @Override
+    @NotNull
+    protected final java.util.concurrent.atomic.AtomicInteger fromDJVM() {
+        return new java.util.concurrent.atomic.AtomicInteger(value);
+    }
+
+    @Override
+    @NotNull
+    public java.lang.String toString() {
+        return java.lang.Integer.toString(value);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/locks/Condition.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/locks/Condition.java
@@ -1,0 +1,25 @@
+package sandbox.java.util.concurrent.locks;
+
+import sandbox.java.util.Date;
+import sandbox.java.util.concurrent.TimeUnit;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.concurrent.locks.Condition}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.DJVMConditionObject}.
+ */
+@SuppressWarnings("unused")
+public interface Condition {
+    void await() throws InterruptedException;
+
+    void awaitUninterruptibly();
+
+    long awaitNanos(long nanosTimeout) throws InterruptedException;
+
+    boolean await(long time, TimeUnit unit) throws InterruptedException;
+
+    boolean awaitUntil(Date deadline) throws InterruptedException;
+
+    void signal();
+
+    void signalAll();
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/locks/DJVMConditionObject.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/locks/DJVMConditionObject.java
@@ -1,0 +1,40 @@
+package sandbox.java.util.concurrent.locks;
+
+import sandbox.java.util.Date;
+import sandbox.java.util.concurrent.TimeUnit;
+
+class DJVMConditionObject extends sandbox.java.lang.Object implements Condition {
+    DJVMConditionObject() {
+    }
+
+    @Override
+    public void await() {
+    }
+
+    @Override
+    public void awaitUninterruptibly() {
+    }
+
+    @Override
+    public long awaitNanos(long nanosTimeout) {
+        return 0;
+    }
+
+    @Override
+    public boolean await(long time, TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public boolean awaitUntil(Date deadline) {
+        return true;
+    }
+
+    @Override
+    public void signal() {
+    }
+
+    @Override
+    public void signalAll() {
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/locks/Lock.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/locks/Lock.java
@@ -1,0 +1,22 @@
+package sandbox.java.util.concurrent.locks;
+
+import sandbox.java.util.concurrent.TimeUnit;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.concurrent.locks.Lock}
+ * to allow us to compile {@link sandbox.java.util.concurrent.locks.ReentrantLock}.
+ */
+@SuppressWarnings("unused")
+public interface Lock {
+    void lock();
+
+    void lockInterruptibly() throws InterruptedException;
+
+    boolean tryLock();
+
+    boolean tryLock(long time, TimeUnit unit) throws InterruptedException;
+
+    void unlock();
+
+    Condition newCondition();
+}

--- a/djvm/src/main/java/sandbox/java/util/concurrent/locks/ReentrantLock.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/locks/ReentrantLock.java
@@ -1,0 +1,115 @@
+package sandbox.java.util.concurrent.locks;
+
+import sandbox.java.lang.Thread;
+import sandbox.java.util.ArrayList;
+import sandbox.java.util.Collection;
+import sandbox.java.util.concurrent.TimeUnit;
+
+import java.io.Serializable;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class ReentrantLock extends sandbox.java.lang.Object implements Lock, Serializable {
+    private final boolean isFair;
+    private int holdCount;
+
+    public ReentrantLock(boolean isFair) {
+        this.isFair = isFair;
+    }
+
+    public ReentrantLock() {
+        this(false);
+    }
+
+    @Override
+    public void lock() {
+        ++holdCount;
+    }
+
+    @Override
+    public void lockInterruptibly() {
+        lock();
+    }
+
+    @Override
+    public boolean tryLock() {
+        lock();
+        return true;
+    }
+
+    @Override
+    public boolean tryLock(long time, TimeUnit unit) {
+        return tryLock();
+    }
+
+    @Override
+    public void unlock() {
+        if (holdCount > 0) {
+            --holdCount;
+        }
+    }
+
+    @Override
+    public Condition newCondition() {
+        return new DJVMConditionObject();
+    }
+
+    public int getHoldCount() {
+        return holdCount;
+    }
+
+    public boolean isLocked() {
+        return holdCount > 0;
+    }
+
+    public boolean isHeldByCurrentThread() {
+        return isLocked();
+    }
+
+    public final boolean isFair() {
+        return isFair;
+    }
+
+    protected Thread getOwner() {
+        return null;
+    }
+
+    public final boolean hasQueuedThreads() {
+        return false;
+    }
+
+    public final boolean hasQueuedThread(Thread thread) {
+        if (thread == null) {
+            throw new NullPointerException();
+        }
+        return false;
+    }
+
+    public final int getQueueLength() {
+        return 0;
+    }
+
+    protected Collection<Thread> getQueuedThreads() {
+        return new ArrayList<>();
+    }
+
+    public boolean hasWaiters(Condition condition) {
+        if (condition == null) {
+            throw new NullPointerException();
+        }
+        return false;
+    }
+
+    public int getWaitQueueLength(Condition condition) {
+        if (condition == null) {
+            throw new NullPointerException();
+        }
+        return 0;
+    }
+
+    protected Collection<Thread> getWaitingThreads(Condition condition) {
+        if (condition == null) {
+            throw new NullPointerException();
+        }
+        return new ArrayList<>();
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/function/IntBinaryOperator.java
+++ b/djvm/src/main/java/sandbox/java/util/function/IntBinaryOperator.java
@@ -1,0 +1,10 @@
+package sandbox.java.util.function;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.function.IntBinaryOperator}
+ * to allow us to compile {@link sandbox.java.util.concurrent.atomic.AtomicInteger}.
+ */
+@FunctionalInterface
+public interface IntBinaryOperator {
+    int applyAsInt(int left, int right);
+}

--- a/djvm/src/main/java/sandbox/java/util/function/IntUnaryOperator.java
+++ b/djvm/src/main/java/sandbox/java/util/function/IntUnaryOperator.java
@@ -1,0 +1,10 @@
+package sandbox.java.util.function;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.function.IntUnaryOperator}
+ * to allow us to compile {@link sandbox.java.util.concurrent.atomic.AtomicInteger}.
+ */
+@FunctionalInterface
+public interface IntUnaryOperator {
+    int applyAsInt(int value);
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -147,7 +147,9 @@ class AnalysisConfiguration private constructor(
             java.security.AccessController::class.java,
             java.util.concurrent.ConcurrentHashMap::class.java,
             java.util.concurrent.ConcurrentHashMap.KeySetView::class.java,
+            java.util.concurrent.atomic.AtomicInteger::class.java,
             java.util.concurrent.atomic.AtomicLong::class.java,
+            java.util.concurrent.locks.ReentrantLock::class.java,
             kotlin.Any::class.java,
             sun.misc.JavaLangAccess::class.java,
             sun.misc.SharedSecrets::class.java,
@@ -171,6 +173,7 @@ class AnalysisConfiguration private constructor(
             "sandbox/java/util/concurrent/atomic/AtomicLongFieldUpdater\$AtomicLongFieldUpdaterImpl",
             "sandbox/java/util/concurrent/atomic/AtomicReferenceFieldUpdater\$AtomicReferenceFieldUpdaterImpl",
             "sandbox/java/util/concurrent/atomic/DJVM",
+            "sandbox/java/util/concurrent/locks/DJVMConditionObject",
             "sandbox/sun/misc/SharedSecrets\$1",
             "sandbox/sun/misc/SharedSecrets\$JavaLangAccessImpl",
             "sandbox/sun/security/provider/ByteArrayAccess"

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -299,6 +299,7 @@ private val bannedClasses = setOf(
     "^net\\.corda\\.djvm\\..*\$".toRegex(),
     "^java\\..*\\.DJVM\$".toRegex(),
     "^java\\.io\\.DJVM[^.]++\$".toRegex(),
+    "^java\\.util\\.concurrent\\.locks\\.DJVM[^.]++\$".toRegex(),
     "^RuntimeCostAccounter\$".toRegex(),
     "^Task(.*)?\$".toRegex()
 )

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/LinkedBlockingQueueTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/LinkedBlockingQueueTest.kt
@@ -1,0 +1,27 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.concurrent.LinkedBlockingQueue
+
+import java.util.function.Function
+
+class LinkedBlockingQueueTest : TestBase(KOTLIN) {
+    @Test
+    fun `elementary linked blocking queue test`() = parentedSandbox {
+        val executor = DeterministicSandboxExecutor<String, Int>(configuration)
+        val summary = executor.run<CreateLinkedBlockingQueue>("Message")
+        assertThat(summary.result).isEqualTo(1)
+    }
+
+    class CreateLinkedBlockingQueue : Function<String, Int> {
+        private val queue = LinkedBlockingQueue<String>()
+
+        override fun apply(message: String): Int {
+            queue.add(message)
+            return queue.size
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -636,6 +636,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "java.lang.DJVMResourceKey",
         "java.lang.DJVMThrowableWrapper",
         "java.util.concurrent.atomic.DJVM",
+        "java.util.concurrent.locks.DJVMConditionObject",
         "RuntimeCostAccounter",
         "TaskTypes",
         "Task"


### PR DESCRIPTION
Corda requires SLF4J and SLF4J requires `LinkedBlockingQueue`, which in turn requires `AtomicInteger` and `ReentrantLock`.