### PR TITLE
CORDA-2871: Add built-in tasks to marshall basic objects into and out of the sandbox.

### DIFF
--- a/djvm/src/main/java/sandbox/java/util/function/Supplier.java
+++ b/djvm/src/main/java/sandbox/java/util/function/Supplier.java
@@ -1,7 +1,7 @@
 package sandbox.java.util.function;
 
 /**
- * This is a dummy class that implements just enough of @{link java.util.function.Supplier}
+ * This is a dummy class that implements just enough of {@link java.util.function.Supplier}
  * to allow us to compile {@link sandbox.java.lang.ThreadLocal}.
  */
 @FunctionalInterface

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -168,6 +168,8 @@ class AnalysisConfiguration private constructor(
             sun.security.action.GetBooleanAction::class.java,
             sun.security.action.GetPropertyAction::class.java
         ).sandboxed() + setOf(
+            "sandbox/BasicInput",
+            "sandbox/BasicOutput",
             "sandbox/RawTask",
             "sandbox/Task",
             "sandbox/TaskTypes",

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -85,7 +85,7 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
             val task = taskClass.getDeclaredConstructor(functionClass).newInstance(runnable)
 
             // Execute the task...
-            val method = taskClass.getMethod("apply", Any::class.java)
+            val method = taskClass.getDeclaredMethod("apply", Any::class.java)
             try {
                 @Suppress("UNCHECKED_CAST")
                 method.invoke(task, input) as? OUTPUT

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
@@ -21,7 +21,7 @@ class SandboxRawExecutor(configuration: SandboxConfiguration) : Executor<Any?, A
             val task = taskClass.getDeclaredConstructor(functionClass).newInstance(runnable)
 
             // Execute the task...
-            val method = taskClass.getMethod("apply", Any::class.java)
+            val method = taskClass.getDeclaredMethod("apply", Any::class.java)
             try {
                 method.invoke(task, input)
             } catch (ex: InvocationTargetException) {

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -353,9 +353,7 @@ private val bannedClasses = setOf(
     "^javax?\\..*\\.DJVM\$".toRegex(),
     "^java\\.io\\.DJVM[^.]++\$".toRegex(),
     "^java\\.util\\.concurrent\\.locks\\.DJVM[^.]++\$".toRegex(),
-    "^RawTask\$".toRegex(),
-    "^RuntimeCostAccounter\$".toRegex(),
-    "^Task(.*)?\$".toRegex()
+    "^[^.]++\$".toRegex()
 )
 
 /**

--- a/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
@@ -1,0 +1,55 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static net.corda.djvm.messages.Severity.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class BasicInputOutputTest extends TestBase {
+    private static final String MESSAGE = "Hwllo World!";
+    private static final Long BIG_NUMBER = 123456789000L;
+
+    BasicInputOutputTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testBasicInput() {
+        parentedSandbox(WARNING, false, ctx -> {
+            try {
+                Function<Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
+                Object sandboxObject = inputTask.apply(MESSAGE);
+                assertEquals("sandbox.java.lang.String", sandboxObject.getClass().getName());
+                assertEquals(MESSAGE, sandboxObject.toString());
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testBasicOutput() {
+        parentedSandbox(WARNING, false, ctx -> {
+            try {
+                Function<Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
+                Object sandboxObject = inputTask.apply(BIG_NUMBER);
+
+                Function<Object, ?> outputTask = ctx.getClassLoader().createBasicOutput();
+                Object output = outputTask.apply(sandboxObject);
+                assertThat(output)
+                    .isExactlyInstanceOf(Long.class)
+                    .isEqualTo(BIG_NUMBER);
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TaskExecutor.kt
@@ -16,7 +16,7 @@ class TaskExecutor
     init {
         val taskClass = classLoader.loadClass("sandbox.Task")
         constructor = taskClass.getDeclaredConstructor(classLoader.loadClass("sandbox.java.util.function.Function"))
-        executeMethod = taskClass.getMethod("apply", Any::class.java)
+        executeMethod = taskClass.getDeclaredMethod("apply", Any::class.java)
     }
 
     @Throws(ClassNotFoundException::class)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -630,6 +630,8 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = [
+        "BasicInput",
+        "BasicOutput",
         "java.io.DJVMInputStream",
         "java.lang.DJVM",
         "java.lang.DJVMException",


### PR DESCRIPTION
Expose the `DJVM.sandbox(Object)` and `DJVM.unsandbox(Object)` functions via tasks `BasicInput` and `BasicOutput`.