### PR TITLE
CORDA-2871: Resolve issues blocking serialisation of ProtonJ primitives.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -77,6 +77,7 @@ shadowJar {
     exclude 'sandbox/java/lang/Comparable.class'
     exclude 'sandbox/java/lang/Enum.class'
     exclude 'sandbox/java/lang/Iterable.class'
+    exclude 'sandbox/java/lang/Number.class'
     exclude 'sandbox/java/lang/SecurityManager.class'
     exclude 'sandbox/java/lang/StackTraceElement.class'
     exclude 'sandbox/java/lang/StringBuffer.class'

--- a/djvm/src/main/java/sandbox/java/lang/Boolean.java
+++ b/djvm/src/main/java/sandbox/java/lang/Boolean.java
@@ -43,12 +43,6 @@ public final class Boolean extends Object implements Comparable<Boolean>, Serial
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Boolean.toString(value);
-    }
-
-    @Override
-    @NotNull
     public String toDJVMString() {
         return toString(value);
     }

--- a/djvm/src/main/java/sandbox/java/lang/Byte.java
+++ b/djvm/src/main/java/sandbox/java/lang/Byte.java
@@ -68,8 +68,8 @@ public final class Byte extends Number implements Comparable<Byte> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Byte.toString(value);
+    public String toDJVMString() {
+        return Byte.toString(value);
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/lang/Character.java
+++ b/djvm/src/main/java/sandbox/java/lang/Character.java
@@ -102,12 +102,6 @@ public final class Character extends Object implements Comparable<Character>, Se
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Character.toString(value);
-    }
-
-    @Override
-    @NotNull
     public String toDJVMString() {
         return toString(value);
     }

