### PR TITLE
CORDA-2871: Add basic DatatypeFactory for hex-to-binary conversions.

### DIFF
--- a/djvm-example/src/main/kotlin/com/example/testing/PublicKeyDecoder.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/PublicKeyDecoder.kt
@@ -1,0 +1,11 @@
+package com.example.testing
+
+import net.corda.core.crypto.Crypto
+import java.security.PublicKey
+import java.util.function.Function
+
+class PublicKeyDecoder : Function<ByteArray, PublicKey> {
+    override fun apply(encoded: ByteArray): PublicKey {
+        return Crypto.decodePublicKey(encoded)
+    }
+}

--- a/djvm-example/src/main/kotlin/com/example/testing/PublicKeyFunction.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/PublicKeyFunction.kt
@@ -6,6 +6,6 @@ import java.util.function.Function
 
 class PublicKeyFunction : Function<PublicKey, String> {
     override fun apply(key: PublicKey): String {
-        return "PublicKey: Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'"
+        return "Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'"
     }
 }

--- a/djvm-example/src/main/kotlin/com/example/testing/PublicKeyFunction.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/PublicKeyFunction.kt
@@ -1,0 +1,11 @@
+package com.example.testing
+
+import net.corda.core.internal.hash
+import java.security.PublicKey
+import java.util.function.Function
+
+class PublicKeyFunction : Function<PublicKey, String> {
+    override fun apply(key: PublicKey): String {
+        return "PublicKey: Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'"
+    }
+}

--- a/djvm-example/src/main/kotlin/com/example/testing/TransformPublicKey.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/TransformPublicKey.kt
@@ -3,7 +3,7 @@ package com.example.testing
 import net.corda.core.crypto.Crypto
 import java.util.function.Function
 
-class DecodePublicKey : Function<Array<Any>, ByteArray> {
+class TransformPublicKey : Function<Array<Any>, ByteArray> {
     override fun apply(data: Array<Any>): ByteArray {
         val publicKey = Crypto.decodePublicKey(data[0] as String, data[1] as ByteArray)
         return publicKey.encoded

--- a/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
@@ -66,6 +66,6 @@ class CryptoTest : TestBase(KOTLIN) {
             task = executor.toSandboxClass(PublicKeyFunction::class.java).newInstance(),
             input = sandboxKey
         ).toString()
-        assertThat(result).isEqualTo("PublicKey: Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'")
+        assertThat(result).isEqualTo("Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'")
     }
 }

--- a/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/CryptoTest.kt
@@ -4,6 +4,7 @@ import com.example.testing.SandboxType.KOTLIN
 import net.corda.core.crypto.CompositeKey
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SignatureScheme
+import net.corda.core.internal.hash
 import net.corda.djvm.execution.DeterministicSandboxExecutor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -29,7 +30,7 @@ class CryptoTest : TestBase(KOTLIN) {
         val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
         val keyPair = Crypto.generateKeyPair(signatureScheme)
         val input = keyPair.public.encoded
-        assertThat(executor.run<DecodePublicKey>(arrayOf(signatureScheme.schemeCodeName, input)).result)
+        assertThat(executor.run<TransformPublicKey>(arrayOf(signatureScheme.schemeCodeName, input)).result)
             .isEqualTo(input)
     }
 
@@ -47,7 +48,24 @@ class CryptoTest : TestBase(KOTLIN) {
 
         val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
         val input = compositeKey.encoded
-        assertThat(executor.run<DecodePublicKey>(arrayOf(Crypto.COMPOSITE_KEY.schemeCodeName, input)).result)
+        assertThat(executor.run<TransformPublicKey>(arrayOf(Crypto.COMPOSITE_KEY.schemeCodeName, input)).result)
             .isEqualTo(input)
+    }
+
+    @Test
+    fun `test marshalling a public key`() = sandbox {
+        val executor = Executor(classLoader)
+
+        val key = Crypto.generateKeyPair(Crypto.ECDSA_SECP256K1_SHA256).public
+        val sandboxKey = executor.execute(
+            task = executor.toSandboxClass(PublicKeyDecoder::class.java).newInstance(),
+            input = key.encoded
+        )
+
+        val result = executor.execute(
+            task = executor.toSandboxClass(PublicKeyFunction::class.java).newInstance(),
+            input = sandboxKey
+        ).toString()
+        assertThat(result).isEqualTo("PublicKey: Format='${key.format}', Algorithm='${key.algorithm}', Hash='${key.hash}'")
     }
 }

