### PR TITLE
CORDA-2871: Support AtomicReference inside the sandbox.

### DIFF
--- a/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicReference.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/atomic/AtomicReference.java
@@ -1,0 +1,78 @@
+package sandbox.java.util.concurrent.atomic;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.String;
+import sandbox.java.util.function.BinaryOperator;
+import sandbox.java.util.function.UnaryOperator;
+
+import java.io.Serializable;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class AtomicReference<V> extends sandbox.java.lang.Object implements Serializable {
+
+    private V value;
+
+    public AtomicReference(V initialValue) {
+        value = initialValue;
+    }
+
+    public AtomicReference() {
+    }
+
+    public final V get() {
+        return value;
+    }
+
+    public final void set(V newValue) {
+        value = newValue;
+    }
+
+    public final void lazySet(V newValue) {
+        set(newValue);
+    }
+
+    public final boolean compareAndSet(V expectedValue, V newValue) {
+        if (value == expectedValue) {
+            value = newValue;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public final boolean weakCompareAndSet(V expectedValue, V newValue) {
+        return compareAndSet(expectedValue, newValue);
+    }
+
+    public final V getAndSet(V newValue) {
+        V oldValue = value;
+        value = newValue;
+        return oldValue;
+    }
+
+    public final V getAndUpdate(UnaryOperator<V> updater) {
+        V oldValue = value;
+        value = updater.apply(oldValue);
+        return oldValue;
+    }
+
+    public final V updateAndGet(UnaryOperator<V> updater) {
+        return (value = updater.apply(value));
+    }
+
+    public final V getAndAccumulate(V x, BinaryOperator<V> accumulator) {
+        V oldValue = value;
+        value = accumulator.apply(oldValue, x);
+        return oldValue;
+    }
+
+    public final V accumulateAndGet(V x, BinaryOperator<V> accumulator) {
+        return (value = accumulator.apply(value, x));
+    }
+
+    @Override
+    @NotNull
+    public String toDJVMString() {
+        return String.valueOf(get());
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/function/BinaryOperator.java
+++ b/djvm/src/main/java/sandbox/java/util/function/BinaryOperator.java
@@ -1,0 +1,10 @@
+package sandbox.java.util.function;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.function.BinaryOperator}
+ * to allow us to compile {@link sandbox.java.util.concurrent.atomic.AtomicReference}.
+ */
+@FunctionalInterface
+public interface BinaryOperator<T> {
+    T apply(T left, T right);
+}

--- a/djvm/src/main/java/sandbox/java/util/function/UnaryOperator.java
+++ b/djvm/src/main/java/sandbox/java/util/function/UnaryOperator.java
@@ -1,0 +1,11 @@
+package sandbox.java.util.function;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.function.UnaryOperator}
+ * to allow us to compile {@link sandbox.java.util.concurrent.atomic.AtomicReference}.
+ */
+@FunctionalInterface
+public interface UnaryOperator<T> extends Function<T, T> {
+    @Override
+    T apply(T value);
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -169,6 +169,7 @@ class AnalysisConfiguration private constructor(
             java.util.concurrent.ConcurrentHashMap.KeySetView::class.java,
             java.util.concurrent.atomic.AtomicInteger::class.java,
             java.util.concurrent.atomic.AtomicLong::class.java,
+            java.util.concurrent.atomic.AtomicReference::class.java,
             java.util.concurrent.locks.ReentrantLock::class.java,
             java.util.zip.CRC32::class.java,
             java.util.zip.Inflater::class.java,


### PR DESCRIPTION
We need `AtomicReference` to support `Enumeration<*>.asSequence()` in Kotlin.