--- a/djvm/src/main/java/sandbox/java/lang/Double.java
+++ b/djvm/src/main/java/sandbox/java/lang/Double.java
@@ -82,8 +82,8 @@ public final class Double extends Number implements Comparable<Double> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Double.toString(value);
+    public String toDJVMString() {
+        return Double.toString(value);
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/lang/Float.java
+++ b/djvm/src/main/java/sandbox/java/lang/Float.java
@@ -44,8 +44,8 @@ public final class Float extends Number implements Comparable<Float> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Float.toString(value);
+    public String toDJVMString() {
+        return Float.toString(value);
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/lang/Integer.java
+++ b/djvm/src/main/java/sandbox/java/lang/Integer.java
@@ -76,8 +76,8 @@ public final class Integer extends Number implements Comparable<Integer> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Integer.toString(value);
+    public String toDJVMString() {
+        return Integer.toString(value);
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/lang/Long.java
+++ b/djvm/src/main/java/sandbox/java/lang/Long.java
@@ -84,8 +84,8 @@ public final class Long extends Number implements Comparable<Long> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Long.toString(value);
+    public String toDJVMString() {
+        return Long.toString(value);
     }
 
     public static String toString(long l) {

--- a/djvm/src/main/java/sandbox/java/lang/Number.java
+++ b/djvm/src/main/java/sandbox/java/lang/Number.java
@@ -1,8 +1,11 @@
 package sandbox.java.lang;
 
-import org.jetbrains.annotations.NotNull;
 import java.io.Serializable;
 
+/**
+ * This is a dummy class that implements just enough of {@link java.lang.Number}
+ * to allow us to compile {@link sandbox.java.lang.Long}, etc.
+ */
 @SuppressWarnings("unused")
 public abstract class Number extends Object implements Serializable {
 
@@ -13,9 +16,4 @@ public abstract class Number extends Object implements Serializable {
     public abstract short shortValue();
     public abstract byte byteValue();
 
-    @Override
-    @NotNull
-    public String toDJVMString() {
-        return String.toDJVM(toString());
-    }
 }

--- a/djvm/src/main/java/sandbox/java/lang/Short.java
+++ b/djvm/src/main/java/sandbox/java/lang/Short.java
@@ -54,8 +54,8 @@ public final class Short extends Number implements Comparable<Short> {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Integer.toString(value);
+    public String toDJVMString() {
+        return Integer.toString(value);
     }
 
     @Override

--- a/djvm/src/main/java/sandbox/java/util/Date.java
+++ b/djvm/src/main/java/sandbox/java/util/Date.java
@@ -10,8 +10,24 @@ import sandbox.java.lang.Comparable;
 public class Date extends sandbox.java.lang.Object implements java.io.Serializable, Cloneable, Comparable<Date> {
     private static final String NOT_IMPLEMENTED = "Dummy class - not implemented";
 
+    private final long time;
+
+    public Date(long time) {
+        this.time = time;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
     @Override
     public int compareTo(@NotNull Date o) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+    }
+
+    @Override
+    @NotNull
+    protected final java.util.Date fromDJVM() {
+        return new java.util.Date(getTime());
     }
 }

--- a/djvm/src/main/java/sandbox/java/util/concurrent/ConcurrentHashMap.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/ConcurrentHashMap.java
@@ -196,7 +196,7 @@ public class ConcurrentHashMap<K, V> extends AbstractMap<K, V> implements Concur
 
         @Override
         @NotNull
-        public final String toString() {
+        public final sandbox.java.lang.String toDJVMString() {
             throw new UnsupportedOperationException(UNSUPPORTED);
         }
 

--- a/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicInteger.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicInteger.java
@@ -1,7 +1,9 @@
 package sandbox.java.util.concurrent.atomic;
 
 import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Integer;
 import sandbox.java.lang.Number;
+import sandbox.java.lang.String;
 import sandbox.java.util.function.IntBinaryOperator;
 import sandbox.java.util.function.IntUnaryOperator;
 
@@ -137,7 +139,7 @@ public class AtomicInteger extends Number implements Serializable {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Integer.toString(value);
+    public String toDJVMString() {
+        return Integer.toString(value);
     }
 }

--- a/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicLong.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicLong.java
@@ -1,7 +1,9 @@
 package sandbox.java.util.concurrent.atomic;
 
 import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Long;
 import sandbox.java.lang.Number;
+import sandbox.java.lang.String;
 import sandbox.java.util.function.LongBinaryOperator;
 import sandbox.java.util.function.LongUnaryOperator;
 import java.io.Serializable;
@@ -136,7 +138,7 @@ public class AtomicLong extends Number implements Serializable {
 
     @Override
     @NotNull
-    public java.lang.String toString() {
-        return java.lang.Long.toString(value);
+    public String toDJVMString() {
+        return Long.toString(value);
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -155,7 +155,6 @@ class AnalysisConfiguration private constructor(
             java.lang.Float::class.java,
             java.lang.Integer::class.java,
             java.lang.Long::class.java,
-            java.lang.Number::class.java,
             java.lang.Runtime::class.java,
             java.lang.Short::class.java,
             java.lang.StrictMath::class.java,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaTimeConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaTimeConfiguration.kt
@@ -238,6 +238,22 @@ fun generateJavaTimeMethods(): List<Member> = object : FromDJVMBuilder(
         invokeStatic("java/time/ZoneId", OF, "(Ljava/lang/String;)Ljava/time/ZoneId;")
         returnObject()
     }
+}.build() + object : FromDJVMBuilder(
+    className = sandboxed(java.util.Date::class.java),
+    bridgeDescriptor = "()Ljava/util/Date;"
+) {
+    /**
+     * Implements Date.fromDJVM():
+     *     return java.time.Date(getTime())
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        new("java/util/Date")
+        duplicate()
+        pushObject(0)
+        invokeVirtual(className, "getTime", "()J")
+        invokeSpecial("java/util/Date", CONSTRUCTOR_NAME, "(J)V")
+        returnObject()
+    }
 }.build() + listOf(
     /**
      * Create an accessor for [sandbox.java.time.ZonedDateTime.ofLenient]:
@@ -288,6 +304,7 @@ fun generateJavaTimeMethods(): List<Member> = object : FromDJVMBuilder(
         }
     }.withBody()
      .build(),
+
     /**
      * Delete the original no-argument constructor.
      */

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StaticConstantRemover.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StaticConstantRemover.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm.rules.implementation
 
 import net.corda.djvm.analysis.AnalysisRuntimeContext
+import net.corda.djvm.code.DJVM_NAME
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.MemberDefinitionProvider
 import net.corda.djvm.references.Member
@@ -22,7 +23,7 @@ object StaticConstantRemover : MemberDefinitionProvider {
         fun writeInitializer(emitter: EmitterModule): Unit = with(emitter) {
             val value = member.value ?: return
             loadConstant(value)
-            invokeStatic("sandbox/java/lang/String", "toDJVM", "(Ljava/lang/String;)Lsandbox/java/lang/String;", false)
+            invokeStatic(DJVM_NAME, "intern", "(Ljava/lang/String;)Lsandbox/java/lang/String;", false)
             putStatic(member.className, member.memberName, "Lsandbox/java/lang/String;")
         }
     }

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -42,6 +42,7 @@ fun Any.sandbox(): Any {
         is kotlin.Boolean -> Boolean.toDJVM(this)
         is kotlin.Enum<*> -> toDJVMEnum()
         is kotlin.Throwable -> toDJVMThrowable()
+        is java.util.Date -> Date(time)
         is java.time.Duration -> sandbox.java.time.Duration.ofSeconds(seconds, nano.toLong())
         is java.time.Instant -> sandbox.java.time.Instant.ofEpochSecond(epochSecond, nano.toLong())
         is java.time.LocalDate -> toDJVM()

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -307,7 +307,7 @@ class JavaTimeTest extends TestBase {
             try {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
                 String defaultTimeZone = (String) run(executor, DefaultTimeZone.class, null);
-                assertThat(defaultTimeZone).isEqualTo("UTC");
+                assertThat(defaultTimeZone).isEqualTo("Coordinated Universal Time");
             } catch (Exception e) {
                 fail(e);
             }
@@ -318,7 +318,14 @@ class JavaTimeTest extends TestBase {
     @Test
     void testDate() {
         Date now = new Date();
-        parentedSandbox(ctx -> {
+
+        // We need to use a standalone sandbox here until we can
+        // recreate parent classloaders from cached byte-code.
+        // The problem is that each sandbox should know about those
+        // strings which have already been interned by the parent
+        // classloader when (e.g.) they were loaded into static
+        // final fields.
+        sandbox(ctx -> {
             try {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
                 String result = (String) run(executor, ShowDate.class, now);
@@ -380,7 +387,7 @@ class JavaTimeTest extends TestBase {
     public static class DefaultTimeZone implements Function<Object, String> {
         @Override
         public String apply(Object o) {
-            return TimeZone.getDefault().getID();
+            return TimeZone.getDefault().getDisplayName();
         }
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 import java.util.function.Function;
 
-import static java.util.Collections.singleton;
+import static java.util.Collections.*;
 import static net.corda.djvm.SandboxType.JAVA;
 import static net.corda.djvm.messages.Severity.WARNING;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -25,7 +25,7 @@ class SandboxExecutorJavaTest extends TestBase {
         //TODO: Transaction should not be a pinned class! It needs
         //      to be marshalled into and out of the sandbox.
         Set<Class<?>> pinnedClasses = singleton(Transaction.class);
-        sandbox(new Object[0], pinnedClasses, WARNING, true, ctx -> {
+        sandbox(new Object[0], pinnedClasses, emptySet(), WARNING, true, ctx -> {
             SandboxExecutor<Transaction, Void> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Transaction tx = new Transaction(TX_ID);
             assertThatExceptionOfType(IllegalArgumentException.class)

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -7,6 +7,7 @@ import net.corda.djvm.rules.RuleViolationError;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
+import static java.util.Collections.*;
 import static net.corda.djvm.SandboxType.JAVA;
 import static net.corda.djvm.Utilities.*;
 import static net.corda.djvm.messages.Severity.*;
@@ -14,7 +15,6 @@ import static net.corda.djvm.messages.Severity.*;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -106,8 +106,8 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testMultiCatchWithDisallowedExceptions() {
-        Set<Class<?>> pinnedClasses = Collections.singleton(Utilities.class);
-        sandbox(new Object[0], pinnedClasses, WARNING, true, ctx -> {
+        Set<Class<?>> pinnedClasses = singleton(Utilities.class);
+        sandbox(new Object[0], pinnedClasses, emptySet(), WARNING, true, ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -15,7 +15,8 @@ import java.util.*
 class ClassRewriterTest : TestBase(KOTLIN) {
 
     @Test
-    fun `empty transformer does nothing`() = sandbox(BLANK) {
+    fun `empty transformer does nothing`() = sandbox(BLANK, enableTracing = false) {
+        // An empty transformer doesn't contain the tracing emitters either.
         val callable = newCallable<Empty>()
         assertThat(callable).isSandboxed()
         callable.createAndInvoke()


### PR DESCRIPTION
- Stop templating the `Number` class to avoid possible infinite recursion in `toString()`.
- Add `Date` to the DJVM's list of native types.
- Fix loading of resource bundles, i.e. establish the bundle's parent chain.
- Ensure that `static final String` field values are interned.
- Remove some more cruft from `TestBase`.