### PR TITLE
Ensure that DJVM project creates its artifact for composite build.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -72,6 +72,11 @@ tasks.withType(Test) {
     systemProperty 'sandbox-libraries.path', configurations.sandboxTesting.asPath
 }
 
+def djvmProject = gradle.includedBuilds.find { it.name == 'deterministic-jvm-sandbox' }
+if (djvmProject) {
+    assemble.dependsOn djvmProject.task(':djvm:assemble')
+}
+
 wrapper {
     gradleVersion = "5.5.1"
     distributionType = Wrapper.DistributionType.ALL

--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -66,15 +66,16 @@ tasks.withType(KotlinCompile) {
     }
 }
 
+def djvmProject = gradle.includedBuilds.find { it.name == 'deterministic-jvm-sandbox' }
+
 tasks.withType(Test) {
     useJUnitPlatform()
     systemProperty 'deterministic-rt.path', configurations.jdkRt.asPath
     systemProperty 'sandbox-libraries.path', configurations.sandboxTesting.asPath
-}
 
-def djvmProject = gradle.includedBuilds.find { it.name == 'deterministic-jvm-sandbox' }
-if (djvmProject) {
-    assemble.dependsOn djvmProject.task(':djvm:assemble')
+    if (djvmProject) {
+        dependsOn djvmProject.task(':djvm:assemble')
+    }
 }
 
 wrapper {


### PR DESCRIPTION
Ensure that `djvm-example` can find the DJVM jar artifact when executed as a composite Gradle project.