### PR TITLE
CORDA-3089: Support X500Principal and X500Name inside the sandbox.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         sourceCompatibility = VERSION_1_8
         targetCompatibility = VERSION_1_8
         options.encoding = 'UTF-8'
+        options.compilerArgs += '-XDenableSunApiLintControl'
     }
 
     tasks.withType(KotlinCompile) {

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -61,6 +61,9 @@ shadowJar {
         attributes('Sealed': true)
     }
 
+    // Discard the ASM library's module information.
+    exclude 'module-info.class'
+
     // These particular classes are only needed to "bootstrap"
     // the compilation of the other sandbox classes. At runtime,
     // we will generate better versions from deterministic-rt.jar.
@@ -108,6 +111,8 @@ shadowJar {
     exclude 'sandbox/java/util/MissingResourceException.class'
     exclude 'sandbox/java/util/Properties.class'
     exclude 'sandbox/java/util/ResourceBundle*.class'
+    exclude 'sandbox/javax/security/auth/x500/X500Principal.class'
+    exclude 'sandbox/sun/security/x509/X500Name.class'
 }
 assemble.dependsOn shadowJar
 

--- a/djvm/src/main/java/sandbox/javax/security/auth/x500/DJVM.java
+++ b/djvm/src/main/java/sandbox/javax/security/auth/x500/DJVM.java
@@ -1,0 +1,17 @@
+package sandbox.javax.security.auth.x500;
+
+import sandbox.sun.security.x509.X500Name;
+
+@SuppressWarnings("unused")
+public final class DJVM {
+    private DJVM() {
+    }
+
+    public static X500Principal create(X500Name name) {
+        return new X500Principal(name);
+    }
+
+    public static X500Name unwrap(X500Principal principal) {
+        return principal.unwrap();
+    }
+}

--- a/djvm/src/main/java/sandbox/javax/security/auth/x500/X500Principal.java
+++ b/djvm/src/main/java/sandbox/javax/security/auth/x500/X500Principal.java
@@ -1,0 +1,24 @@
+package sandbox.javax.security.auth.x500;
+
+import sandbox.sun.security.x509.X500Name;
+
+/**
+ * This is a dummy class that implements just enough of {@link javax.security.auth.x500.X500Principal} to allow
+ * us to compile {@link sandbox.javax.security.auth.x500.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class X500Principal extends sandbox.java.lang.Object {
+    private transient X500Name thisX500Name;
+
+    X500Principal(X500Name name) {
+    }
+
+    /**
+     * This method will be stitched into the actual {@link X500Principal}
+     * class at run-time. It is implemented here only for reference.
+     * @return internal {@link X500Name} value.
+     */
+    final X500Name unwrap() {
+        return thisX500Name;
+    }
+}

--- a/djvm/src/main/java/sandbox/sun/security/action/GetBooleanAction.java
+++ b/djvm/src/main/java/sandbox/sun/security/action/GetBooleanAction.java
@@ -1,0 +1,16 @@
+package sandbox.sun.security.action;
+
+import sandbox.java.lang.Boolean;
+import sandbox.java.lang.String;
+import sandbox.java.security.PrivilegedAction;
+
+@SuppressWarnings("unused")
+public class GetBooleanAction extends sandbox.java.lang.Object implements PrivilegedAction<Boolean> {
+    public GetBooleanAction(String propertyName) {
+    }
+
+    @Override
+    public Boolean run() {
+        return Boolean.FALSE;
+    }
+}

