### PR TITLE
CORDA-3218: Align DJVM with internal Corda Serialisation API.

### DIFF
--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -25,7 +25,7 @@ allprojects {
         }
     }
 
-    configurations{
+    configurations {
         // This is for the latest deterministic Corda SNAPSHOT artifacts...
         [ compileClasspath, runtimeClasspath ].forEach { cfg ->
             cfg.resolutionStrategy {
@@ -37,6 +37,11 @@ allprojects {
                     substitute module("net.corda:corda-serialization") with module("net.corda:corda-serialization-deterministic:$corda_version")
                 }
             }
+        }
+
+        testRuntimeClasspath.resolutionStrategy {
+            // Always check the repository for a newer SNAPSHOT.
+            cacheChangingModulesFor 0, 'seconds'
         }
     }
 

--- a/serialization/src/main/kotlin/net/corda/djvm/serialization/SandboxSerializerFactoryFactory.kt
+++ b/serialization/src/main/kotlin/net/corda/djvm/serialization/SandboxSerializerFactoryFactory.kt
@@ -14,6 +14,7 @@ import java.util.*
 import java.util.Collections.singleton
 import java.util.Collections.unmodifiableMap
 import java.util.function.Function
+import java.util.function.Predicate
 
 /**
  * This has all been lovingly copied from [SerializerFactoryBuilder].
@@ -60,6 +61,7 @@ class SandboxSerializerFactoryFactory(
             classloader = classLoader,
             descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry,
             primitiveSerializerFactory = primitiveSerializerFactory,
+            isPrimitiveType = Predicate { clazz -> clazz.isPrimitive || clazz in primitiveTypes.keys },
             customSerializerRegistry = customSerializerRegistry,
             onlyCustomSerializers = false
         )


### PR DESCRIPTION
Allow the DJVM to tell the Deserialiser which types are "primitive", and so should not be added to the object history.