### PR TITLE
CORDA-2871: Add java.time.* types to those which can be marshalled into and out of sandbox.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -37,6 +37,7 @@ configurations {
 
             dependencySubstitution {
                 substitute module("net.corda:corda-core:$corda_version") with module("net.corda:corda-core-deterministic:$corda_version")
+                substitute module("net.corda:corda-serialization:$corda_version") with module("net.corda:corda-serialization-deterministic:$corda_version")
             }
         }
     }
@@ -48,6 +49,7 @@ dependencies {
     implementation "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_version"
     implementation "com.r3.corda.lib.tokens:tokens-money:$corda_tokens_version"
     implementation "net.corda:corda-core:$corda_version"
+    implementation "net.corda:corda-serialization:$corda_version"
 
     testImplementation "net.corda:corda-djvm:$djvm_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"

--- a/djvm-example/src/test/kotlin/com/example/testing/LocalSerialization.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/LocalSerialization.kt
@@ -1,0 +1,60 @@
+package com.example.testing
+
+import net.corda.core.serialization.SerializationContext
+import net.corda.core.serialization.SerializationContext.UseCase.*
+import net.corda.core.serialization.SerializationCustomSerializer
+import net.corda.core.serialization.SerializationWhitelist
+import net.corda.core.serialization.internal.SerializationEnvironment
+import net.corda.core.serialization.internal._contextSerializationEnv
+import net.corda.serialization.internal.*
+import net.corda.serialization.internal.amqp.*
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class LocalSerialization : BeforeEachCallback, AfterEachCallback {
+    private companion object {
+        private val AMQP_P2P_CONTEXT = SerializationContextImpl(
+            amqpMagic,
+            LocalSerialization::class.java.classLoader,
+            GlobalTransientClassWhiteList(BuiltInExceptionsWhitelist()),
+            emptyMap(),
+            true,
+            P2P,
+            null
+        )
+    }
+
+    override fun beforeEach(context: ExtensionContext) {
+        _contextSerializationEnv.set(createTestSerializationEnv())
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        _contextSerializationEnv.set(null)
+    }
+
+    private fun createTestSerializationEnv(): SerializationEnvironment {
+        val factory = SerializationFactoryImpl(mutableMapOf()).apply {
+            registerScheme(AMQPSerializationScheme(emptySet(), emptySet(), AccessOrderLinkedHashMap(128)))
+        }
+        return SerializationEnvironment.with(factory, AMQP_P2P_CONTEXT)
+    }
+
+    private class AMQPSerializationScheme(
+        cordappCustomSerializers: Set<SerializationCustomSerializer<*, *>>,
+        cordappSerializationWhitelists: Set<SerializationWhitelist>,
+        serializerFactoriesForContexts: AccessOrderLinkedHashMap<SerializationFactoryCacheKey, SerializerFactory>
+    ) : AbstractAMQPSerializationScheme(cordappCustomSerializers, cordappSerializationWhitelists, serializerFactoriesForContexts) {
+        override fun rpcServerSerializerFactory(context: SerializationContext): SerializerFactory {
+            throw UnsupportedOperationException()
+        }
+
+        override fun rpcClientSerializerFactory(context: SerializationContext): SerializerFactory {
+            throw UnsupportedOperationException()
+        }
+
+        override fun canDeserializeVersion(magic: CordaSerializationMagic, target: SerializationContext.UseCase): Boolean {
+            return canDeserializeVersion(magic) && target == P2P
+        }
+    }
+}

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -88,6 +88,16 @@ shadowJar {
     exclude 'sandbox/java/security/AccessControlException.class'
     exclude 'sandbox/java/security/PrivilegedAction.class'
     exclude 'sandbox/java/security/PrivilegedExceptionAction.class'
+    exclude 'sandbox/java/time/Duration.class'
+    exclude 'sandbox/java/time/Instant.class'
+    exclude 'sandbox/java/time/Local*.class'
+    exclude 'sandbox/java/time/Month*.class'
+    exclude 'sandbox/java/time/Offset*.class'
+    exclude 'sandbox/java/time/Period.class'
+    exclude 'sandbox/java/time/Year*.class'
+    exclude 'sandbox/java/time/Zone*.class'
+    exclude "sandbox/java/time/zone/ZoneRulesException.class"
+    exclude "sandbox/java/time/zone/*ZoneRulesProvider.class"
     exclude 'sandbox/java/util/concurrent/ConcurrentMap.class'
     exclude 'sandbox/java/util/concurrent/ConcurrentHashMap\$CollectionView.class'
     exclude 'sandbox/java/util/concurrent/TimeUnit.class'

--- a/djvm/src/main/java/sandbox/java/time/DJVM.java
+++ b/djvm/src/main/java/sandbox/java/time/DJVM.java
@@ -1,0 +1,32 @@
+package sandbox.java.time;
+
+import java.lang.reflect.Method;
+
+public final class DJVM {
+    private static final Method createZonedDateTime;
+
+    static {
+        try {
+            createZonedDateTime = java.time.ZonedDateTime.class.getDeclaredMethod(
+                "ofLenient",
+                java.time.LocalDateTime.class,
+                java.time.ZoneOffset.class,
+                java.time.ZoneId.class
+            );
+            createZonedDateTime.setAccessible(true);
+        } catch (Exception e) {
+            throw new InternalError(e.getMessage(), e);
+        }
+    }
+
+    private DJVM() {}
+
+    static java.time.ZonedDateTime zonedDateTime(LocalDateTime localDateTime, ZoneOffset offset, ZoneId zone) {
+        try {
+            //noinspection JavaReflectionInvocation
+            return (java.time.ZonedDateTime) createZonedDateTime.invoke(null, localDateTime.fromDJVM(), offset.fromDJVM(), zone.fromDJVM());
+        } catch (Exception e) {
+            throw new InternalError(e.getMessage(), e);
+        }
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/Duration.java
+++ b/djvm/src/main/java/sandbox/java/time/Duration.java
@@ -1,0 +1,41 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+import static sandbox.java.time.LocalTime.NANOS_PER_SECOND;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.Duration}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class Duration extends sandbox.java.lang.Object implements Serializable {
+    private final long seconds;
+    private final int nanos;
+
+    private Duration(long seconds, int nanos) {
+        this.seconds = seconds;
+        this.nanos = nanos;
+    }
+
+    public long getSeconds() {
+        return seconds;
+    }
+
+    public int getNano() {
+        return nanos;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.Duration fromDJVM() {
+        return java.time.Duration.ofSeconds(seconds, nanos);
+    }
+
+    public static Duration ofSeconds(long seconds, long nanoAdjustment) {
+        int nanos = (int)Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
+        return new Duration(seconds, nanos);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/Instant.java
+++ b/djvm/src/main/java/sandbox/java/time/Instant.java
@@ -1,0 +1,41 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+import static sandbox.java.time.LocalTime.NANOS_PER_SECOND;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.Instant}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class Instant extends sandbox.java.lang.Object implements Serializable {
+    private final long seconds;
+    private final int nanos;
+
+    private Instant(long epochSecond, int nano) {
+        this.seconds = epochSecond;
+        this.nanos = nano;
+    }
+
+    public long getEpochSecond() {
+        return seconds;
+    }
+
+    public int getNano() {
+        return nanos;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.Instant fromDJVM() {
+        return java.time.Instant.ofEpochSecond(seconds, nanos);
+    }
+
+    public static Instant ofEpochSecond(long epochSecond, long nanoAdjustment) {
+        int nanos = (int)Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
+        return new Instant(epochSecond, nanos);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/LocalDate.java
+++ b/djvm/src/main/java/sandbox/java/time/LocalDate.java
@@ -1,0 +1,44 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.LocalDate}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class LocalDate extends sandbox.java.lang.Object implements Serializable {
+    private final int year;
+    private final short month;
+    private final short day;
+
+    private LocalDate(int year, int month, int dayOfMonth) {
+        this.year = year;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonthValue() {
+        return month;
+    }
+
+    public int getDayOfMonth() {
+        return day;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.LocalDate fromDJVM() {
+        return java.time.LocalDate.of(year, month, day);
+    }
+
+    public static LocalDate of(int year, int month, int dayOfMonth) {
+        return new LocalDate(year, month, dayOfMonth);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/LocalDateTime.java
+++ b/djvm/src/main/java/sandbox/java/time/LocalDateTime.java
@@ -1,0 +1,38 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.LocalDateTime}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public class LocalDateTime extends sandbox.java.lang.Object implements Serializable {
+    private final LocalDate date;
+    private final LocalTime time;
+
+    private LocalDateTime(LocalDate date, LocalTime time) {
+        this.date = date;
+        this.time = time;
+    }
+
+    public LocalDate toLocalDate() {
+        return date;
+    }
+
+    public LocalTime toLocalTime() {
+        return time;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.LocalDateTime fromDJVM() {
+        return java.time.LocalDateTime.of(date.fromDJVM(), time.fromDJVM());
+    }
+
+    public static LocalDateTime of(LocalDate date, LocalTime time) {
+        return new LocalDateTime(date, time);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/LocalTime.java
+++ b/djvm/src/main/java/sandbox/java/time/LocalTime.java
@@ -1,0 +1,52 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.LocalTime}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class LocalTime extends sandbox.java.lang.Object implements Serializable {
+    static final long NANOS_PER_SECOND = 1000_000_000L;
+
+    private final byte hour;
+    private final byte minute;
+    private final byte second;
+    private final int nano;
+
+    private LocalTime(int hour, int minute, int second, int nanoOfSecond) {
+        this.hour = (byte) hour;
+        this.minute = (byte) minute;
+        this.second = (byte) second;
+        this.nano = nanoOfSecond;
+    }
+
+    public int getHour() {
+        return hour;
+    }
+
+    public int getMinute() {
+        return minute;
+    }
+
+    public int getSecond() {
+        return second;
+    }
+
+    public int getNano() {
+        return nano;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.LocalTime fromDJVM() {
+        return java.time.LocalTime.of(hour, minute, second, nano);
+    }
+
+    public static LocalTime of(int hour, int minute, int second, int nanoOfSecond) {
+        return new LocalTime(hour, minute, second, nanoOfSecond);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/MonthDay.java
+++ b/djvm/src/main/java/sandbox/java/time/MonthDay.java
@@ -1,0 +1,38 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.MonthDay}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class MonthDay extends sandbox.java.lang.Object implements Serializable {
+    private final int month;
+    private final int day;
+
+    private MonthDay(int month, int day) {
+        this.month = month;
+        this.day = day;
+    }
+
+    public int getMonthValue() {
+        return month;
+    }
+
+    public int getDayOfMonth() {
+        return day;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.MonthDay fromDJVM() {
+        return java.time.MonthDay.of(month, day);
+    }
+
+    public static MonthDay of(int month, int dayOfMonth) {
+        return new MonthDay(month, dayOfMonth);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/OffsetDateTime.java
+++ b/djvm/src/main/java/sandbox/java/time/OffsetDateTime.java
@@ -1,0 +1,38 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.OffsetDateTime}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public class OffsetDateTime extends sandbox.java.lang.Object implements Serializable {
+    private final LocalDateTime dateTime;
+    private final ZoneOffset offset;
+
+    private OffsetDateTime(LocalDateTime dateTime, ZoneOffset offset) {
+        this.dateTime = dateTime;
+        this.offset = offset;
+    }
+
+    public ZoneOffset getOffset() {
+        return offset;
+    }
+
+    public LocalDateTime toLocalDateTime() {
+        return dateTime;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.OffsetDateTime fromDJVM() {
+        return java.time.OffsetDateTime.of(dateTime.fromDJVM(), (java.time.ZoneOffset) offset.fromDJVM());
+    }
+
+    public static OffsetDateTime of(LocalDateTime dateTime, ZoneOffset offset) {
+        return new OffsetDateTime(dateTime, offset);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/OffsetTime.java
+++ b/djvm/src/main/java/sandbox/java/time/OffsetTime.java
@@ -1,0 +1,38 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.OffsetTime}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class OffsetTime extends sandbox.java.lang.Object implements Serializable {
+    private final LocalTime time;
+    private final ZoneOffset offset;
+
+    private OffsetTime(LocalTime time, ZoneOffset offset) {
+        this.time = time;
+        this.offset = offset;
+    }
+
+    public ZoneOffset getOffset() {
+        return offset;
+    }
+
+    public LocalTime toLocalTime() {
+        return time;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.OffsetTime fromDJVM() {
+        return java.time.OffsetTime.of(time.fromDJVM(), (java.time.ZoneOffset) offset.fromDJVM());
+    }
+
+    public static OffsetTime of(LocalTime time, ZoneOffset offset) {
+        return new OffsetTime(time, offset);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/Period.java
+++ b/djvm/src/main/java/sandbox/java/time/Period.java
@@ -1,0 +1,44 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.Period}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class Period extends sandbox.java.lang.Object implements Serializable {
+    private final int years;
+    private final int months;
+    private final int days;
+
+    private Period(int years, int months, int days) {
+        this.years = years;
+        this.months = months;
+        this.days = days;
+    }
+
+    public int getYears() {
+        return years;
+    }
+
+    public int getMonths() {
+        return months;
+    }
+
+    public int getDays() {
+        return days;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.Period fromDJVM() {
+        return java.time.Period.of(years, months, days);
+    }
+
+    public static Period of(int years, int months, int days) {
+        return new Period(years, months, days);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/Year.java
+++ b/djvm/src/main/java/sandbox/java/time/Year.java
@@ -1,0 +1,32 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.Year}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class Year extends sandbox.java.lang.Object implements Serializable {
+    private final int year;
+
+    private Year(int year) {
+        this.year = year;
+    }
+
+    public int getValue() {
+        return year;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.Year fromDJVM() {
+        return java.time.Year.of(year);
+    }
+
+    public static Year of(int year) {
+        return new Year(year);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/YearMonth.java
+++ b/djvm/src/main/java/sandbox/java/time/YearMonth.java
@@ -1,0 +1,38 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.YearMonth}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class YearMonth extends sandbox.java.lang.Object implements Serializable {
+    private final int year;
+    private final int month;
+
+    private YearMonth(int year, int month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonthValue() {
+        return month;
+    }
+
+    @Override
+    @NotNull
+    protected java.time.YearMonth fromDJVM() {
+        return java.time.YearMonth.of(year, month);
+    }
+
+    public static YearMonth of(int year, int month) {
+        return new YearMonth(year, month);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/ZoneId.java
+++ b/djvm/src/main/java/sandbox/java/time/ZoneId.java
@@ -1,0 +1,25 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.String;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.ZoneId}
+ * to allow us to compile {@link sandbox.java.time.ZoneOffset}.
+ */
+@SuppressWarnings("unused")
+public abstract class ZoneId extends sandbox.java.lang.Object implements Serializable {
+    public abstract String getId();
+
+    @Override
+    @NotNull
+    protected final java.time.ZoneId fromDJVM() {
+        return java.time.ZoneId.of(String.fromDJVM(getId()));
+    }
+
+    public static ZoneId of(String zoneId) {
+        throw new UnsupportedOperationException("Dummy class - not implemented");
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/ZoneOffset.java
+++ b/djvm/src/main/java/sandbox/java/time/ZoneOffset.java
@@ -1,0 +1,15 @@
+package sandbox.java.time;
+
+import sandbox.java.lang.String;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.ZoneOffset}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class ZoneOffset extends ZoneId {
+    @Override
+    public String getId() {
+        throw new UnsupportedOperationException("Dummy class - not implemented");
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/ZonedDateTime.java
+++ b/djvm/src/main/java/sandbox/java/time/ZonedDateTime.java
@@ -1,0 +1,49 @@
+package sandbox.java.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.ZonedDateTime}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings("unused")
+public final class ZonedDateTime extends sandbox.java.lang.Object implements Serializable {
+    private final LocalDateTime dateTime;
+    private final ZoneOffset offset;
+    private final ZoneId zone;
+
+    private ZonedDateTime(LocalDateTime dateTime, ZoneOffset offset, ZoneId zone) {
+        this.dateTime = dateTime;
+        this.offset = offset;
+        this.zone = zone;
+    }
+
+    public ZoneOffset getOffset() {
+        return offset;
+    }
+
+    public ZoneId getZone() {
+        return zone;
+    }
+
+    public LocalDateTime toLocalDateTime() {
+        return dateTime;
+    }
+
+    private static ZonedDateTime ofLenient(LocalDateTime localDateTime, ZoneOffset offset, ZoneId zone) {
+        return new ZonedDateTime(localDateTime, offset, zone);
+    }
+
+    @Override
+    @NotNull
+    protected java.time.ZonedDateTime fromDJVM() {
+        return DJVM.zonedDateTime(dateTime, offset, zone);
+    }
+
+    @NotNull
+    public static ZonedDateTime createDJVM(LocalDateTime localDateTime, ZoneOffset offset, ZoneId zone) {
+        return ofLenient(localDateTime, offset, zone);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/zone/TzdbZoneRulesProvider.java
+++ b/djvm/src/main/java/sandbox/java/time/zone/TzdbZoneRulesProvider.java
@@ -1,0 +1,23 @@
+package sandbox.java.time.zone;
+
+import sandbox.java.io.DataInputStream;
+import sandbox.java.util.Map;
+import sandbox.java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This is a dummy class that implements just enough of {@link TzdbZoneRulesProvider}
+ * to allow us to compile {@link sandbox.java.time.zone.ZoneRulesProvider}.
+ */
+@SuppressWarnings({"unused", "RedundantThrows"})
+final class TzdbZoneRulesProvider extends ZoneRulesProvider {
+
+    private final Map<String, Object> regionToRules = new ConcurrentHashMap<>();
+
+    TzdbZoneRulesProvider(DataInputStream dis) throws Exception {
+        load(dis);
+    }
+
+    private void load(DataInputStream dis) throws Exception {
+        throw new UnsupportedOperationException("Dummy class - not implemented");
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesException.java
+++ b/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesException.java
@@ -1,0 +1,10 @@
+package sandbox.java.time.zone;
+
+import sandbox.java.lang.String;
+import sandbox.java.lang.Throwable;
+
+public class ZoneRulesException extends Throwable {
+    ZoneRulesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesProvider.java
+++ b/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesProvider.java
@@ -1,0 +1,41 @@
+package sandbox.java.time.zone;
+
+import sandbox.java.io.DataInputStream;
+import sandbox.java.lang.DJVM;
+import sandbox.java.lang.String;
+import sandbox.java.lang.Throwable;
+import sandbox.java.security.AccessController;
+import sandbox.java.security.PrivilegedAction;
+import sandbox.java.util.ArrayList;
+import sandbox.java.util.List;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.time.zone.ZoneRulesProvider}
+ * to allow us to compile its anonymous inner class.
+ */
+@SuppressWarnings({"unused", "WeakerAccess", "Convert2Lambda"})
+public abstract class ZoneRulesProvider extends sandbox.java.lang.Object {
+    static {
+        final List<ZoneRulesProvider> loaded = new ArrayList<>();
+
+        /*
+         * This anonymous inner class is a NON-dummy class called ZoneRulesProvider$1.
+         */
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            public Object run() {
+                try (DataInputStream input = DJVM.loadSystemResource("tzdb.dat")) {
+                    registerProvider(new TzdbZoneRulesProvider(input));
+                    loaded.clear();
+                } catch (Exception ex) {
+                    Throwable t = DJVM.doCatch(ex);
+                    throw (RuntimeException) DJVM.fromDJVM(new ZoneRulesException(String.toDJVM("Unable to load TZDB time-zone rules"), t));
+                }
+                return null;
+            }
+        });
+    }
+
+    public static void registerProvider(ZoneRulesProvider provider) {
+        throw new UnsupportedOperationException("Dummy class - not implemented");
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/Currency.java
+++ b/djvm/src/main/java/sandbox/java/util/Currency.java
@@ -1,8 +1,6 @@
 package sandbox.java.util;
 
-import sandbox.java.io.BufferedInputStream;
 import sandbox.java.io.DataInputStream;
-import sandbox.java.io.InputStream;
 import sandbox.java.lang.DJVM;
 import sandbox.java.lang.String;
 import sandbox.java.security.AccessController;
@@ -44,11 +42,7 @@ public final class Currency extends sandbox.java.lang.Object implements Serializ
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
             public Void run() {
-                InputStream currencies = DJVM.getSystemResourceAsStream("currency.data");
-                if (currencies == null) {
-                    throw new InternalError("Missing currency.data");
-                }
-                try (DataInputStream dis = new DataInputStream(new BufferedInputStream(currencies))) {
+                try (DataInputStream dis = DJVM.loadSystemResource("currency.data")) {
                     if (dis.readInt() != MAGIC_NUMBER) {
                         throw new InternalError("Currency data is possibly corrupted");
                     }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaTimeConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaTimeConfiguration.kt
@@ -1,0 +1,300 @@
+@file:JvmName("JavaTimeConfiguration")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.sandboxed
+import net.corda.djvm.code.CONSTRUCTOR_NAME
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.references.Member
+import org.objectweb.asm.Opcodes.*
+
+private const val OF = "of"
+
+/**
+ * Generate [Member] objects for the [sandbox.java.lang.Object.fromDJVM]
+ * methods that will be stitched into the [sandbox.java.time] classes.
+ */
+fun generateJavaTimeMethods(): List<Member> = object : FromDJVMBuilder(
+        className = sandboxed(java.time.Duration::class.java),
+        bridgeDescriptor = "()Ljava/time/Duration;"
+) {
+    /**
+     * Implements Duration.fromDJVM():
+     *     return java.time.Duration.ofSeconds(seconds, nanos)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "seconds", "J")
+        pushObject(0)
+        pushField(className, "nanos", "I")
+        instruction(I2L)
+        invokeStatic("java/time/Duration", "ofSeconds", "(JJ)Ljava/time/Duration;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.Instant::class.java),
+        bridgeDescriptor = "()Ljava/time/Instant;"
+) {
+    /**
+     * Implements Instant.fromDJVM():
+     *     return java.time.Instant.ofEpochSecond(seconds, nanos)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "seconds", "J")
+        pushObject(0)
+        pushField(className, "nanos", "I")
+        instruction(I2L)
+        invokeStatic("java/time/Instant", "ofEpochSecond", "(JJ)Ljava/time/Instant;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.LocalDate::class.java),
+        bridgeDescriptor = "()Ljava/time/LocalDate;"
+) {
+    /**
+     * Implements LocalDate.fromDJVM():
+     *     return java.time.LocalDate.of(year, month, day)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "year", "I")
+        pushObject(0)
+        pushField(className, "month", "S")
+        pushObject(0)
+        pushField(className, "day", "S")
+        invokeStatic("java/time/LocalDate", OF, "(III)Ljava/time/LocalDate;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.LocalDateTime::class.java),
+        bridgeDescriptor = "()Ljava/time/LocalDateTime;"
+) {
+    /**
+     * Implements LocalDateTime.fromDJVM():
+     *     return java.time.LocalDateTime.of(date.fromDJVM(), time.fromDJVM())
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "date", "Lsandbox/java/time/LocalDate;")
+        invokeVirtual("sandbox/java/time/LocalDate", FROM_DJVM, "()Ljava/time/LocalDate;")
+        pushObject(0)
+        pushField(className, "time", "Lsandbox/java/time/LocalTime;")
+        invokeVirtual("sandbox/java/time/LocalTime", FROM_DJVM, "()Ljava/time/LocalTime;")
+        invokeStatic("java/time/LocalDateTime", OF, "(Ljava/time/LocalDate;Ljava/time/LocalTime;)Ljava/time/LocalDateTime;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.LocalTime::class.java),
+        bridgeDescriptor = "()Ljava/time/LocalTime;"
+) {
+    /**
+     * Implements LocalTime.fromDJVM():
+     *     return java.time.LocalTime.of(hour, minute, second, nano)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "hour", "B")
+        pushObject(0)
+        pushField(className, "minute", "B")
+        pushObject(0)
+        pushField(className, "second", "B")
+        pushObject(0)
+        pushField(className, "nano", "I")
+        invokeStatic("java/time/LocalTime", OF, "(IIII)Ljava/time/LocalTime;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.MonthDay::class.java),
+        bridgeDescriptor = "()Ljava/time/MonthDay;"
+) {
+    /**
+     * Implements MonthDay.fromDJVM():
+     *     return java.time.MonthDay.of(month, day)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "month", "I")
+        pushObject(0)
+        pushField(className, "day", "I")
+        invokeStatic("java/time/MonthDay", OF, "(II)Ljava/time/MonthDay;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.OffsetDateTime::class.java),
+        bridgeDescriptor = "()Ljava/time/OffsetDateTime;"
+) {
+    /**
+     * Implements OffsetDateTime.fromDJVM():
+     *     return java.time.OffsetDateTime.of(dateTime, offset)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "dateTime", "Lsandbox/java/time/LocalDateTime;")
+        invokeVirtual("sandbox/java/time/LocalDateTime", FROM_DJVM, "()Ljava/time/LocalDateTime;")
+        pushObject(0)
+        pushField(className, "offset", "Lsandbox/java/time/ZoneOffset;")
+        invokeVirtual("sandbox/java/time/ZoneOffset", FROM_DJVM, "()Ljava/time/ZoneId;")
+        castObjectTo("java/time/ZoneOffset")
+        invokeStatic("java/time/OffsetDateTime", OF, "(Ljava/time/LocalDateTime;Ljava/time/ZoneOffset;)Ljava/time/OffsetDateTime;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.OffsetTime::class.java),
+        bridgeDescriptor = "()Ljava/time/OffsetTime;"
+) {
+    /**
+     * Implements OffsetTime.fromDJVM():
+     *     return java.time.OffsetTime.of(time, offset)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "time", "Lsandbox/java/time/LocalTime;")
+        invokeVirtual("sandbox/java/time/LocalTime", FROM_DJVM, "()Ljava/time/LocalTime;")
+        pushObject(0)
+        pushField(className, "offset", "Lsandbox/java/time/ZoneOffset;")
+        invokeVirtual("sandbox/java/time/ZoneOffset", FROM_DJVM, "()Ljava/time/ZoneId;")
+        castObjectTo("java/time/ZoneOffset")
+        invokeStatic("java/time/OffsetTime", OF, "(Ljava/time/LocalTime;Ljava/time/ZoneOffset;)Ljava/time/OffsetTime;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.Period::class.java),
+        bridgeDescriptor = "()Ljava/time/Period;"
+) {
+    /**
+     * Implements Period.fromDJVM():
+     *     return java.time.Period.of(years, months, days)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "years", "I")
+        pushObject(0)
+        pushField(className, "months", "I")
+        pushObject(0)
+        pushField(className, "days", "I")
+        invokeStatic("java/time/Period", OF, "(III)Ljava/time/Period;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.Year::class.java),
+        bridgeDescriptor = "()Ljava/time/Year;"
+) {
+    /**
+     * Implements Year.fromDJVM():
+     *     return java.time.Year.of(year)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "year", "I")
+        invokeStatic("java/time/Year", OF, "(I)Ljava/time/Year;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.YearMonth::class.java),
+        bridgeDescriptor = "()Ljava/time/YearMonth;"
+) {
+    /**
+     * Implements YearMonth.fromDJVM():
+     *     return java.time.YearMonth.of(year, month)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "year", "I")
+        pushObject(0)
+        pushField(className, "month", "I")
+        invokeStatic("java/time/YearMonth", OF, "(II)Ljava/time/YearMonth;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.ZonedDateTime::class.java),
+        bridgeDescriptor = "()Ljava/time/ZonedDateTime;"
+) {
+    /**
+     * Implements ZonedDateTime.fromDJVM():
+     *     return sandbox.java.time.DJVM.zonedDateTime(dateTime, offset, zone)
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        pushField(className, "dateTime", "Lsandbox/java/time/LocalDateTime;")
+        pushObject(0)
+        pushField(className, "offset", "Lsandbox/java/time/ZoneOffset;")
+        pushObject(0)
+        pushField(className, "zone", "Lsandbox/java/time/ZoneId;")
+        invokeStatic("sandbox/java/time/DJVM", "zonedDateTime", "(Lsandbox/java/time/LocalDateTime;Lsandbox/java/time/ZoneOffset;Lsandbox/java/time/ZoneId;)Ljava/time/ZonedDateTime;")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+        className = sandboxed(java.time.ZoneId::class.java),
+        bridgeDescriptor = "()Ljava/time/ZoneId;"
+) {
+    /**
+     * Implements ZoneId.fromDJVM():
+     *     return java.time.ZoneId.of(sandbox.java.lang.String.fromDJVM(getId()))
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        pushObject(0)
+        invokeVirtual(className, "getId", "()Lsandbox/java/lang/String;")
+        invokeStatic("sandbox/java/lang/String", FROM_DJVM, "(Lsandbox/java/lang/String;)Ljava/lang/String;")
+        invokeStatic("java/time/ZoneId", OF, "(Ljava/lang/String;)Ljava/time/ZoneId;")
+        returnObject()
+    }
+}.build() + listOf(
+    /**
+     * Create an accessor for [sandbox.java.time.ZonedDateTime.ofLenient]:
+     *     return ofLenient(localDateTime, offset, zone)
+     */
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(java.time.ZonedDateTime::class.java),
+        memberName = "createDJVM",
+        descriptor = "(Lsandbox/java/time/LocalDateTime;Lsandbox/java/time/ZoneOffset;Lsandbox/java/time/ZoneId;)Lsandbox/java/time/ZonedDateTime;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            pushObject(2)
+            invokeStatic(className, "ofLenient", descriptor)
+            returnObject()
+        }
+    }.withBody()
+      .build(),
+    /**
+     * Replace [java.time.zone.TzdbZoneRulesProvider] constructor with one that
+     * accepts a [sandbox.java.io.DataInputStream] that will be managed elsewhere.
+     */
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STRICT,
+        className = "sandbox/java/time/zone/TzdbZoneRulesProvider",
+        memberName = CONSTRUCTOR_NAME,
+        descriptor = "(Lsandbox/java/io/DataInputStream;)V",
+        exceptions = setOf("java/lang/Exception")
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            invokeSpecial("sandbox/java/time/zone/ZoneRulesProvider", CONSTRUCTOR_NAME, "()V")
+
+            // Initialise the regionToRules map field.
+            pushObject(0)
+            new("sandbox/java/util/concurrent/ConcurrentHashMap")
+            duplicate()
+            invokeSpecial("sandbox/java/util/concurrent/ConcurrentHashMap", CONSTRUCTOR_NAME, "()V")
+            popField(className, "regionToRules", "Lsandbox/java/util/Map;")
+
+            // Read the time-zone data from the input stream.
+            pushObject(0)
+            pushObject(1)
+            invokeSpecial(className, "load", descriptor)
+            returnVoid()
+        }
+    }.withBody()
+     .build(),
+    /**
+     * Delete the original no-argument constructor.
+     */
+    MethodBuilder(
+        access = ACC_PUBLIC,
+        className = "sandbox/java/time/zone/TzdbZoneRulesProvider",
+        memberName = CONSTRUCTOR_NAME,
+        descriptor = "()V"
+    ).build()
+)

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
@@ -1,0 +1,72 @@
+@file:JvmName("SewingKit")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.references.Member
+import net.corda.djvm.references.MethodBody
+import org.objectweb.asm.Opcodes.*
+
+const val FROM_DJVM = "fromDJVM"
+
+open class MethodBuilder(
+    protected val access: Int,
+    protected val className: String,
+    protected val memberName: String,
+    protected val descriptor: String,
+    protected val signature: String = "",
+    protected val exceptions: Set<String> = emptySet()
+) {
+    private val bodies = mutableListOf<MethodBody>()
+
+    protected open fun writeBody(emitter: EmitterModule) {}
+
+    fun withBody(body: MethodBody): MethodBuilder {
+        bodies.add(body)
+        return this
+    }
+
+    fun withBody() = withBody(::writeBody)
+
+    fun build() = Member(
+        access = access,
+        className = className,
+        memberName = memberName,
+        descriptor = descriptor,
+        genericsDetails = signature,
+        exceptions = exceptions.toMutableSet(),
+        body = bodies
+    )
+}
+
+abstract class FromDJVMBuilder(
+    protected val className: String,
+    private val bridgeDescriptor: String,
+    signature: String = ""
+) {
+    private val builder = MethodBuilder(
+        access = ACC_FINAL or ACC_PROTECTED,
+        className = className,
+        memberName = FROM_DJVM,
+        descriptor = bridgeDescriptor,
+        signature = signature
+    )
+
+    protected abstract fun writeBody(emitter: EmitterModule)
+
+    fun build(): List<Member> = listOf(
+        builder.withBody(::writeBody).build(),
+        object : MethodBuilder(
+            access = ACC_BRIDGE or ACC_SYNTHETIC or ACC_PROTECTED,
+            className = className,
+            memberName = FROM_DJVM,
+            descriptor = "()Ljava/lang/Object;"
+        ) {
+            override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                pushObject(0)
+                invokeVirtual(className, memberName, bridgeDescriptor)
+                returnObject()
+            }
+        }.withBody()
+         .build()
+    )
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/HandleExceptionUnwrapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/HandleExceptionUnwrapper.kt
@@ -25,7 +25,7 @@ object HandleExceptionUnwrapper : Emitter {
                         /**
                          * This is a catch block; the wrapping function is allowed to throw exceptions.
                          */
-                        invokeStatic(DJVM_NAME, "catch", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
+                        invokeStatic(DJVM_NAME, "doCatch", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
 
                         /**
                          * When catching exceptions, we also need to tell the verifier which
@@ -38,7 +38,7 @@ object HandleExceptionUnwrapper : Emitter {
                         /**
                          * This is a finally block; the wrapping function MUST NOT throw exceptions.
                          */
-                        invokeStatic(DJVM_NAME, "finally", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
+                        invokeStatic(DJVM_NAME, "doFinally", "(Ljava/lang/Throwable;)Lsandbox/java/lang/Throwable;")
                     }
                 }
             }

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -1,0 +1,307 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TaskExecutor;
+import net.corda.djvm.TestBase;
+import org.junit.jupiter.api.Test;
+
+import java.time.*;
+import java.time.zone.ZoneRulesProvider;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JavaTimeTest extends TestBase {
+    JavaTimeTest() {
+        super(JAVA);
+    }
+
+    private Object run(TaskExecutor executor, Class<?> task, Object data) throws Throwable {
+        Object toStringTask = executor.toSandboxClass(task).newInstance();
+        return executor.execute(toStringTask, data);
+    }
+
+    @Test
+    void testInstant() {
+        Instant instant = Instant.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, instant);
+                assertThat(toStringResult).isEqualTo(instant.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, instant);
+                assertThat(identityResult).isEqualTo(instant);
+                assertThat(identityResult).isNotSameAs(instant);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testDuration() {
+        Duration duration = Duration.ofHours(2);
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, duration);
+                assertThat(toStringResult).isEqualTo(duration.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, duration);
+                assertThat(identityResult).isEqualTo(duration);
+                assertThat(identityResult).isNotSameAs(duration);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testLocalDate() {
+        LocalDate localDate = LocalDate.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, localDate);
+                assertThat(toStringResult).isEqualTo(localDate.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, localDate);
+                assertThat(identityResult).isEqualTo(localDate);
+                assertThat(identityResult).isNotSameAs(localDate);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testLocalTime() {
+        LocalTime localTime = LocalTime.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, localTime);
+                assertThat(toStringResult).isEqualTo(localTime.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, localTime);
+                assertThat(identityResult).isEqualTo(localTime);
+                assertThat(identityResult).isNotSameAs(localTime);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testLocalDateTime() {
+        LocalDateTime localDateTime = LocalDateTime.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, localDateTime);
+                assertThat(toStringResult).isEqualTo(localDateTime.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, localDateTime);
+                assertThat(identityResult).isEqualTo(localDateTime);
+                assertThat(identityResult).isNotSameAs(localDateTime);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testMonthDay() {
+        MonthDay monthDay = MonthDay.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, monthDay);
+                assertThat(toStringResult).isEqualTo(monthDay.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, monthDay);
+                assertThat(identityResult).isEqualTo(monthDay);
+                assertThat(identityResult).isNotSameAs(monthDay);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testOffsetDateTime() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, offsetDateTime);
+                assertThat(toStringResult).isEqualTo(offsetDateTime.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, offsetDateTime);
+                assertThat(identityResult).isEqualTo(offsetDateTime);
+                assertThat(identityResult).isNotSameAs(offsetDateTime);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testOffsetTime() {
+        OffsetTime offsetTime = OffsetTime.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, offsetTime);
+                assertThat(toStringResult).isEqualTo(offsetTime.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, offsetTime);
+                assertThat(identityResult).isEqualTo(offsetTime);
+                assertThat(identityResult).isNotSameAs(offsetTime);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testPeriod() {
+        Period period = Period.of(1, 2, 3);
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, period);
+                assertThat(toStringResult).isEqualTo(period.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, period);
+                assertThat(identityResult).isEqualTo(period);
+                assertThat(identityResult).isNotSameAs(period);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testYear() {
+        Year year = Year.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, year);
+                assertThat(toStringResult).isEqualTo(year.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, year);
+                assertThat(identityResult).isEqualTo(year);
+                assertThat(identityResult).isNotSameAs(year);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testYearMonth() {
+        YearMonth yearMonth = YearMonth.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, yearMonth);
+                assertThat(toStringResult).isEqualTo(yearMonth.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, yearMonth);
+                assertThat(identityResult).isEqualTo(yearMonth);
+                assertThat(identityResult).isNotSameAs(yearMonth);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testZonedDateTime() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, zonedDateTime);
+                assertThat(toStringResult).isEqualTo(zonedDateTime.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, zonedDateTime);
+                assertThat(identityResult).isEqualTo(zonedDateTime);
+                assertThat(identityResult).isNotSameAs(zonedDateTime);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testZoneOffset() {
+        ZoneOffset zoneOffset = ZoneOffset.ofHours(7);
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                Object toStringResult = run(executor, TemporalToString.class, zoneOffset);
+                assertThat(toStringResult).isEqualTo(zoneOffset.toString());
+
+                Object identityResult = run(executor, IdentityTransformation.class, zoneOffset);
+                assertThat(identityResult).isEqualTo(zoneOffset);
+                assertThat(identityResult).isSameAs(zoneOffset);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testAllZoneIDs() {
+        parentedSandbox(WARNING, true, ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                String[] zoneIDs = (String[]) run(executor, AllZoneIDs.class, null);
+                assertThat(zoneIDs).hasSize(600);
+            } catch (Throwable t) {
+                fail(t);
+            }
+            return null;
+        });
+    }
+
+    public static class TemporalToString implements Function<Object, String> {
+        @Override
+        public String apply(Object temporal) {
+            return temporal.toString();
+        }
+    }
+
+    public static class IdentityTransformation implements Function<Object, Object> {
+        @Override
+        public Object apply(Object temporal) {
+            return temporal;
+        }
+    }
+
+    public static class AllZoneIDs implements Function<Object, String[]> {
+        @Override
+        public String[] apply(Object o) {
+            return ZoneRulesProvider.getAvailableZoneIds().toArray(new String[0]);
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
@@ -6,7 +6,10 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
-class TaskExecutor(private val classLoader: SandboxClassLoader) {
+class TaskExecutor
+    @Throws(ClassNotFoundException::class, NoSuchMethodException::class, SecurityException::class)
+    constructor(private val classLoader: SandboxClassLoader
+) {
     private val constructor: Constructor<out Any>
     private val executeMethod: Method
 
@@ -16,10 +19,12 @@ class TaskExecutor(private val classLoader: SandboxClassLoader) {
         executeMethod = taskClass.getMethod("apply", Any::class.java)
     }
 
+    @Throws(ClassNotFoundException::class)
     fun toSandboxClass(clazz: Class<*>): Class<*> {
         return classLoader.loadClassForSandbox(ClassSource.fromClassName(clazz.name))
     }
 
+    @Throws(Throwable::class)
     fun execute(task: Any, input: Any?): Any? {
         return try {
             executeMethod.invoke(constructor.newInstance(task), input)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -636,6 +636,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "java.lang.DJVMNoResource",
         "java.lang.DJVMResourceKey",
         "java.lang.DJVMThrowableWrapper",
+        "java.time.DJVM",
         "java.util.concurrent.atomic.DJVM",
         "java.util.concurrent.locks.DJVMConditionObject",
         "javax.security.auth.x500.DJVM",


### PR DESCRIPTION
Support `java.time.*` classes inside the sandbox. Mostly this involves teaching the DJVM how to convert instances between `java.time.X` and `sandbox.java.time.X`, but we also need to load the `tzdb.dat` file which contains Java's time zone database.

The majority of the work involves stitching `fromDJVM()` implementations into the `sandbox.java.time.X` classes, along with their accompanying bridge methods.

The `java.time.*` types are needed to deserialise Corda's `TimeWindow` object.