### PR TITLE
CORDA-2871: Handle TypeNotPresentException

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -393,7 +393,7 @@ class SandboxClassLoader private constructor(
                 rewriter.rewrite(reader, context)
             } catch (e: TypeNotPresentException) {
                 // Ensure that a missing class results in a ClassNotFoundException.
-                throw ClassNotFoundException(e.typeName())
+                throw ClassNotFoundException(e.typeName(), e)
             }
         }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -389,7 +389,12 @@ class SandboxClassLoader private constructor(
             }
 
             // Transform the class definition and byte code in accordance with provided rules.
-            rewriter.rewrite(reader, context)
+            try {
+                rewriter.rewrite(reader, context)
+            } catch (e: TypeNotPresentException) {
+                // Ensure that a missing class results in a ClassNotFoundException.
+                throw ClassNotFoundException(e.typeName())
+            }
         }
 
         // Try to define the transformed class.


### PR DESCRIPTION
`SandboxClassWriter.getCommonSuperClass()` can throw `TypeNotPresentException` in some circumstances. Convert this into `ClassNotFoundException` to preserve behaviour of `ClassLoader.loadClass().`