### PR TITLE
Ensure ClassLoader.loadClass() throws ClassNotFoundException.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -278,8 +278,6 @@ class SandboxClassLoader private constructor(
                     try {
                         clazz = super.loadClass(name, false)
                     } catch (e: ClassNotFoundException) {
-                    } catch (e: SandboxClassLoadingException) {
-                        e.messages.clearProvisional()
                     }
                 }
 
@@ -368,7 +366,12 @@ class SandboxClassLoader private constructor(
             loadUnmodifiedByteCode(requestedPath)
         } else {
             // Load the byte code for the specified class.
-            val reader = supportingClassLoader.classReader(sourceName, context, request.origin)
+            val reader = try {
+                supportingClassLoader.classReader(sourceName, context, request.origin)
+            } catch (e: SandboxClassLoadingException) {
+                e.messages.clearProvisional()
+                throw ClassNotFoundException(e.message)
+            }
 
             // Analyse the class if not matching the whitelist.
             val readClassName = reader.className

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -2,7 +2,6 @@ package net.corda.djvm
 
 import net.corda.djvm.SandboxType.KOTLIN
 import net.corda.djvm.assertions.AssertionExtensions.assertThatDJVM
-import net.corda.djvm.rewiring.SandboxClassLoadingException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
@@ -133,7 +132,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     @Test
     fun testWeCannotCreateSyntheticExceptionForImaginaryJavaClass() = parentedSandbox {
         val djvm = DJVM(classLoader)
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.java.util.DoesNotExist\$1DJVM") }
             .withMessageContaining("Class file not found: java/util/DoesNotExist")
     }
@@ -145,7 +144,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     @Test
     fun testWeCannotCreateSyntheticExceptionForImaginaryUserClass() = parentedSandbox {
         val djvm = DJVM(classLoader)
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.com.example.DoesNotExist\$1DJVM") }
             .withMessageContaining("Class file not found: com/example/DoesNotExist")
     }

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
@@ -2,7 +2,6 @@ package net.corda.djvm.execution
 
 import net.corda.djvm.SandboxType.JAVA
 import net.corda.djvm.TestBase
-import net.corda.djvm.rewiring.SandboxClassLoadingException
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -11,7 +10,7 @@ import java.util.function.Function
 class KotlinNeedsKotlinTest : TestBase(JAVA) {
     @Test
     fun `kotlin code needs kotlin libraries`() {
-        val exception = assertThrows<SandboxClassLoadingException> {
+        val exception = assertThrows<NoClassDefFoundError> {
             parentedSandbox {
                 val taskFactory = classLoader.createTaskFactory()
                 classLoader.typedTaskFor<String, String, UseKotlinForSomething>(taskFactory)
@@ -19,7 +18,9 @@ class KotlinNeedsKotlinTest : TestBase(JAVA) {
             }
         }
         assertThat(exception)
-            .isExactlyInstanceOf(SandboxClassLoadingException::class.java)
+            .hasMessageContaining("sandbox/kotlin/jvm/internal/Intrinsics")
+            .hasCauseExactlyInstanceOf(ClassNotFoundException::class.java)
+        assertThat(exception.cause)
             .hasMessageContaining("Class file not found: kotlin/jvm/internal/Intrinsics.class")
     }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -9,7 +9,6 @@ import net.corda.djvm.Utilities.*
 import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.assertions.AssertionExtensions.withProblem
 import net.corda.djvm.costing.ThresholdViolationError
-import net.corda.djvm.rewiring.SandboxClassLoadingException
 import net.corda.djvm.rules.RuleViolationError
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -350,7 +349,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         val executor = DeterministicSandboxExecutor<String, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
             .isThrownBy { executor.run<TestIO>("test.dat") }
-            .withCauseInstanceOf(SandboxClassLoadingException::class.java)
+            .withCauseInstanceOf(ClassNotFoundException::class.java)
             .withMessageContaining("Class file not found: java/nio/file/Paths.class")
     }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -38,8 +38,8 @@ class ClassRewriterTest : TestBase(KOTLIN) {
         assertThat(callable).isSandboxed()
         callable.createAndInvoke()
         assertThat(runtimeCosts)
-                .hasInvocationCostGreaterThanOrEqualTo(1) // Includes static constructor calls for java.lang.Math, etc.
-                .hasJumpCostGreaterThanOrEqualTo(30 * 2 + 1)
+            .hasInvocationCostGreaterThanOrEqualTo(1) // Includes static constructor calls for java.lang.Math, etc.
+            .hasJumpCostGreaterThanOrEqualTo(30 * 2 + 1)
     }
 
     @Test
@@ -51,9 +51,9 @@ class ClassRewriterTest : TestBase(KOTLIN) {
             callable.createAndInvoke()
         }.withMessageContaining("terminated due to excessive use of looping")
         assertThat(runtimeCosts)
-                .hasAllocationCost(0)
-                .hasInvocationCost(1)
-                .hasJumpCost(1)
+            .hasAllocationCost(0)
+            .hasInvocationCost(1)
+            .hasJumpCost(1)
     }
 
     @Test
@@ -66,36 +66,36 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     @Test
     fun `can load a Java API that still exists in Java runtime`() = sandbox(DEFAULT) {
         assertThat(loadClass<MutableList<*>>())
-                .hasClassName("sandbox.java.util.List")
-                .hasBeenModified()
+            .hasClassName("sandbox.java.util.List")
+            .hasBeenModified()
     }
 
     @Test
     fun `cannot load a Java API that was deleted from Java runtime`() = sandbox(DEFAULT) {
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
-                .isThrownBy { loadClass<Paths>() }
-                .withMessageContaining("Class file not found: java/nio/file/Paths.class")
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
+            .isThrownBy { loadClass<Paths>() }
+            .withMessageContaining("Class file not found: java/nio/file/Paths.class")
     }
 
     @Test
     fun `load internal Sun class that still exists in Java runtime`() = sandbox(DEFAULT) {
         assertThat(loadClass<sun.misc.Unsafe>())
-                .hasClassName("sandbox.sun.misc.Unsafe")
-                .hasBeenModified()
+            .hasClassName("sandbox.sun.misc.Unsafe")
+            .hasBeenModified()
     }
 
     @Test
     fun `cannot load internal Sun class that was deleted from Java runtime`() = sandbox(DEFAULT) {
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
-                .isThrownBy { loadClass<sun.misc.Timer>() }
-                .withMessageContaining("Class file not found: sun/misc/Timer.class")
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
+            .isThrownBy { loadClass<sun.misc.Timer>() }
+            .withMessageContaining("Class file not found: sun/misc/Timer.class")
     }
 
     @Test
     fun `can load local class`() = sandbox(DEFAULT) {
         assertThat(loadClass<Example>())
-                .hasClassName("sandbox.net.corda.djvm.rewiring.ClassRewriterTest\$Example")
-                .hasBeenModified()
+            .hasClassName("sandbox.net.corda.djvm.rewiring.ClassRewriterTest\$Example")
+            .hasBeenModified()
     }
 
     class Example : java.util.function.Function<Int, Int> {
@@ -107,31 +107,31 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     @Test
     fun `can load class with constant fields`() = sandbox(DEFAULT) {
         assertThat(loadClass<ObjectWithConstants>())
-                .hasClassName("sandbox.net.corda.djvm.rewiring.ObjectWithConstants")
-                .hasBeenModified()
+            .hasClassName("sandbox.net.corda.djvm.rewiring.ObjectWithConstants")
+            .hasBeenModified()
     }
 
     @Test
     fun `test rewrite static method`() = sandbox(DEFAULT) {
         assertThat(loadClass<Arrays>())
-                .hasClassName("sandbox.java.util.Arrays")
-                .hasBeenModified()
+            .hasClassName("sandbox.java.util.Arrays")
+            .hasBeenModified()
     }
 
     @Test
     fun `test stitch new super-interface`() = sandbox(DEFAULT) {
         assertThat(loadClass<CharSequence>())
-                .hasClassName("sandbox.java.lang.CharSequence")
-                .hasInterface("java.lang.CharSequence")
-                .hasBeenModified()
+            .hasClassName("sandbox.java.lang.CharSequence")
+            .hasInterface("java.lang.CharSequence")
+            .hasBeenModified()
     }
 
     @Test
     fun `test class with stitched interface`() = sandbox(DEFAULT) {
         assertThat(loadClass<StringBuilder>())
-                .hasClassName("sandbox.java.lang.StringBuilder")
-                .hasInterface("sandbox.java.lang.CharSequence")
-                .hasBeenModified()
+            .hasClassName("sandbox.java.lang.StringBuilder")
+            .hasInterface("sandbox.java.lang.CharSequence")
+            .hasBeenModified()
     }
 
     @Test
@@ -143,27 +143,27 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     @Test
     fun `test user class is owned by new classloader`() = parentedSandbox {
         assertThat(loadClass<Empty>())
-                .hasClassLoader(classLoader)
-                .hasBeenModified()
+            .hasClassLoader(classLoader)
+            .hasBeenModified()
     }
 
     @Test
     fun `test template class is owned by parent classloader`() = parentedSandbox {
         assertThat(classLoader.loadForSandbox("sandbox.java.lang.DJVM"))
-                .hasClassLoader(parentClassLoader)
-                .hasNotBeenModified()
+            .hasClassLoader(parentClassLoader)
+            .hasNotBeenModified()
     }
 
     @Test
     fun `test rule violation error cannot be loaded`() = parentedSandbox {
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { loadClass<RuleViolationError>() }
             .withMessageContaining("Class file not found: net/corda/djvm/rules/RuleViolationError.class")
     }
 
     @Test
     fun `test threshold violation error cannot be loaded`() = parentedSandbox {
-        assertThatExceptionOfType(SandboxClassLoadingException::class.java)
+        assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { loadClass<ThresholdViolationError>() }
             .withMessageContaining("Class file not found: net/corda/djvm/costing/ThresholdViolationError.class")
     }

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/DeserializeKotlinAliasTest.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/DeserializeKotlinAliasTest.kt
@@ -1,0 +1,69 @@
+package net.corda.djvm.serialization
+
+import net.corda.core.crypto.SecureHash
+import net.corda.core.node.services.AttachmentId
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.serialization.internal._contextSerializationEnv
+import net.corda.core.serialization.serialize
+import net.corda.djvm.serialization.SandboxType.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.fail
+import java.util.function.Function
+
+@ExtendWith(LocalSerialization::class)
+class DeserializeKotlinAliasTest : TestBase(KOTLIN) {
+    @Test
+    fun `test deserializing kotlin alias`() {
+        val attachmentId = SecureHash.allOnesHash
+        val data = attachmentId.serialize()
+
+        sandbox {
+            _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+
+            val sandboxAttachmentId = data.deserializeFor(classLoader)
+
+            val taskFactory = classLoader.createRawTaskFactory()
+            val showAlias = classLoader.createTaskFor(taskFactory, ShowAlias::class.java)
+            val result = showAlias.apply(sandboxAttachmentId) ?: fail("Result cannot be null")
+
+            assertEquals(ShowAlias().apply(attachmentId), result.toString())
+            assertEquals(SANDBOX_STRING, result::class.java.name)
+        }
+    }
+
+    class ShowAlias : Function<AttachmentId, String> {
+        override fun apply(id: AttachmentId): String {
+            return id.toString()
+        }
+    }
+
+    @Test
+    fun `test deserializing data with kotlin alias`() {
+        val attachment = AttachmentData(SecureHash.allOnesHash)
+        val data = attachment.serialize()
+
+        sandbox {
+            _contextSerializationEnv.set(createSandboxSerializationEnv(classLoader))
+
+            val sandboxAttachment = data.deserializeFor(classLoader)
+
+            val taskFactory = classLoader.createRawTaskFactory()
+            val showAliasData = classLoader.createTaskFor(taskFactory, ShowAliasData::class.java)
+            val result = showAliasData.apply(sandboxAttachment) ?: fail("Result cannot be null")
+
+            assertEquals(ShowAliasData().apply(attachment), result.toString())
+            assertEquals(SANDBOX_STRING, result::class.java.name)
+        }
+    }
+
+    class ShowAliasData: Function<AttachmentData, String> {
+        override fun apply(data: AttachmentData): String {
+            return data.toString()
+        }
+    }
+}
+
+@CordaSerializable
+data class AttachmentData(val id: AttachmentId)


### PR DESCRIPTION
ClassLoader.loadClass() needs to throw `ClassNotFoundException` for all cases where a class cannot be found. Throwing `SandboxClassLoadingException` in some cases is not good enough.

This fixes Kotlin's handling ot `typealias` inside the sandbox.