--- a/djvm/src/main/java/sandbox/sun/security/x509/X500Name.java
+++ b/djvm/src/main/java/sandbox/sun/security/x509/X500Name.java
@@ -1,0 +1,47 @@
+package sandbox.sun.security.x509;
+
+import sandbox.java.security.PrivilegedExceptionAction;
+import sandbox.javax.security.auth.x500.DJVM;
+import sandbox.javax.security.auth.x500.X500Principal;
+
+/**
+ * This is a dummy class. What we're actually reimplementing here is
+ * the anonymous inner class.
+ */
+@SuppressWarnings("unused")
+public class X500Name extends sandbox.java.lang.Object {
+    static {
+        /*
+         * This is what we're really replacing here.
+         */
+        new PrivilegedExceptionAction<Object[]>() {
+            @Override
+            public Object[] run() {
+                return new Object[]{ null, null };
+            }
+        };
+    }
+
+    private X500Principal x500Principal;
+
+    /**
+     * This method will be stitched into the actual {@link X500Name}
+     * class at run-time. It is implemented here only for reference.
+     * @return A new {@link X500Principal} wrapping this {@link X500Name}.
+     */
+    public X500Principal asX500Principal() {
+        return DJVM.create(this);
+    }
+
+    /**
+     * This method will be stitched into the actual {@link X500Name}
+     * class at run-time. It is implemented here only for reference.
+     * @param principal Any {@link X500Principal} object.
+     * @return The {@link X500Name} contained within this {@link X500Principal}.
+     */
+    public static X500Name asX500Name(X500Principal principal) {
+        X500Name name = DJVM.unwrap(principal);
+        name.x500Principal = principal;
+        return name;
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -101,6 +101,22 @@ class EmitterModule(
     }
 
     /**
+     * Emit instruction for pushing a field value onto the stack.
+     */
+    fun pushField(owner: String, name: String, descriptor: String) {
+        methodVisitor.visitFieldInsn(GETFIELD, owner, name, descriptor)
+        hasEmittedCustomCode = true
+    }
+
+    /**
+     * Emit instruction for popping a value from the stack into a field.
+     */
+    fun popField(owner: String, name: String, descriptor: String) {
+        methodVisitor.visitFieldInsn(PUTFIELD, owner, name, descriptor)
+        hasEmittedCustomCode = true
+    }
+
+    /**
      * Emit an opcode for a single instruction.
      */
     fun instruction(opcode: Int) {
@@ -117,6 +133,15 @@ class EmitterModule(
      * Emit instruction for duplicating the top of the stack.
      */
     fun duplicate() = instruction(DUP)
+
+    /**
+     * Emit instruction for popping an object reference
+     * from the stack into a register.
+     */
+    fun popObject(regNum: Int) {
+        methodVisitor.visitVarInsn(ASTORE, regNum)
+        hasEmittedCustomCode = true
+    }
 
     /**
      * Emit instruction for pushing an object reference

--- a/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
@@ -1,0 +1,74 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import org.junit.jupiter.api.Test;
+import sun.security.x509.AVA;
+import sun.security.x509.X500Name;
+
+import javax.security.auth.x500.X500Principal;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class X500Tests extends TestBase {
+    X500Tests() {
+        super(JAVA);
+    }
+
+    @Test
+    void testCreateX500Principal() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, CreateX500Principal.class, "CN=Example,O=Corda,C=GB");
+            assertEquals("cn=example,o=corda,c=gb", success.getResult());
+            return null;
+        });
+    }
+
+    public static class CreateX500Principal implements Function<String, String> {
+        public String apply(String input) {
+            X500Principal principal = new X500Principal(input);
+            return principal.getName(X500Principal.CANONICAL);
+        }
+    }
+
+    @Test
+    void testX500PrincipalToX500Name() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, X500PrincipalToX500Name.class, "CN=Example,O=Corda,C=GB");
+            assertThat(success.getResult()).isEqualTo(new String[] {
+                "c=gb", "cn=example", "o=corda"
+            });
+            return null;
+        });
+    }
+
+    public static class X500PrincipalToX500Name implements Function<String, String[]> {
+        public String[] apply(String input) {
+            X500Name name = X500Name.asX500Name(new X500Principal(input));
+            return name.allAvas().stream().map(AVA::toRFC2253CanonicalString).sorted().toArray(String[]::new);
+        }
+    }
+
+    @Test
+    void testX500NameToX500Principal() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, X500NameToX500Principal.class, "CN=Example,O=Corda,C=GB");
+            assertEquals("cn=example,o=corda,c=gb", success.getResult());
+            return null;
+        });
+    }
+
+    public static class X500NameToX500Principal implements Function<String, String> {
+        public String apply(String input) {
+            X500Principal principal = X500Name.asX500Name(new X500Principal(input)).asX500Principal();
+            return principal.getName(X500Principal.CANONICAL);
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
@@ -21,8 +21,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
     @ValueSource(strings = [ "SHA", "SHA-256", "SHA-384", "SHA-512" ])
     @ParameterizedTest
     fun `test SHA hashing`(algorithmName: String) = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<Array<String>, ByteArray>(configuration)
-        val summary = contractExecutor.run<Hashing>(arrayOf(algorithmName, SECRET_MESSAGE))
+        val executor = DeterministicSandboxExecutor<Array<String>, ByteArray>(configuration)
+        val summary = executor.run<Hashing>(arrayOf(algorithmName, SECRET_MESSAGE))
         assertThat(summary.result)
             .isEqualTo(MessageDigest.getInstance(algorithmName).digest(SECRET_MESSAGE.toByteArray()))
     }
@@ -45,8 +45,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
             sign()
         }
 
-        val contractExecutor = DeterministicSandboxExecutor<Array<*>, Boolean>(configuration)
-        val summary = contractExecutor.run<VerifySignature>(
+        val executor = DeterministicSandboxExecutor<Array<*>, Boolean>(configuration)
+        val summary = executor.run<VerifySignature>(
             arrayOf(algorithm, keyPair.public.encoded, algorithmName, data, signature)
         )
         assertThat(summary.result).isTrue()
@@ -68,8 +68,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @Test
     fun `test security providers`() = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
-        val summary = contractExecutor.run<SecurityProviders>("")
+        val executor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
+        val summary = executor.run<SecurityProviders>("")
         assertThat(summary.result).isEqualTo(arrayOf("SUN", "SunRsaSign"))
     }
 
@@ -102,8 +102,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
     @ArgumentsSource(AlgorithmProvider::class)
     @ParameterizedTest
     fun `test service algorithms`(serviceName: String, algorithms: Array<String>) = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
-        val summary = contractExecutor.run<ServiceAlgorithms>(serviceName)
+        val executor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
+        val summary = executor.run<ServiceAlgorithms>(serviceName)
         assertThat(summary.result)
             .isEqualTo(algorithms)
     }
@@ -117,8 +117,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
     @ParameterizedTest
     @ValueSource(strings = [ "SUN", "SunRsaSign" ])
     fun `test no secure random for`(serviceName: String) = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<String, Double>(configuration)
-        val exception = assertThrows<SandboxException> { contractExecutor.run<SecureRandomService>(serviceName) }
+        val executor = DeterministicSandboxExecutor<String, Double>(configuration)
+        val exception = assertThrows<SandboxException> { executor.run<SecureRandomService>(serviceName) }
         assertThat(exception)
             .hasCauseExactlyInstanceOf(Exception::class.java)
             .hasMessage("sandbox.java.security.NoSuchAlgorithmException -> $serviceName SecureRandom not available")
@@ -132,8 +132,8 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @Test
     fun `test secure random instance`() = parentedSandbox {
-        val contractExecutor = DeterministicSandboxExecutor<ByteArray?, Double>(configuration)
-        val exception = assertThrows<SandboxException> { contractExecutor.run<SecureRandomInstance>(null) }
+        val executor = DeterministicSandboxExecutor<ByteArray?, Double>(configuration)
+        val exception = assertThrows<SandboxException> { executor.run<SecureRandomInstance>(null) }
         assertThat(exception)
             .hasCauseExactlyInstanceOf(UnsupportedOperationException::class.java)
             .hasMessageContaining("Seed generation disabled")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -637,6 +637,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "java.lang.DJVMThrowableWrapper",
         "java.util.concurrent.atomic.DJVM",
         "java.util.concurrent.locks.DJVMConditionObject",
+        "javax.security.auth.x500.DJVM",
         "RawTask",
         "RuntimeCostAccounter",
         "TaskTypes",


### PR DESCRIPTION
We need `X500Principal` (and hence `X500Name`) inside the sandbox so that the DJVM can support `CordaX500Name`. Remove these classes internal use of reflection which was preventing them from initialising.