### PR TITLE
CORDA-2871: Add support for BouncyCastle to DJVM for sake of Corda

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -28,6 +28,18 @@ configurations {
         // Always check the repository for a newer SNAPSHOT.
         cacheChangingModulesFor 0, 'seconds'
     }
+
+    // This is for the latest deterministic Corda SNAPSHOT artifacts...
+    [ compileClasspath, runtimeClasspath ].forEach { cfg ->
+        cfg.resolutionStrategy {
+            // Always check the repository for a newer SNAPSHOT.
+            cacheChangingModulesFor 0, 'seconds'
+
+            dependencySubstitution {
+                substitute module("net.corda:corda-core:$corda_version") with module("net.corda:corda-core-deterministic:$corda_version")
+            }
+        }
+    }
 }
 
 dependencies {
@@ -35,7 +47,9 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_version"
     implementation "com.r3.corda.lib.tokens:tokens-money:$corda_tokens_version"
-    implementation "net.corda:corda-core-deterministic:$corda_version"
+    implementation ("net.corda:corda-core:$corda_version") {
+        changing = true
+    }
 
     testImplementation "net.corda:corda-djvm:$djvm_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"

--- a/djvm-example/src/main/kotlin/com/example/testing/DecodePublicKey.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/DecodePublicKey.kt
@@ -1,0 +1,11 @@
+package com.example.testing
+
+import net.corda.core.crypto.Crypto
+import java.util.function.Function
+
+class DecodePublicKey : Function<Array<Any>, ByteArray> {
+    override fun apply(data: Array<Any>): ByteArray {
+        val publicKey = Crypto.decodePublicKey(data[0] as String, data[1] as ByteArray)
+        return publicKey.encoded
+    }
+}

--- a/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
@@ -4,7 +4,6 @@ import com.example.testing.SandboxType.KOTLIN
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SignatureScheme
-import net.corda.core.crypto.internal.providerMap
 import net.corda.djvm.execution.DeterministicSandboxExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,7 +12,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
-import java.security.*
 import java.util.stream.Stream
 
 class CryptoTest : TestBase(KOTLIN) {
@@ -29,7 +27,7 @@ class CryptoTest : TestBase(KOTLIN) {
     @ParameterizedTest(name = "{index} => {0}")
     fun `test non-composite public keys`(signatureScheme: SignatureScheme) = sandbox {
         val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
-        val keyPair = signatureScheme.generateKeyPair()
+        val keyPair = Crypto.generateKeyPair(signatureScheme)
         val input = keyPair.public.encoded
         assertThat(executor.run<DecodePublicKey>(arrayOf(signatureScheme.schemeCodeName, input)).result)
             .isEqualTo(input)
@@ -37,9 +35,9 @@ class CryptoTest : TestBase(KOTLIN) {
 
     @Test
     fun `test composite public key`() = sandbox {
-        val key1 = Crypto.ECDSA_SECP256K1_SHA256.generateKeyPair().public
-        val key2 = Crypto.ECDSA_SECP256R1_SHA256.generateKeyPair().public
-        val key3 = Crypto.EDDSA_ED25519_SHA512.generateKeyPair().public
+        val key1 = Crypto.generateKeyPair(Crypto.ECDSA_SECP256K1_SHA256).public
+        val key2 = Crypto.generateKeyPair(Crypto.ECDSA_SECP256R1_SHA256).public
+        val key3 = Crypto.generateKeyPair(Crypto.EDDSA_ED25519_SHA512).public
 
         val compositeKey = CompositeKey.Builder()
             .addKey(key1, weight = 1)
@@ -51,16 +49,5 @@ class CryptoTest : TestBase(KOTLIN) {
         val input = compositeKey.encoded
         assertThat(executor.run<DecodePublicKey>(arrayOf(Crypto.COMPOSITE_KEY.schemeCodeName, input)).result)
             .isEqualTo(input)
-    }
-
-    private fun SignatureScheme.generateKeyPair(): KeyPair {
-        return KeyPairGenerator.getInstance(algorithmName, providerMap[providerName]).let {
-            if (algSpec != null) {
-                it.initialize(algSpec, SecureRandom())
-            } else {
-                it.initialize(keySize!!, SecureRandom())
-            }
-            it.generateKeyPair()
-        }
     }
 }

--- a/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
@@ -1,0 +1,66 @@
+package com.example.testing
+
+import com.example.testing.SandboxType.KOTLIN
+import net.corda.core.crypto.CompositeKey
+import net.corda.core.crypto.Crypto
+import net.corda.core.crypto.SignatureScheme
+import net.corda.core.crypto.internal.providerMap
+import net.corda.djvm.execution.DeterministicSandboxExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import java.security.*
+import java.util.stream.Stream
+
+class CryptoTest : TestBase(KOTLIN) {
+    class SignatureSchemeProvider : ArgumentsProvider {
+        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> {
+            return Crypto.supportedSignatureSchemes().stream()
+                .filter { it != Crypto.COMPOSITE_KEY }
+                .map { Arguments.of(it) }
+        }
+    }
+
+    @ArgumentsSource(SignatureSchemeProvider::class)
+    @ParameterizedTest(name = "{index} => {0}")
+    fun `test non-composite public keys`(signatureScheme: SignatureScheme) = sandbox {
+        val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
+        val keyPair = signatureScheme.generateKeyPair()
+        val input = keyPair.public.encoded
+        assertThat(executor.run<DecodePublicKey>(arrayOf(signatureScheme.schemeCodeName, input)).result)
+            .isEqualTo(input)
+    }
+
+    @Test
+    fun `test composite public key`() = sandbox {
+        val key1 = Crypto.ECDSA_SECP256K1_SHA256.generateKeyPair().public
+        val key2 = Crypto.ECDSA_SECP256R1_SHA256.generateKeyPair().public
+        val key3 = Crypto.EDDSA_ED25519_SHA512.generateKeyPair().public
+
+        val compositeKey = CompositeKey.Builder()
+            .addKey(key1, weight = 1)
+            .addKey(key2, weight = 1)
+            .addKey(key3, weight = 1)
+            .build(2)
+
+        val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
+        val input = compositeKey.encoded
+        assertThat(executor.run<DecodePublicKey>(arrayOf(Crypto.COMPOSITE_KEY.schemeCodeName, input)).result)
+            .isEqualTo(input)
+    }
+
+    private fun SignatureScheme.generateKeyPair(): KeyPair {
+        return KeyPairGenerator.getInstance(algorithmName, providerMap[providerName]).let {
+            if (algSpec != null) {
+                it.initialize(algSpec, SecureRandom())
+            } else {
+                it.initialize(keySize!!, SecureRandom())
+            }
+            it.generateKeyPair()
+        }
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseExactMath.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseExactMath.kt
@@ -54,5 +54,10 @@ object AlwaysUseExactMath : Emitter {
                     = className.startsWith("sun/security/") ||
                         className.startsWith("java/math/") ||
                         className.startsWith("java/util/regex/") ||
-                        className == "java/lang/Math"
+                        className == "java/lang/Math" ||
+                        /*
+                         * I REALLY didn't want to include non-JVM
+                         * packages here, but Corda NEEDS this!
+                         */
+                        className.startsWith("org/bouncycastle/math/")
 }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -295,9 +295,10 @@ fun toSandbox(className: kotlin.String): kotlin.String {
         return className
     }
 
-    val (actualName, sandboxName) = OBJECT_ARRAY.matchEntire(className)?.let {
+    val matchName = className.removePrefix(SANDBOX_PREFIX)
+    val (actualName, sandboxName) = OBJECT_ARRAY.matchEntire(matchName)?.let {
         Pair(it.groupValues[2], it.groupValues[1] + SANDBOX_PREFIX + it.groupValues[2] + ';')
-    } ?: Pair(className, SANDBOX_PREFIX + className)
+    } ?: Pair(matchName, SANDBOX_PREFIX + matchName)
 
     if (bannedClasses.any { it.matches(actualName) }) {
         throw ClassNotFoundException(className).sanitise(1)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -748,7 +748,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         override fun apply(input: String): Class<*> {
             val cl = object : ClassLoader() {
                 fun load(): Class<*> {
-                    return super.loadClass(input)
+                    return super.loadClass(input, true)
                 }
             }
             return cl.load()


### PR DESCRIPTION
We need to be able to decode Corda's `PublicKey` instances within the DJVM's sandbox. Validate this for all of Corda's signature schemes.