### PR TITLE
CORDA-2871: Use UnaryOperator for basic input/output tasks.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -18,7 +18,7 @@ import org.objectweb.asm.ClassReader.SKIP_FRAMES
 import org.objectweb.asm.Type
 import java.lang.reflect.InvocationTargetException
 import java.net.URL
-import java.util.function.Function
+import java.util.function.UnaryOperator
 
 /**
  * Class loader that enables registration of rewired classes.
@@ -83,7 +83,7 @@ class SandboxClassLoader private constructor(
     )
 
     /**
-     * Returns an instance of [Function] that can transform a
+     * Returns an instance of [UnaryOperator] that can transform a
      * basic Java object into its equivalent inside the sandbox.
      */
     @Throws(
@@ -93,12 +93,12 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class,
         SecurityException::class
     )
-    fun createBasicInput(): Function<in Any?, out Any?> {
+    fun createBasicInput(): UnaryOperator<in Any?> {
         return createBasicTask("sandbox.BasicInput")
     }
 
     /**
-     * Returns an instance of [Function] that can transform
+     * Returns an instance of [UnaryOperator] that can transform
      * a basic sandbox object into its equivalent Java object.
      */
     @Throws(
@@ -108,7 +108,7 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class,
         SecurityException::class
     )
-    fun createBasicOutput(): Function<in Any?, out Any?> {
+    fun createBasicOutput(): UnaryOperator<in Any?> {
         return createBasicTask("sandbox.BasicOutput")
     }
 
@@ -119,11 +119,11 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class,
         SecurityException::class
     )
-    private fun createBasicTask(taskName: String): Function<in Any?, out Any?>  {
+    private fun createBasicTask(taskName: String): UnaryOperator<in Any?> {
         val taskClass = loadClass(taskName)
         val applyMethod = taskClass.getDeclaredMethod("apply", Any::class.java)
         val task = taskClass.newInstance()
-        return Function { value ->
+        return UnaryOperator { value ->
             try {
                 applyMethod(task, value)
             } catch (e: InvocationTargetException) {

--- a/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
@@ -3,7 +3,7 @@ package net.corda.djvm.execution;
 import net.corda.djvm.TestBase;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static net.corda.djvm.SandboxType.JAVA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,7 +22,7 @@ class BasicInputOutputTest extends TestBase {
     void testBasicInput() {
         parentedSandbox(ctx -> {
             try {
-                Function<Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
+                UnaryOperator<? super Object> inputTask = ctx.getClassLoader().createBasicInput();
                 Object sandboxObject = inputTask.apply(MESSAGE);
                 assertEquals("sandbox.java.lang.String", sandboxObject.getClass().getName());
                 assertEquals(MESSAGE, sandboxObject.toString());
@@ -37,10 +37,10 @@ class BasicInputOutputTest extends TestBase {
     void testBasicOutput() {
         parentedSandbox(ctx -> {
             try {
-                Function<Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
+                UnaryOperator<? super Object> inputTask = ctx.getClassLoader().createBasicInput();
                 Object sandboxObject = inputTask.apply(BIG_NUMBER);
 
-                Function<Object, ?> outputTask = ctx.getClassLoader().createBasicOutput();
+                UnaryOperator<? super Object> outputTask = ctx.getClassLoader().createBasicOutput();
                 Object output = outputTask.apply(sandboxObject);
                 assertThat(output)
                     .isExactlyInstanceOf(Long.class)


### PR DESCRIPTION
Simplify Java generics by replacing `Function` with `UnaryOperator` for basic input/output tasks.