--- a/djvm-example/src/test/kotlin/com/example/testing/Executor.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/Executor.kt
@@ -1,0 +1,30 @@
+package com.example.testing
+
+import net.corda.djvm.rewiring.SandboxClassLoader
+import net.corda.djvm.source.ClassSource
+import java.lang.reflect.Constructor
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+
+class Executor(private val classLoader: SandboxClassLoader) {
+    private val constructor: Constructor<out Any>
+    private val executeMethod: Method
+
+    init {
+        val taskClass = classLoader.loadClass("sandbox.RawTask")
+        constructor = taskClass.getDeclaredConstructor(classLoader.loadClass("sandbox.java.util.function.Function"))
+        executeMethod = taskClass.getMethod("apply", Any::class.java)
+    }
+
+    fun toSandboxClass(clazz: Class<*>): Class<*> {
+        return classLoader.loadClassForSandbox(ClassSource.fromClassName(clazz.name))
+    }
+
+    fun execute(task: Any, input: Any?): Any? {
+        return try {
+            executeMethod.invoke(constructor.newInstance(task), input)
+        } catch (ex: InvocationTargetException) {
+            throw ex.targetException
+        }
+    }
+}

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -21,8 +21,8 @@ public final class String extends Object implements Comparable<String>, CharSequ
         }
     }
 
-    private static final String TRUE = DJVM.intern("true");
-    private static final String FALSE = DJVM.intern("false");
+    private static final String TRUE = new String("true").intern();
+    private static final String FALSE = new String("false").intern();
 
     private static final Constructor SHARED;
 

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -41,7 +41,11 @@ public final class String extends Object implements Comparable<String>, CharSequ
         this.value = "";
     }
 
-    public String(java.lang.String value) {
+    public String(String str) {
+        this.value = str.value;
+    }
+
+    String(java.lang.String value) {
         this.value = value;
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -21,8 +21,8 @@ public final class String extends Object implements Comparable<String>, CharSequ
         }
     }
 
-    private static final String TRUE = new String("true");
-    private static final String FALSE = new String("false");
+    private static final String TRUE = DJVM.intern("true");
+    private static final String FALSE = DJVM.intern("false");
 
     private static final Constructor SHARED;
 
@@ -37,16 +37,16 @@ public final class String extends Object implements Comparable<String>, CharSequ
 
     private final java.lang.String value;
 
+    private String(java.lang.String value) {
+        this.value = value;
+    }
+
     public String() {
         this.value = "";
     }
 
     public String(String str) {
         this.value = str.value;
-    }
-
-    String(java.lang.String value) {
-        this.value = value;
     }
 
     public String(char[] value) {
@@ -62,13 +62,13 @@ public final class String extends Object implements Comparable<String>, CharSequ
     }
 
     @Deprecated
