### PR TITLE
CORDA-2871: Enable Class.getPackage() for outside the sandbox.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -346,6 +346,8 @@ class AnalysisConfiguration private constructor(
             }.build()
         ).mapByClassName() + (
             generateJavaTimeMethods()
+        ).mapByClassName() + (
+            generateJavaPackageMethods()
         ).mapByClassName() + listOf(
             object : MethodBuilder(
                 access = ACC_STATIC or ACC_PRIVATE,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaPackageConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaPackageConfiguration.kt
@@ -1,0 +1,65 @@
+@file:JvmName("JavaPackageConfiguration")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.sandboxed
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.references.Member
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * Generate [Member] objects that will be stitched into [Package].
+ */
+fun generateJavaPackageMethods(): List<Member> = listOf(
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(java.lang.Package::class.java),
+        memberName = "getPackage",
+        descriptor = "(Lsandbox/java/lang/String;)Lsandbox/java/lang/Package;"
+    ) {
+        /**
+         * Disable Package.getPackage(String).
+         *     return null
+         */
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushNull()
+            returnObject()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(java.lang.Package::class.java),
+        memberName = "getPackages",
+        descriptor = "()[Lsandbox/java/lang/Package;"
+    ) {
+        /**
+         * Disable Package.getPackages().
+         *     return new Package[0]
+         */
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushIntegerZero()
+            new(className, ANEWARRAY)
+            returnObject()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_STATIC,
+        className = sandboxed(java.lang.Package::class.java),
+        memberName = "getPackage",
+        descriptor = "(Ljava/lang/Class;)Lsandbox/java/lang/Package;",
+        signature = "(Ljava/lang/Class<*>;)Lsandbox/java/lang/Package;"
+    ) {
+        /**
+         * Disable Package.getPackage(Class<?>).
+         *     return null
+         */
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushNull()
+            returnObject()
+        }
+    }.withBody()
+     .build()
+)

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -159,9 +159,15 @@ class EmitterModule(
     fun pushNull() = instruction(ACONST_NULL)
 
     /**
+     * Emit instruction for pushing zero (Integer) onto the stack.
+     */
+    fun pushIntegerZero() = instruction(ICONST_0)
+
+    /**
      * Emit instruction for pushing "false" onto the stack.
      */
-    fun pushFalse() = instruction(ICONST_0)
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun pushFalse() = pushIntegerZero()
 
     /**
      * Emit instruction for pushing an integer value

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
@@ -24,7 +24,7 @@ object DisallowNonDeterministicMethods : Emitter {
                         Choice.FORBID -> forbid(instruction)
                         Choice.LOAD_CLASS -> loadClass()
                         Choice.INIT_CLASSLOADER -> initClassLoader()
-                        Choice.GET_PARENT -> returnNull(POP)
+                        Choice.GET_PARENT, Choice.GET_PACKAGE -> returnNull(POP)
                         Choice.NO_RESOURCE -> returnNull(POP2)
                         Choice.EMPTY_RESOURCES -> emptyResources(POP2)
                         else -> Unit
@@ -82,6 +82,7 @@ object DisallowNonDeterministicMethods : Emitter {
         FORBID,
         LOAD_CLASS,
         INIT_CLASSLOADER,
+        GET_PACKAGE,
         GET_PARENT,
         NO_RESOURCE,
         EMPTY_RESOURCES,
@@ -103,6 +104,7 @@ object DisallowNonDeterministicMethods : Emitter {
             isClassLoader && instruction.memberName == "getParent" -> Choice.GET_PARENT
             isClassLoader && instruction.memberName == "getResources" -> Choice.EMPTY_RESOURCES
             isClassLoader && instruction.memberName.startsWith("getResource") -> Choice.NO_RESOURCE
+            isClass && instruction.memberName == "getPackage" -> Choice.GET_PACKAGE
 
             className == "java/security/Provider\$Service" -> allowLoadClass()
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
@@ -1,0 +1,65 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TaskExecutor;
+import net.corda.djvm.TestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JavaPackageTest extends TestBase {
+    JavaPackageTest() {
+        super(JAVA);
+    }
+
+    private Object run(TaskExecutor executor, Class<?> task, Object data) throws Exception {
+        Object toStringTask = executor.toSandboxClass(task).newInstance();
+        return executor.execute(toStringTask, data);
+    }
+
+    @Test
+    void testFetchingPackage() {
+        parentedSandbox(ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                assertNull(run(executor, FetchPackage.class, "java.lang"));
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class FetchPackage implements Function<String, String> {
+        @Override
+        public String apply(String packageName) {
+            Package pkg = Package.getPackage(packageName);
+            return (pkg == null) ? null : pkg.getName();
+        }
+    }
+
+    @Test
+    void testFetchingAllPackage() {
+        parentedSandbox(ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                assertThat((String[]) run(executor, FetchAllPackages.class, null)).isEmpty();
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class FetchAllPackages implements Function<Object, String[]> {
+        @Override
+        public String[] apply(Object input) {
+            return Arrays.stream(Package.getPackages()).map(Package::getName).toArray(String[]::new);
+        }
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -2,6 +2,7 @@ package net.corda.djvm.execution;
 
 import net.corda.djvm.TaskExecutor;
 import net.corda.djvm.TestBase;
+import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
@@ -17,7 +18,7 @@ class JavaTimeTest extends TestBase {
         super(JAVA);
     }
 
-    private Object run(TaskExecutor executor, Class<?> task, Object data) throws Throwable {
+    private Object run(TaskExecutor executor, Class<?> task, Object data) throws Exception {
         Object toStringTask = executor.toSandboxClass(task).newInstance();
         return executor.execute(toStringTask, data);
     }
@@ -34,8 +35,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, instant);
                 assertThat(identityResult).isEqualTo(instant);
                 assertThat(identityResult).isNotSameAs(instant);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -53,8 +54,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, duration);
                 assertThat(identityResult).isEqualTo(duration);
                 assertThat(identityResult).isNotSameAs(duration);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -72,8 +73,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, localDate);
                 assertThat(identityResult).isEqualTo(localDate);
                 assertThat(identityResult).isNotSameAs(localDate);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -91,8 +92,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, localTime);
                 assertThat(identityResult).isEqualTo(localTime);
                 assertThat(identityResult).isNotSameAs(localTime);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -110,8 +111,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, localDateTime);
                 assertThat(identityResult).isEqualTo(localDateTime);
                 assertThat(identityResult).isNotSameAs(localDateTime);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -129,8 +130,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, monthDay);
                 assertThat(identityResult).isEqualTo(monthDay);
                 assertThat(identityResult).isNotSameAs(monthDay);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -148,8 +149,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, offsetDateTime);
                 assertThat(identityResult).isEqualTo(offsetDateTime);
                 assertThat(identityResult).isNotSameAs(offsetDateTime);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -167,8 +168,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, offsetTime);
                 assertThat(identityResult).isEqualTo(offsetTime);
                 assertThat(identityResult).isNotSameAs(offsetTime);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -186,8 +187,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, period);
                 assertThat(identityResult).isEqualTo(period);
                 assertThat(identityResult).isNotSameAs(period);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -205,8 +206,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, year);
                 assertThat(identityResult).isEqualTo(year);
                 assertThat(identityResult).isNotSameAs(year);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -224,8 +225,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, yearMonth);
                 assertThat(identityResult).isEqualTo(yearMonth);
                 assertThat(identityResult).isNotSameAs(yearMonth);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -243,8 +244,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, zonedDateTime);
                 assertThat(identityResult).isEqualTo(zonedDateTime);
                 assertThat(identityResult).isNotSameAs(zonedDateTime);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -262,8 +263,8 @@ class JavaTimeTest extends TestBase {
                 Object identityResult = run(executor, IdentityTransformation.class, zoneOffset);
                 assertThat(identityResult).isEqualTo(zoneOffset);
                 assertThat(identityResult).isSameAs(zoneOffset);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -276,8 +277,22 @@ class JavaTimeTest extends TestBase {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
                 String[] zoneIDs = (String[]) run(executor, AllZoneIDs.class, null);
                 assertThat(zoneIDs).hasSize(600);
-            } catch (Throwable t) {
-                fail(t);
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testDefaultZoneID() {
+        parentedSandbox(ctx -> {
+            try {
+                TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
+                RuleViolationError ex = assertThrows(RuleViolationError.class, () -> run(executor, DefaultZoneId.class, null));
+                assertThat(ex).hasMessage("Native method has been deleted; java.util.TimeZone.getSystemTimeZoneID(String)");
+            } catch (Exception e) {
+                fail(e);
             }
             return null;
         });
@@ -301,6 +316,13 @@ class JavaTimeTest extends TestBase {
         @Override
         public String[] apply(Object o) {
             return ZoneRulesProvider.getAvailableZoneIds().toArray(new String[0]);
+        }
+    }
+
+    public static class DefaultZoneId implements Function<Object, String> {
+        @Override
+        public String apply(Object o) {
+            return ZoneId.systemDefault().getId();
         }
     }
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -865,6 +865,23 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
+    fun `test users cannot read package`() = parentedSandbox {
+        assertThat(GetClassPackage().apply(null))
+            .isEqualTo(GetClassPackage::class.java.getPackage()?.toString())
+
+        val executor = DeterministicSandboxExecutor<String?, String?>(configuration)
+        executor.run<GetClassPackage>(null).apply {
+            assertThat(result).isNull()
+        }
+    }
+
+    class GetClassPackage : Function<String?, String?> {
+        override fun apply(input: String?): String? {
+            return javaClass.getPackage()?.toString()
+        }
+    }
+
+    @Test
     fun `test creating arrays of arrays`() = parentedSandbox {
         val executor = DeterministicSandboxExecutor<Any, Array<Any>>(configuration)
         executor.run<ArraysOfArrays>("THINGY").apply {


### PR DESCRIPTION
The `SandboxClassLoader` only expects a single thread of execution, but it can also be invoked from _outside_ the `sandbox.*` package space. It should therefore implement standard class loader locking, to be safe.

Sandbox classes can also reasonably be expected to support `Class.getPackage()`, although this could be dangerous inside the sandbox as it could potentially expose the `SandboxClassLoader` instance. For now, only support `Class.getPackage()` _outside_ the `sandbox.*` package space.