### PR TITLE
CORDA-2871: Sanity fixes!

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -215,7 +215,7 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
                     context.recordClassOrigin(reference.className, originReference)
                 }
             }
-            throw SandboxClassLoadingException(context)
+            throw SandboxClassLoadingException("Analysis has failed", context)
         }
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -276,7 +276,7 @@ class SandboxClassLoader private constructor(
             return loadedClass
         } else if (analysisConfiguration.isPinnedClass(requestedPath)) {
             logger.error("Class {} should not be loaded here", request.qualifiedClassName)
-            throw SandboxClassLoadingException(context)
+            throw SandboxClassLoadingException("Refusing to load pinned ${request.qualifiedClassName}", context)
         }
 
         val byteCode = if (analysisConfiguration.isTemplateClass(requestedPath)) {
@@ -297,7 +297,7 @@ class SandboxClassLoader private constructor(
             context.messages.acceptProvisional()
             if (context.messages.errorCount > 0) {
                 logger.debug("Errors detected after analyzing class {}", request.qualifiedClassName)
-                throw SandboxClassLoadingException(context)
+                throw SandboxClassLoadingException("Analysis failed for ${request.qualifiedClassName}", context)
             }
 
             // Transform the class definition and byte code in accordance with provided rules.

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
@@ -16,11 +16,12 @@ import net.corda.djvm.references.EntityReference
  * @property classOrigins Map of class origins. The resulting set represents the types referencing the class in question.
  */
 class SandboxClassLoadingException(
+        message: String,
         private val context: AnalysisContext,
         val messages: MessageCollection = context.messages,
         val classes: ClassHierarchy = context.classes,
         val classOrigins: Map<String, Set<EntityReference>> = context.classOrigins
-) : SandboxRuntimeException("Failed to load class") {
+) : SandboxRuntimeException(message) {
 
     /**
      * The detailed description of the exception.

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -114,12 +114,13 @@ class SourceClassLoader(
         val originalName = classResolver.reverse(className.asResourcePath)
 
         fun throwClassLoadingError(): Nothing {
+            val message = "Class file not found: $originalName.class"
             context.messages.provisionalAdd(Message(
-                message ="Class file not found; $originalName.class",
+                message = message,
                 severity = Severity.ERROR,
                 location = SourceLocation(origin ?: "")
             ))
-            throw SandboxClassLoadingException(context)
+            throw SandboxClassLoadingException(message, context)
         }
 
         return try {

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -135,7 +135,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
         val djvm = DJVM(classLoader)
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
             .isThrownBy { djvm.classFor("sandbox.java.util.DoesNotExist\$1DJVM") }
-            .withMessageContaining("Failed to load class")
+            .withMessageContaining("Class file not found: java/util/DoesNotExist")
     }
 
     /**
@@ -147,7 +147,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
         val djvm = DJVM(classLoader)
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
             .isThrownBy { djvm.classFor("sandbox.com.example.DoesNotExist\$1DJVM") }
-            .withMessageContaining("Failed to load class")
+            .withMessageContaining("Class file not found: com/example/DoesNotExist")
     }
 }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
@@ -17,7 +17,7 @@ class KotlinNeedsKotlinTest : TestBase(JAVA) {
         }
         assertThat(exception)
             .hasCauseExactlyInstanceOf(SandboxClassLoadingException::class.java)
-            .hasMessageContaining("Class file not found; kotlin/jvm/internal/Intrinsics.class")
+            .hasMessageContaining("Class file not found: kotlin/jvm/internal/Intrinsics.class")
     }
 
     class UseKotlinForSomething : Function<String, String> {

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -352,7 +352,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         assertThatExceptionOfType(SandboxException::class.java)
             .isThrownBy { executor.run<TestIO>("test.dat") }
             .withCauseInstanceOf(SandboxClassLoadingException::class.java)
-            .withMessageContaining("Class file not found; java/nio/file/Paths.class")
+            .withMessageContaining("Class file not found: java/nio/file/Paths.class")
     }
 
     class TestIO : Function<String, Int> {

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -74,7 +74,7 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     fun `cannot load a Java API that was deleted from Java runtime`() = sandbox(DEFAULT) {
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
                 .isThrownBy { loadClass<Paths>() }
-                .withMessageContaining("Class file not found; java/nio/file/Paths.class")
+                .withMessageContaining("Class file not found: java/nio/file/Paths.class")
     }
 
     @Test
@@ -88,7 +88,7 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     fun `cannot load internal Sun class that was deleted from Java runtime`() = sandbox(DEFAULT) {
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
                 .isThrownBy { loadClass<sun.misc.Timer>() }
-                .withMessageContaining("Class file not found; sun/misc/Timer.class")
+                .withMessageContaining("Class file not found: sun/misc/Timer.class")
     }
 
     @Test
@@ -158,14 +158,14 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     fun `test rule violation error cannot be loaded`() = parentedSandbox {
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
             .isThrownBy { loadClass<RuleViolationError>() }
-            .withMessageContaining("Class file not found; net/corda/djvm/rules/RuleViolationError.class")
+            .withMessageContaining("Class file not found: net/corda/djvm/rules/RuleViolationError.class")
     }
 
     @Test
     fun `test threshold violation error cannot be loaded`() = parentedSandbox {
         assertThatExceptionOfType(SandboxClassLoadingException::class.java)
             .isThrownBy { loadClass<ThresholdViolationError>() }
-            .withMessageContaining("Class file not found; net/corda/djvm/costing/ThresholdViolationError.class")
+            .withMessageContaining("Class file not found: net/corda/djvm/costing/ThresholdViolationError.class")
     }
 }
 

--- a/serialization/src/main/kotlin/net/corda/djvm/serialization/Serialization.kt
+++ b/serialization/src/main/kotlin/net/corda/djvm/serialization/Serialization.kt
@@ -75,11 +75,17 @@ inline fun <reified T : Any> SerializedBytes<T>.deserializeFor(classLoader: Sand
 }
 
 fun ByteSequence.deserializeTo(clazz: Class<*>, classLoader: SandboxClassLoader): Any {
-    return deserializeTo(clazz, classLoader, SerializationFactory.defaultFactory)
+    val factory = SerializationFactory.defaultFactory
+    return deserializeTo(clazz, classLoader, factory, factory.defaultContext)
 }
 
-fun ByteSequence.deserializeTo(clazz: Class<*>, classLoader: SandboxClassLoader, factory: SerializationFactory): Any {
-    val obj = factory.deserialize(this, Any::class.java, factory.defaultContext)
+fun ByteSequence.deserializeTo(
+    clazz: Class<*>,
+    classLoader: SandboxClassLoader,
+    factory: SerializationFactory,
+    context: SerializationContext
+): Any {
+    val obj = factory.deserialize(this, Any::class.java, context)
     return if (clazz.isInstance(obj)) {
         obj
     } else {


### PR DESCRIPTION
- Add a sensible top-level message to `SandboxClassLoadingException` so that the poor developers can tell what might be going wrong!
- Modify the deserialisation API so that we can specify both serialisation factory and serialisation context.