-    public String(byte[] ascii, int hibyte, int offset, int count) {
-        this.value = new java.lang.String(ascii, hibyte, offset, count);
+    public String(byte[] ascii, int hiByte, int offset, int count) {
+        this.value = new java.lang.String(ascii, hiByte, offset, count);
     }
 
     @Deprecated
-    public String(byte[] ascii, int hibyte) {
-        this.value = new java.lang.String(ascii, hibyte);
+    public String(byte[] ascii, int hiByte) {
+        this.value = new java.lang.String(ascii, hiByte);
     }
 
     public String(byte[] bytes, int offset, int length, String charsetName)

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -96,6 +96,7 @@ class SourceClassLoader(
         private val logger = loggerFor<SourceClassLoader>()
     }
 
+    @Throws(Exception::class)
     override fun close() {
         bootstrap.use {
            userSource.close()

--- a/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
@@ -49,7 +49,9 @@ class DatatypeConverterTest extends TestBase {
     public static class BytesToHex implements Function<byte[], String> {
         @Override
         public String apply(byte[] input) {
-            return DatatypeConverter.printHexBinary(input).toUpperCase();
+            // Corda apparently depends on this returning in
+            // uppercase in order not to break hash values.
+            return DatatypeConverter.printHexBinary(input);
         }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
@@ -1,0 +1,55 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DatatypeConverterTest extends TestBase {
+    private static final byte[] BINARY = new byte[]{ 0x1f, 0x2e, 0x3d, 0x4c, 0x5b, 0x6a, 0x70 };
+    private static final String TEXT = "1F2E3D4C5B6A70";
+
+    DatatypeConverterTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testHexToBinary() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<String, byte[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, HexToBytes.class, TEXT);
+            assertThat(success.getResult()).isEqualTo(BINARY);
+            return null;
+        });
+    }
+
+    public static class HexToBytes implements Function<String, byte[]> {
+        @Override
+        public byte[] apply(String input) {
+            return DatatypeConverter.parseHexBinary(input);
+        }
+    }
+
+    @Test
+    void testBinaryToHex() {
+        parentedSandbox(WARNING, true, ctx -> {
+            SandboxExecutor<byte[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, BytesToHex.class, BINARY);
+            assertThat(success.getResult()).isEqualTo(TEXT);
+            return null;
+        });
+    }
+
+    public static class BytesToHex implements Function<byte[], String> {
+        @Override
+        public String apply(byte[] input) {
+            return DatatypeConverter.printHexBinary(input).toUpperCase();
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -4,16 +4,18 @@ import net.corda.djvm.SandboxType.KOTLIN
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import sandbox.java.lang.sandbox
 import java.text.DecimalFormatSymbols
+import java.util.function.Function
 
 class DJVMTest : TestBase(KOTLIN) {
 
     @Test
-    fun testDJVMString() {
-        val djvmString = sandbox.java.lang.String.toDJVM("New Value")
-        assertNotEquals(djvmString, "New Value")
-        assertEquals(djvmString, "New Value".sandbox())
+    fun testDJVMString() = parentedSandbox {
+        with(DJVM(classLoader)) {
+            val djvmString = stringOf("New Value")
+            assertNotEquals(djvmString, "New Value")
+            assertEquals(djvmString, sandbox("New Value"))
+        }
     }
 
     @Test
@@ -68,17 +70,25 @@ class DJVMTest : TestBase(KOTLIN) {
 
     @Test
     fun testObjectFormat() = parentedSandbox {
-        val result = with(DJVM(classLoader)) {
-            stringClass.getMethod("format", stringClass, Array<Any>::class.java)
-                .invoke(null, stringOf("%s"), arrayOf(object : sandbox.java.lang.Object() {})).toString()
-        }
+        val executor = TaskExecutor(classLoader)
+        val task = executor.toSandboxClass(NewObject::class.java).newInstance()
+        val result = executor.execute(task, null) as String
         assertThat(result).startsWith("sandbox.java.lang.Object@")
     }
 
+    class NewObject : Function<Any?, String> {
+        override fun apply(input: Any?): String {
+            return String.format("%s", object : Any() {})
+        }
+    }
+
     @Test
-    fun testStringEquality() {
-        val number = sandbox.java.lang.String.valueOf((Double.MIN_VALUE / 2.0) * 2.0)
-        require(number == "0.0".sandbox())
+    fun testStringEquality() = parentedSandbox {
+        with (DJVM(classLoader)) {
+            val number = stringClass.getMethod("valueOf", Double::class.javaPrimitiveType)
+                .invoke(null, (Double.MIN_VALUE / 2.0) * 2.0)
+            require(number == sandbox("0.0"))
+        }
     }
 
     @Test

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -11,7 +11,7 @@ class DJVMTest : TestBase(KOTLIN) {
 
     @Test
     fun testDJVMString() {
-        val djvmString = sandbox.java.lang.String("New Value")
+        val djvmString = sandbox.java.lang.String.toDJVM("New Value")
         assertNotEquals(djvmString, "New Value")
         assertEquals(djvmString, "New Value".sandbox())
     }

--- a/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
@@ -1,0 +1,30 @@
+package net.corda.djvm
+
+import net.corda.djvm.rewiring.SandboxClassLoader
+import net.corda.djvm.source.ClassSource
+import java.lang.reflect.Constructor
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+
+class TaskExecutor(private val classLoader: SandboxClassLoader) {
+    private val constructor: Constructor<out Any>
+    private val executeMethod: Method
+
+    init {
+        val taskClass = classLoader.loadClass("sandbox.Task")
+        constructor = taskClass.getDeclaredConstructor(classLoader.loadClass("sandbox.java.util.function.Function"))
+        executeMethod = taskClass.getMethod("apply", Any::class.java)
+    }
+
+    fun toSandboxClass(clazz: Class<*>): Class<*> {
+        return classLoader.loadClassForSandbox(ClassSource.fromClassName(clazz.name))
+    }
+
+    fun execute(task: Any, input: Any?): Any? {
+        return try {
+            executeMethod.invoke(constructor.newInstance(task), input)
+        } catch (ex: InvocationTargetException) {
+            throw ex.targetException
+        }
+    }
+}


### PR DESCRIPTION
Java 8 code typically uses the `printHexBinary` and `parseHexBinary` methods of `DatatypeConverter` to convert between `byte[]` and hexadecimal strings, c.f. Corda's `ByteArray.toHexString()` and `String.parseAsHex()` methods.

Support `DatatypeConverter` inside the sandbox by initialising it with a default `DatatypeFactory` instance.