### PR TITLE
CORDA-2871: Set the default Java TimeZone to GMT.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -124,6 +124,7 @@ shadowJar {
     exclude 'sandbox/java/util/ResourceBundle*.class'
     exclude 'sandbox/javax/security/auth/x500/X500Principal.class'
     exclude 'sandbox/sun/security/x509/X500Name.class'
+    exclude 'sandbox/sun/util/calendar/ZoneInfoFile.class'
 }
 assemble.dependsOn shadowJar
 

--- a/djvm/src/main/java/sandbox/java/lang/System.java
+++ b/djvm/src/main/java/sandbox/java/lang/System.java
@@ -29,6 +29,10 @@ public final class System extends Object {
         return null;
     }
 
+    public static String setProperty(String name, String value) {
+        return null;
+    }
+
     @Nullable
     public static SecurityManager getSecurityManager() {
         return null;

--- a/djvm/src/main/java/sandbox/sun/util/calendar/ZoneInfoFile.java
+++ b/djvm/src/main/java/sandbox/sun/util/calendar/ZoneInfoFile.java
@@ -1,0 +1,35 @@
+package sandbox.sun.util.calendar;
+
+import sandbox.java.io.DataInputStream;
+import sandbox.java.lang.DJVM;
+import sandbox.java.security.AccessController;
+import sandbox.java.security.PrivilegedAction;
+
+import java.io.IOException;
+
+/**
+ * This is a dummy class that implements just enough of {@link sun.util.calendar.ZoneInfoFile}
+ * to allow us to compile its anonymous inner class.
+ */
+@SuppressWarnings({"unused", "WeakerAccess", "Convert2Lambda", "RedundantThrows"})
+public final class ZoneInfoFile extends sandbox.java.lang.Object {
+    static {
+        /*
+         * This anonymous inner class is a NON-dummy class called ZoneInfoFile$1.
+         */
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            public Object run() {
+                try (DataInputStream input = DJVM.loadSystemResource("tzdb.dat")) {
+                    ZoneInfoFile.load(input);
+                } catch (Exception e) {
+                    throw new InternalError(e);
+                }
+                return null;
+            }
+        });
+    }
+
+    private static void load(DataInputStream dis) throws ClassNotFoundException, IOException {
+        throw new UnsupportedOperationException("Dummy class - not implemented");
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -205,7 +205,8 @@ class AnalysisConfiguration private constructor(
             "sandbox/sun/misc/SharedSecrets\$1",
             "sandbox/sun/misc/SharedSecrets\$JavaLangAccessImpl",
             "sandbox/sun/security/provider/ByteArrayAccess",
-            "sandbox/sun/security/x509/X500Name\$1"
+            "sandbox/sun/security/x509/X500Name\$1",
+            "sandbox/sun/util/calendar/ZoneInfoFile\$1"
         ))
 
         /**

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
@@ -106,7 +106,8 @@ object DisallowNonDeterministicMethods : Emitter {
             isClassLoader && instruction.memberName.startsWith("getResource") -> Choice.NO_RESOURCE
             isClass && instruction.memberName == "getPackage" -> Choice.GET_PACKAGE
 
-            className == "java/security/Provider\$Service" -> allowLoadClass()
+            className == "java/security/Provider\$Service"
+                || className == "sun/security/x509/CertificateExtensions" -> allowLoadClass()
 
             // Forbid reflection otherwise.
             hasClassReflection -> Choice.FORBID

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -2,7 +2,6 @@ package net.corda.djvm.execution;
 
 import net.corda.djvm.TaskExecutor;
 import net.corda.djvm.TestBase;
-import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
@@ -289,8 +288,8 @@ class JavaTimeTest extends TestBase {
         parentedSandbox(ctx -> {
             try {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
-                RuleViolationError ex = assertThrows(RuleViolationError.class, () -> run(executor, DefaultZoneId.class, null));
-                assertThat(ex).hasMessage("Native method has been deleted; java.util.TimeZone.getSystemTimeZoneID(String)");
+                String defaultZoneID = (String) run(executor, DefaultZoneId.class, null);
+                assertThat(defaultZoneID).isEqualTo("GMT");
             } catch (Exception e) {
                 fail(e);
             }


### PR DESCRIPTION
Configure the sandbox environment always to use the GMT / UTC time zone.