### PR TITLE
CORDA-2871: Tidy up ResourceBundle handling.

### DIFF
--- a/djvm/src/main/java/sandbox/java/util/ResourceBundle.java
+++ b/djvm/src/main/java/sandbox/java/util/ResourceBundle.java
@@ -10,6 +10,8 @@ import sandbox.java.lang.String;
 public abstract class ResourceBundle extends sandbox.java.lang.Object {
     private static final java.lang.String NOT_IMPLEMENTED = "Dummy class - not implemented";
 
+    private ResourceBundle parent;
+
     protected abstract Object handleGetObject(String key);
     public abstract Enumeration<String> getKeys();
 
@@ -39,6 +41,17 @@ public abstract class ResourceBundle extends sandbox.java.lang.Object {
 
     public Set<String> keySet() {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+    }
+
+    /**
+     * Example implementation. The real one will be stitched here at runtime.
+     * @param parent The {@link ResourceBundle} that will become this bundle's
+     *               parent, assuming it doesn't already have a parent.
+     */
+    public void childOf(ResourceBundle parent) {
+        if (this.parent == null) {
+            this.parent = parent;
+        }
     }
 
     /**

--- a/djvm/src/main/java/sandbox/java/util/ResourceBundle.java
+++ b/djvm/src/main/java/sandbox/java/util/ResourceBundle.java
@@ -10,17 +10,19 @@ import sandbox.java.lang.String;
 public abstract class ResourceBundle extends sandbox.java.lang.Object {
     private static final java.lang.String NOT_IMPLEMENTED = "Dummy class - not implemented";
 
-    private ResourceBundle parent;
+    protected ResourceBundle parent;
+    private String name;
+    private Locale locale;
 
     protected abstract Object handleGetObject(String key);
     public abstract Enumeration<String> getKeys();
 
     public String getBaseBundleName() {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return name;
     }
 
     public Locale getLocale() {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return locale;
     }
 
     public final String getString(String key) {
@@ -52,6 +54,14 @@ public abstract class ResourceBundle extends sandbox.java.lang.Object {
         if (this.parent == null) {
             this.parent = parent;
         }
+    }
+
+    /**
+     * Example implementation. The real one will be stitched here at runtime.
+     */
+    public void init(String name, Locale locale) {
+        this.name = name;
+        this.locale = locale;
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -170,7 +170,7 @@ class AnalysisConfiguration private constructor(
             java.util.concurrent.atomic.AtomicInteger::class.java,
             java.util.concurrent.atomic.AtomicLong::class.java,
             java.util.concurrent.locks.ReentrantLock::class.java,
-            kotlin.Any::class.java,
+            Any::class.java,
             sun.misc.JavaLangAccess::class.java,
             sun.misc.SharedSecrets::class.java,
             sun.misc.VM::class.java,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaResourceBundleConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaResourceBundleConfiguration.kt
@@ -1,0 +1,176 @@
+@file:JvmName("JavaResourceBundleConfiguration")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.sandboxed
+import net.corda.djvm.code.DJVM_NAME
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.references.Member
+import org.objectweb.asm.Label
+import org.objectweb.asm.Opcodes.*
+import java.util.*
+
+private const val GET_BUNDLE = "getBundle"
+
+/**
+ * Generate [Member] objects for the [sandbox.java.lang.Object.fromDJVM]
+ * methods that will be stitched into the [sandbox.java.util.ResourceBundle] class.
+ */
+fun generateJavaResourceBundleMethods(): List<Member> = listOf(
+    /**
+     * Redirect the [ResourceBundle] handling.
+     */
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushDefaultLocale()
+            pushDefaultControl()
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/ResourceBundle\$Control;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushDefaultLocale()
+            pushObject(1)
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            pushDefaultControl()
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;Lsandbox/java/util/ResourceBundle\$Control;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            pushObject(2)
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;Ljava/lang/ClassLoader;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            pushDefaultControl()
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC or ACC_STATIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;Ljava/lang/ClassLoader;Lsandbox/java/util/ResourceBundle\$Control;)Lsandbox/java/util/ResourceBundle;"
+    ) {
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            pushObject(3)
+            returnResourceBundle()
+        }
+    }.withBody()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = "childOf",
+        descriptor = "(Lsandbox/java/util/ResourceBundle;)V"
+    ) {
+        /**
+         * Implements ResourceBundle.childOf(ResourceBundle parent):
+         *     if (this.parent == null) {
+         *         this.parent = parent
+         *     }
+         *     return
+         */
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            lineNumber(1)
+            pushObject(0)
+            pushField(className, "parent", "Lsandbox/java/util/ResourceBundle;")
+
+            val doEnd = Label()
+            jump(IFNONNULL, doEnd)
+            pushObject(0)
+            pushObject(1)
+            popField(className, "parent", "Lsandbox/java/util/ResourceBundle;")
+
+            lineNumber(2, doEnd)
+            returnVoid()
+        }
+    }.withBody()
+     .build()
+)
+
+private fun EmitterModule.returnResourceBundle() {
+    invokeStatic(
+        owner = DJVM_NAME,
+        name = GET_BUNDLE,
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;Lsandbox/java/util/ResourceBundle\$Control;)Lsandbox/java/util/ResourceBundle;"
+    )
+    returnObject()
+}
+
+private fun EmitterModule.pushDefaultLocale() {
+    invokeStatic(
+        owner = sandboxed(Locale::class.java),
+        name = "getDefault",
+        descriptor = "()Lsandbox/java/util/Locale;"
+    )
+}
+
+private fun EmitterModule.pushDefaultControl() {
+    /*
+     * The baseName parameter is expected already to have been
+     * pushed onto the stack, just below the Locale value, so
+     * emit instructions to rearrange the stack as follows:
+     *     [W1]    [W2]
+     *     [W2] -> [W1]
+     *             [W2]
+     */
+    instruction(DUP2)
+    pop()
+    invokeStatic(
+        owner = sandboxed(ResourceBundle::class.java),
+        name = "getDefaultControl",
+        descriptor = "(Lsandbox/java/lang/String;)Lsandbox/java/util/ResourceBundle\$Control;"
+    )
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaResourceBundleConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaResourceBundleConfiguration.kt
@@ -137,7 +137,33 @@ fun generateJavaResourceBundleMethods(): List<Member> = listOf(
             returnVoid()
         }
     }.withBody()
