### PR TITLE
CORDA-3097: Abstract the URLClassLoaders away behind some interfaces.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -8,6 +8,7 @@ import net.corda.djvm.execution.ExecutionProfile
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.source.BootstrapClassLoader
+import net.corda.djvm.source.UserPathSource
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.fail
@@ -35,9 +36,9 @@ abstract class TestBase(type: SandboxType) {
         @JvmStatic
         fun setupClassLoader() {
             val rootConfiguration = AnalysisConfiguration.createRoot(
-                emptyList(),
-                Whitelist.MINIMAL,
-                bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
+                userSource = UserPathSource(emptyList()),
+                whitelist = Whitelist.MINIMAL,
+                bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
             )
             configuration = SandboxConfiguration.of(
                 ExecutionProfile.UNLIMITED,
@@ -71,7 +72,7 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 configuration.analysisConfiguration.createChild(
-                    classPaths = classPaths,
+                    userSource = UserPathSource(classPaths),
                     newMinimumSeverityLevel = minimumSeverityLevel
                 ).use { analysisConfiguration ->
                     SandboxRuntimeContext(SandboxConfiguration.of(

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -10,6 +10,7 @@ import net.corda.djvm.source.SourceClassLoader
 import djvm.org.objectweb.asm.ClassReader
 import net.corda.djvm.SandboxConfiguration.Companion.ALL_DEFINITION_PROVIDERS
 import net.corda.djvm.SandboxConfiguration.Companion.ALL_RULES
+import net.corda.djvm.source.UserPathSource
 import picocli.CommandLine.Option
 import java.nio.file.Files
 import java.nio.file.Path
@@ -54,7 +55,7 @@ abstract class ClassCommand : CommandBase() {
 
     private val classModule = ClassModule()
 
-    private lateinit var classLoader: ClassLoader
+    private lateinit var classLoader: SourceClassLoader
 
     protected lateinit var executor: SandboxExecutor<Any, Any>
         private set
@@ -67,7 +68,7 @@ abstract class ClassCommand : CommandBase() {
 
     override fun handleCommand(): Boolean {
         val configuration = getConfiguration(Whitelist.MINIMAL)
-        classLoader = SourceClassLoader(getClasspath(), configuration.analysisConfiguration.classResolver)
+        classLoader = configuration.analysisConfiguration.supportingClassLoader
         createExecutor(configuration)
 
         val classes = discoverClasses(filters).onEmpty {
@@ -186,7 +187,7 @@ abstract class ClassCommand : CommandBase() {
                 definitionProviders = if (ignoreDefinitionProviders) { emptyList() } else { ALL_DEFINITION_PROVIDERS },
                 enableTracing = !disableTracing,
                 analysisConfiguration = AnalysisConfiguration.createRoot(
-                        classPaths = getClasspath(),
+                        userSource = UserPathSource(getClasspath()),
                         whitelist = whitelist,
                         minimumSeverityLevel = level,
                         analyzeAnnotations = analyzeAnnotations,

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -1,15 +1,15 @@
 package net.corda.djvm.tools.cli
 
+import djvm.org.objectweb.asm.ClassReader
 import net.corda.djvm.SandboxConfiguration
+import net.corda.djvm.SandboxConfiguration.Companion.ALL_DEFINITION_PROVIDERS
+import net.corda.djvm.SandboxConfiguration.Companion.ALL_RULES
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.Whitelist
 import net.corda.djvm.execution.*
 import net.corda.djvm.references.ClassModule
 import net.corda.djvm.source.ClassSource
 import net.corda.djvm.source.SourceClassLoader
-import djvm.org.objectweb.asm.ClassReader
-import net.corda.djvm.SandboxConfiguration.Companion.ALL_DEFINITION_PROVIDERS
-import net.corda.djvm.SandboxConfiguration.Companion.ALL_RULES
 import net.corda.djvm.source.UserPathSource
 import picocli.CommandLine.Option
 import java.nio.file.Files

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -10,6 +10,7 @@ import net.corda.djvm.references.Member
 import net.corda.djvm.references.MemberModule
 import net.corda.djvm.references.MethodBody
 import net.corda.djvm.source.BootstrapClassLoader
+import net.corda.djvm.source.BootstrapSource
 import net.corda.djvm.source.SourceClassLoader
 import org.objectweb.asm.Label
 import org.objectweb.asm.Opcodes.*
@@ -120,7 +121,7 @@ class AnalysisConfiguration private constructor(
         /**
          * An empty placeholder used by "child" instances of [SourceClassLoader].
          */
-        private val EMPTY: BootstrapClassLoader = BootstrapClassLoader()
+        private val EMPTY: BootstrapSource = BootstrapClassLoader()
 
         /**
          * These classes will be duplicated into every sandbox's
@@ -567,7 +568,7 @@ class AnalysisConfiguration private constructor(
             prefixFilters: List<String> = emptyList(),
             classModule: ClassModule = ClassModule(),
             memberModule: MemberModule = MemberModule(),
-            bootstrapClassLoader: BootstrapClassLoader? = null
+            bootstrapSource: BootstrapSource? = null
         ): AnalysisConfiguration {
             /**
              * We may need to whitelist the descriptors for methods that we
@@ -595,7 +596,7 @@ class AnalysisConfiguration private constructor(
                 prefixFilters = prefixFilters,
                 classModule = classModule,
                 memberModule = memberModule,
-                supportingClassLoader = SourceClassLoader(classPaths, classResolver, bootstrapClassLoader)
+                supportingClassLoader = SourceClassLoader(classPaths, classResolver, bootstrapSource)
             )
         }
     }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -18,8 +18,7 @@ import net.corda.djvm.rewiring.LoadedClass
 import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.rules.Rule
 import net.corda.djvm.rules.implementation.*
-import net.corda.djvm.source.BootstrapClassLoader
-import net.corda.djvm.source.ClassSource
+import net.corda.djvm.source.*
 import net.corda.djvm.validation.RuleValidator
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -90,8 +89,8 @@ abstract class TestBase(type: SandboxType) {
         @JvmStatic
         fun setupParentClassLoader() {
             val rootConfiguration = AnalysisConfiguration.createRoot(
-                emptyList(),
-                Whitelist.MINIMAL,
+                userSource = UserPathSource(emptyList()),
+                whitelist = Whitelist.MINIMAL,
                 bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT),
                 pinnedClasses = setOf(
                     Utilities::class.java
@@ -124,8 +123,8 @@ abstract class TestBase(type: SandboxType) {
      * Default analysis configuration.
      */
     val configuration = AnalysisConfiguration.createRoot(
-        classPaths,
-        Whitelist.MINIMAL,
+        userSource = UserPathSource(classPaths),
+        whitelist = Whitelist.MINIMAL,
         bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
     )
 
@@ -149,7 +148,7 @@ abstract class TestBase(type: SandboxType) {
     ) {
         val reader = ClassReader(T::class.java.name)
         AnalysisConfiguration.createRoot(
-            classPaths,
+            userSource = UserPathSource(classPaths),
             whitelist = Whitelist.MINIMAL,
             minimumSeverityLevel = minimumSeverityLevel,
             bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
@@ -198,7 +197,7 @@ abstract class TestBase(type: SandboxType) {
             try {
                 val pinnedTestClasses = pinnedClasses.map(Type::getInternalName).toSet()
                 AnalysisConfiguration.createRoot(
-                    classPaths = classPaths,
+                    userSource = UserPathSource(classPaths),
                     whitelist = whitelist,
                     pinnedClasses = pinnedTestClasses,
                     minimumSeverityLevel = minimumSeverityLevel,
@@ -232,7 +231,7 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 parentConfiguration.analysisConfiguration.createChild(
-                    classPaths = classPaths,
+                    userSource = UserPathSource(classPaths),
                     newMinimumSeverityLevel = minimumSeverityLevel
                 ).use { analysisConfiguration ->
                     SandboxRuntimeContext(SandboxConfiguration.of(

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -92,7 +92,7 @@ abstract class TestBase(type: SandboxType) {
             val rootConfiguration = AnalysisConfiguration.createRoot(
                 emptyList(),
                 Whitelist.MINIMAL,
-                bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT),
+                bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT),
                 pinnedClasses = setOf(
                     Utilities::class.java
                 ).map(Type::getInternalName).toSet()
@@ -126,7 +126,7 @@ abstract class TestBase(type: SandboxType) {
     val configuration = AnalysisConfiguration.createRoot(
         classPaths,
         Whitelist.MINIMAL,
-        bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
+        bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
     )
 
     /**
@@ -152,7 +152,7 @@ abstract class TestBase(type: SandboxType) {
             classPaths,
             whitelist = Whitelist.MINIMAL,
             minimumSeverityLevel = minimumSeverityLevel,
-            bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
+            bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
         ).use { analysisConfiguration ->
             val validator = RuleValidator(ALL_RULES, analysisConfiguration)
             val context = AnalysisContext.fromConfiguration(analysisConfiguration)
@@ -202,7 +202,7 @@ abstract class TestBase(type: SandboxType) {
                     whitelist = whitelist,
                     pinnedClasses = pinnedTestClasses,
                     minimumSeverityLevel = minimumSeverityLevel,
-                    bootstrapClassLoader = BootstrapClassLoader(DETERMINISTIC_RT)
+                    bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
                 ).use { analysisConfiguration ->
                     SandboxRuntimeContext(SandboxConfiguration.of(
                         executionProfile,

--- a/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
@@ -15,14 +15,14 @@ class SourceClassLoaderTest {
 
     @Test
     fun `can load class from Java's lang package when no files are provided to the class loader`() {
-        val classLoader = SourceClassLoader(emptyList(), classResolver)
+        val classLoader = SourceClassLoader(classResolver, UserPathSource(emptyList()))
         val clazz = classLoader.loadClass("java.lang.Boolean")
         assertThat(clazz.simpleName).isEqualTo("Boolean")
     }
 
     @Test
     fun `cannot load arbitrary class when no files are provided to the class loader`() {
-        val classLoader = SourceClassLoader(emptyList(), classResolver)
+        val classLoader = SourceClassLoader(classResolver, UserPathSource(emptyList()))
         assertThrows<ClassNotFoundException> {
             classLoader.loadClass("net.foo.NonExistentClass")
         }
@@ -31,7 +31,7 @@ class SourceClassLoaderTest {
     @Test
     fun `can load class when JAR file is provided to the class loader`() {
         useTemporaryFile("jar-with-single-class.jar") {
-            val classLoader = SourceClassLoader(this, classResolver)
+            val classLoader = SourceClassLoader(classResolver, UserPathSource(this))
             val clazz = classLoader.loadClass("net.foo.Bar")
             assertThat(clazz.simpleName).isEqualTo("Bar")
         }
@@ -40,7 +40,7 @@ class SourceClassLoaderTest {
     @Test
     fun `cannot load arbitrary class when JAR file is provided to the class loader`() {
         useTemporaryFile("jar-with-single-class.jar") {
-            val classLoader = SourceClassLoader(this, classResolver)
+            val classLoader = SourceClassLoader(classResolver, UserPathSource(this))
             assertThrows<ClassNotFoundException> {
                 classLoader.loadClass("net.foo.NonExistentClass")
             }
@@ -50,7 +50,7 @@ class SourceClassLoaderTest {
     @Test
     fun `can load classes when multiple JAR files are provided to the class loader`() {
         useTemporaryFile("jar-with-single-class.jar", "jar-with-two-classes.jar") {
-            val classLoader = SourceClassLoader(this, classResolver)
+            val classLoader = SourceClassLoader(classResolver, UserPathSource(this))
             val firstClass = classLoader.loadClass("com.somewhere.Test")
             assertThat(firstClass.simpleName).isEqualTo("Test")
             val secondClass = classLoader.loadClass("com.somewhere.AnotherTest")
@@ -61,7 +61,7 @@ class SourceClassLoaderTest {
     @Test
     fun `cannot load arbitrary class when multiple JAR files are provided to the class loader`() {
         useTemporaryFile("jar-with-single-class.jar", "jar-with-two-classes.jar") {
-            val classLoader = SourceClassLoader(this, classResolver)
+            val classLoader = SourceClassLoader(classResolver, UserPathSource(this))
             assertThrows<ClassNotFoundException> {
                 classLoader.loadClass("com.somewhere.NonExistentClass")
             }
@@ -73,8 +73,8 @@ class SourceClassLoaderTest {
         useTemporaryFile("jar-with-single-class.jar", "jar-with-two-classes.jar") {
             val (first, second) = this
             val directory = first.parent
-            val classLoader = SourceClassLoader(listOf(directory), classResolver)
-            assertThat(classLoader.urLs).anySatisfy {
+            val userPathSource = UserPathSource(listOf(directory))
+            assertThat(userPathSource.getURLs()).anySatisfy {
                 assertThat(it).isEqualTo(first.toUri().toURL())
             }.anySatisfy {
                 assertThat(it).isEqualTo(second.toUri().toURL())

--- a/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
@@ -74,7 +74,8 @@ class SourceClassLoaderTest {
             val (first, second) = this
             val directory = first.parent
             val userPathSource = UserPathSource(listOf(directory))
-            assertThat(userPathSource.getURLs()).anySatisfy {
+            val classLoader = SourceClassLoader(classResolver, userPathSource)
+            assertThat(classLoader.getURLs()).anySatisfy {
                 assertThat(it).isEqualTo(first.toUri().toURL())
             }.anySatisfy {
                 assertThat(it).isEqualTo(second.toUri().toURL())


### PR DESCRIPTION
The DJVM cannot assume that it can use `URLClassLoader` for its sources, _particularly_ inside the SGX enclave. Abstract its uses away behind new `ApiSource` and `UserSource` interfaces.