### PR TITLE
CORDA-3069: Allow SLF4J to initialise within the sandbox.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 
     sandboxTesting sourceSets.getByName("main").runtimeClasspath
+    sandboxTesting "org.slf4j:slf4j-nop:$slf4j_version"
 }
 
 tasks.withType(JavaCompile) {

--- a/djvm-example/settings.gradle
+++ b/djvm-example/settings.gradle
@@ -5,3 +5,11 @@ pluginManagement {
 }
 
 rootProject.name = "djvm-example"
+
+if (file('../djvm').isDirectory()) {
+    includeBuild('..') {
+        dependencySubstitution {
+            substitute module('net.corda:corda-djvm') with project(':djvm')
+        }
+    }
+}

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 jar.enabled = false
 
 shadowJar {
-    archiveBaseName = 'corda-djvm'
     classifier ''
     reproducibleFileOrder = true
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
@@ -125,7 +124,7 @@ publish {
     dependenciesFrom(configurations.shadow) {
         defaultScope = 'compile'
     }
-    name shadowJar.archiveBaseName.get()
+    name 'corda-djvm'
 }
 
 idea {

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -83,6 +83,7 @@ shadowJar {
     exclude 'sandbox/java/lang/ref/ReferenceQueue.class'
     exclude 'sandbox/java/nio/charset/Charset.class'
     exclude 'sandbox/java/nio/charset/spi/**'
+    exclude 'sandbox/java/security/AccessControlException.class'
     exclude 'sandbox/java/security/PrivilegedAction.class'
     exclude 'sandbox/java/security/PrivilegedExceptionAction.class'
     exclude 'sandbox/java/util/concurrent/ConcurrentMap.class'

--- a/djvm/src/main/java/sandbox/java/lang/System.java
+++ b/djvm/src/main/java/sandbox/java/lang/System.java
@@ -2,9 +2,11 @@ package sandbox.java.lang;
 
 import net.corda.djvm.SandboxRuntimeContext;
 import org.jetbrains.annotations.Nullable;
+import sandbox.java.security.AccessControlException;
 
 @SuppressWarnings("unused")
 public final class System extends Object {
+    private static final String ACCESS_DENIED = DJVM.intern("access denied");
 
     private System() {}
 
@@ -30,6 +32,10 @@ public final class System extends Object {
     @Nullable
     public static SecurityManager getSecurityManager() {
         return null;
+    }
+
+    public static void setSecurityManager(SecurityManager sm) {
+        throw (RuntimeException) DJVM.fromDJVM(new AccessControlException(ACCESS_DENIED));
     }
 
     public static void runFinalization() {}

--- a/djvm/src/main/java/sandbox/java/security/AccessControlException.java
+++ b/djvm/src/main/java/sandbox/java/security/AccessControlException.java
@@ -1,0 +1,13 @@
+package sandbox.java.security;
+
+import sandbox.java.lang.String;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.security.AccessControlException}
+ * to allow us to compile {@link sandbox.java.lang.System}.
+ */
+public class AccessControlException extends sandbox.java.lang.Throwable {
+    public AccessControlException(String message) {
+        super(message);
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -378,6 +378,15 @@ class AnalysisConfiguration private constructor(
                 genericsDetails = ""
             )
         ).mapByClassName() + listOf(
+            // This method will be deleted.
+            Member(
+                access = ACC_STATIC,
+                className = sandboxed(SecurityManager::class.java),
+                memberName = "<clinit>",
+                descriptor = "()V",
+                genericsDetails = ""
+            )
+        ).mapByClassName() + listOf(
             object : MethodBuilder(
                 access = ACC_PRIVATE or ACC_STATIC,
                 className = sandboxed(SecureRandom::class.java),

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -360,32 +360,11 @@ class AnalysisConfiguration private constructor(
             }.withBody()
              .build()
         ).mapByClassName() + listOf(
-            // This method will be deleted.
-            Member(
-                access = ACC_STATIC,
-                className = sandboxed(Modifier::class.java),
-                memberName = "<clinit>",
-                descriptor = "()V",
-                genericsDetails = ""
-            )
+            deleteClassInitialiserFor(Modifier::class.java)
         ).mapByClassName() + listOf(
-            // This method will be deleted.
-            Member(
-                access = ACC_STATIC,
-                className = sandboxed(Random::class.java),
-                memberName = "<clinit>",
-                descriptor = "()V",
-                genericsDetails = ""
-            )
+            deleteClassInitialiserFor(Random::class.java)
         ).mapByClassName() + listOf(
-            // This method will be deleted.
-            Member(
-                access = ACC_STATIC,
-                className = sandboxed(SecurityManager::class.java),
-                memberName = "<clinit>",
-                descriptor = "()V",
-                genericsDetails = ""
-            )
+            deleteClassInitialiserFor(SecurityManager::class.java)
         ).mapByClassName() + listOf(
             object : MethodBuilder(
                 access = ACC_PRIVATE or ACC_STATIC,
@@ -534,6 +513,14 @@ class AnalysisConfiguration private constructor(
         private fun <T> unmodifiable(items: Set<T>): Set<T> {
             return if (items.isEmpty()) emptySet() else unmodifiableSet(items)
         }
+
+        private fun deleteClassInitialiserFor(classType: Class<*>) = Member(
+            access = ACC_STATIC,
+            className = sandboxed(classType),
+            memberName = "<clinit>",
+            descriptor = "()V",
+            genericsDetails = ""
+        )
 
         private fun EmitterModule.returnResourceBundle() {
             invokeStatic(

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -5,6 +5,7 @@ package sandbox.java.lang
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration.Companion.JVM_EXCEPTIONS
 import net.corda.djvm.analysis.ExceptionResolver.Companion.getDJVMException
+import net.corda.djvm.rewiring.SandboxClassLoadingException
 import net.corda.djvm.rules.RuleViolationError
 import net.corda.djvm.rules.implementation.*
 import org.objectweb.asm.Opcodes.ACC_ENUM
@@ -368,9 +369,13 @@ fun finally(t: kotlin.Throwable): Throwable {
  * It is invoked at the start of each catch block.
  *
  * Note: [DisallowCatchingBlacklistedExceptions] means that we don't
- * need to handle [ThreadDeath] here.
+ * need to handle [ThreadDeath] or [VirtualMachineError] here.
  */
 fun catch(t: kotlin.Throwable): Throwable {
+    if (t is SandboxClassLoadingException) {
+        // Don't interfere with sandbox failures!
+        throw t
+    }
     try {
         return t.toDJVMThrowable()
     } catch (e: Exception) {

--- a/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
@@ -1,0 +1,39 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import static net.corda.djvm.messages.Severity.WARNING;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SecurityManagerTest extends TestBase {
+    SecurityManagerTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testReplacingSecurityManager() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> WithJava.run(executor, ReplacingSecurityManager.class, ""));
+            assertThat(ex)
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("sandbox.java.security.AccessControlException -> access denied")
+                .hasNoCause();
+            return null;
+        });
+    }
+
+    public static class ReplacingSecurityManager implements Function<String, String> {
+        @Override
+        public String apply(String s) {
+            System.setSecurityManager(new SecurityManager() {});
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Provide the sandbox example with a NOP implementation of SLF4J's `StaticLoggerBinder` class.
- Allow `SandboxClassLoadingException` instances to escape the sandbox unhindered.
- Stub out `System.setSecurityManager()` always to throw `AccessControlException`.