-     .build()
+     .build(),
+
+    object : MethodBuilder(
+        access = ACC_PUBLIC,
+        className = sandboxed(ResourceBundle::class.java),
+        memberName = "init",
+        descriptor = "(Lsandbox/java/lang/String;Lsandbox/java/util/Locale;)V"
+    ) {
+        /**
+         * Implements ResourceBundle.init(String name, Locale locale):
+         *     this.name = name
+         *     this.locale = locale
+         *     return
+         */
+        override fun writeBody(emitter: EmitterModule) = with(emitter) {
+            pushObject(0)
+            pushObject(1)
+            popField(className, "name", "Lsandbox/java/lang/String;")
+
+            pushObject(0)
+            pushObject(2)
+            popField(className, "locale", "Lsandbox/java/util/Locale;")
+
+            returnVoid()
+        }
+    }.withBody()
+    .build()
 )
 
 private fun EmitterModule.returnResourceBundle() {

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -555,12 +555,9 @@ fun getBundle(baseName: String, locale: Locale, control: ResourceBundle.Control)
         val key = "${baseName}_$locale"
         throw fromDJVM(MissingResourceException(String.toDJVM(message), String.toDJVM(key), intern("")))
     } else {
-        val parentField = ResourceBundle::class.java.getDeclaredField("parent").apply {
-            isAccessible = true
-        }
         var idx = candidateBundles.size - 1
         while (idx > 0) {
-            parentField.set(candidateBundles[idx - 1], candidateBundles[idx])
+            candidateBundles[idx - 1].childOf(candidateBundles[idx])
             --idx
         }
 

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -570,7 +570,9 @@ private fun loadResourceBundle(control: ResourceBundle.Control, key: DJVMResourc
     val bundle = try {
         val bundleClass = systemClassLoader.loadClass(toSandbox(bundleName.toString()))
         if (ResourceBundle::class.java.isAssignableFrom(bundleClass)) {
-            bundleClass.newInstance() as ResourceBundle
+            (bundleClass.newInstance() as ResourceBundle).also {
+                it.init(key.baseName, key.locale)
+            }
         } else {
             DJVMNoResource
         }

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -303,7 +303,15 @@ class JavaTimeTest extends TestBase {
 
     @Test
     void testDefaultTimeZone() {
-        parentedSandbox(ctx -> {
+        // We need to use a standalone sandbox here until we can
+        // recreate parent classloaders from cached byte-code.
+        // The problem is that each sandbox should know about those
+        // strings which have already been interned by the parent
+        // classloader when (e.g.) they were loaded into static
+        // final fields.
+        //
+        // THIS ISSUE AFFECTS ANYTHING THAT LOADS RESOURCE BUNDLES.
+        sandbox(ctx -> {
             try {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());
                 String defaultTimeZone = (String) run(executor, DefaultTimeZone.class, null);
@@ -325,6 +333,8 @@ class JavaTimeTest extends TestBase {
         // strings which have already been interned by the parent
         // classloader when (e.g.) they were loaded into static
         // final fields.
+        //
+        // THIS ISSUE AFFECTS ANYTHING THAT LOADS RESOURCE BUNDLES.
         sandbox(ctx -> {
             try {
                 TaskExecutor executor = new TaskExecutor(ctx.getClassLoader());


### PR DESCRIPTION
- Migrate stitched ResourceBundle method configuration into a separate file.
- Stitch two extra methods to configure ResourceBundle objects more correctly.