### PR TITLE
CORDA-2871: Add a RawTask that does not marshall its inputs and outputs.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -154,6 +154,7 @@ class AnalysisConfiguration private constructor(
             sun.misc.VM::class.java,
             sun.security.action.GetPropertyAction::class.java
         ).sandboxed() + setOf(
+            "sandbox/RawTask",
             "sandbox/Task",
             "sandbox/TaskTypes",
             RUNTIME_ACCOUNTER_NAME,

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
@@ -1,0 +1,45 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.SandboxConfiguration
+import net.corda.djvm.messages.Message
+import net.corda.djvm.source.ClassSource
+import java.lang.reflect.InvocationTargetException
+
+class SandboxRawExecutor(configuration: SandboxConfiguration)
+    : SandboxExecutor<Any?, Any?>(configuration, false) {
+
+    @Throws(Exception::class)
+    override fun run(runnableClass: ClassSource, input: Any?): ExecutionSummaryWithResult<Any?> {
+        val result = IsolatedTask(runnableClass.qualifiedClassName, configuration).run {
+            // Load the "entry-point" task class into the sandbox.
+            val taskClass = classLoader.loadClass("sandbox.RawTask")
+
+            // Create the user's task object inside the sandbox.
+            val runnable = classLoader.loadClassForSandbox(runnableClass).newInstance()
+
+            // Fetch this sandbox's instance of Class<Function> so we can retrieve RawTask(Function)
+            // and then instantiate the RawTask.
+            val functionClass = classLoader.loadClass("sandbox.java.util.function.Function")
+            val task = taskClass.getDeclaredConstructor(functionClass).newInstance(runnable)
+
+            // Execute the task...
+            val method = taskClass.getMethod("apply", Any::class.java)
+            try {
+                method.invoke(task, input)
+            } catch (ex: InvocationTargetException) {
+                throw ex.targetException
+            }
+        }
+
+        when (result.exception) {
+            null -> return ExecutionSummaryWithResult(result.output, result.costs)
+            else -> throw SandboxException(
+                    Message.getMessageFromException(result.exception),
+                    result.identifier,
+                    runnableClass,
+                    ExecutionSummary(result.costs),
+                    result.exception
+            )
+        }
+    }
+}

--- a/djvm/src/main/kotlin/sandbox/TaskTypes.kt
+++ b/djvm/src/main/kotlin/sandbox/TaskTypes.kt
@@ -5,14 +5,13 @@ import sandbox.java.lang.escapeSandbox
 import sandbox.java.lang.sandbox
 import sandbox.java.lang.unsandbox
 
-typealias SandboxFunction<TInput, TOutput> = sandbox.java.util.function.Function<TInput, TOutput>
+typealias SandboxFunction<INPUT, OUTPUT> = sandbox.java.util.function.Function<INPUT, OUTPUT>
 
 internal fun isEntryPoint(elt: StackTraceElement): Boolean {
     return elt.className == "sandbox.Task" && elt.methodName == "apply"
 }
 
 class Task(private val function: SandboxFunction<in Any?, out Any?>?) : SandboxFunction<Any?, Any?> {
-
     /**
      * This function runs inside the sandbox. It marshalls the input
      * object to its sandboxed equivalent, executes the user's code
@@ -29,5 +28,19 @@ class Task(private val function: SandboxFunction<in Any?, out Any?>?) : SandboxF
         }
         return value?.unsandbox()
     }
+}
 
+@Suppress("unused")
+class RawTask(private val function: SandboxFunction<Any?, Any?>?) : SandboxFunction<Any?, Any?> {
+    /**
+     * This function runs inside the sandbox, and performs NO marshalling
+     * of the input and output objects. This must be done by the caller.
+     */
+    override fun apply(input: Any?): Any? {
+        return try {
+            function?.apply(input)
+        } catch (t: Throwable) {
+            throw t.escapeSandbox()
+        }
+    }
 }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -301,6 +301,7 @@ private val bannedClasses = setOf(
     "^java\\..*\\.DJVM\$".toRegex(),
     "^java\\.io\\.DJVM[^.]++\$".toRegex(),
     "^java\\.util\\.concurrent\\.locks\\.DJVM[^.]++\$".toRegex(),
+    "^RawTask\$".toRegex(),
     "^RuntimeCostAccounter\$".toRegex(),
     "^Task(.*)?\$".toRegex()
 )

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -637,6 +637,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "java.lang.DJVMThrowableWrapper",
         "java.util.concurrent.atomic.DJVM",
         "java.util.concurrent.locks.DJVMConditionObject",
+        "RawTask",
         "RuntimeCostAccounter",
         "TaskTypes",
         "Task"

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxRawExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxRawExecutorTest.kt
@@ -1,0 +1,57 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import net.corda.djvm.source.ClassSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.fail
+import java.util.function.Function
+
+class SandboxRawExecutorTest : TestBase(KOTLIN) {
+    @Test
+    fun `test raw executor`() = parentedSandbox {
+        val executor = SandboxRawExecutor(configuration)
+        val inputData = "Hello World!".toByteArray()
+        val result = executor.run(ClassSource.fromClassName(BackwardsUppercase::class.java.name), inputData).result
+        assertThat(String(result as ByteArray)).isEqualTo("!DLROW OLLEH")
+    }
+
+    class BackwardsUppercase : Function<ByteArray, ByteArray> {
+        override fun apply(input: ByteArray): ByteArray {
+            return String(input).toUpperCase().reversed().toByteArray()
+        }
+    }
+
+    @Test
+    fun `test input unmarshalled`() = parentedSandbox {
+        val executor = SandboxRawExecutor(configuration)
+        val inputData = "Hello World!".toByteArray()
+        val ex = assertThrows<SandboxException>{ executor.run(ClassSource.fromClassName(UnmarshalledInput::class.java.name), inputData) }
+        assertThat(ex)
+            .hasMessageContaining("[B cannot be cast to sandbox.java.lang.String")
+            .hasCauseExactlyInstanceOf(ClassCastException::class.java)
+    }
+
+    class UnmarshalledInput : Function<String, ByteArray> {
+        override fun apply(input: String): ByteArray {
+            return input.reversed().toByteArray()
+        }
+    }
+
+    @Test
+    fun `test output is unmarshalled`() = parentedSandbox {
+        val executor = SandboxRawExecutor(configuration)
+        val inputData = "Hello World!".toByteArray()
+        val result = executor.run(ClassSource.fromClassName(UnmarshalledOutput::class.java.name), inputData).result
+                ?: fail("Cannot be null")
+        assertThat(result::class.java.name).isEqualTo("sandbox.java.lang.String")
+    }
+
+    class UnmarshalledOutput : Function<ByteArray, String> {
+        override fun apply(input: ByteArray): String {
+            return String(input).reversed()
+        }
+    }
+}


### PR DESCRIPTION
Provide an Executor that does not attempt to marshall its input and output objects between sandbox and non-sandbox types.