### PR TITLE
CORDA-3137: Only preserve annotations that we know we can handle.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -41,6 +41,11 @@ configurations {
             }
         }
     }
+
+    testRuntimeClasspath.resolutionStrategy {
+        // Always check the repository for a newer SNAPSHOT.
+        cacheChangingModulesFor 0, 'seconds'
+    }
 }
 
 dependencies {

--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -1,6 +1,6 @@
-kotlin.incremental=true
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
+kotlin.incremental=true
 
 djvm_version=5.0-SNAPSHOT
 corda_version=4.3-SNAPSHOT

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -48,6 +48,7 @@ class AnalysisConfiguration private constructor(
         val parent: AnalysisConfiguration?,
         val whitelist: Whitelist,
         val pinnedClasses: Set<String>,
+        val mappedAnnotations: Set<String>,
         val stitchedAnnotations: Set<String>,
         val classResolver: ClassResolver,
         val exceptionResolver: ExceptionResolver,
@@ -87,7 +88,8 @@ class AnalysisConfiguration private constructor(
             parent = this,
             whitelist = whitelist,
             pinnedClasses = pinnedClasses,
-            stitchedAnnotations = stitchedAnnotations.merge(visibleAnnotations),
+            mappedAnnotations = mappedAnnotations.merge(visibleAnnotations),
+            stitchedAnnotations = stitchedAnnotations.mergeSandboxed(visibleAnnotations),
             classResolver = classResolver,
             exceptionResolver = exceptionResolver,
             minimumSeverityLevel = newMinimumSeverityLevel ?: minimumSeverityLevel,
@@ -106,6 +108,9 @@ class AnalysisConfiguration private constructor(
     fun isJvmException(className: String): Boolean = className in JVM_EXCEPTIONS
     fun isSandboxClass(className: String): Boolean = className.startsWith(SANDBOX_PREFIX) && !isPinnedClass(className)
 
+    fun isUnmappedAnnotation(descriptor: String): Boolean = descriptor in UNMAPPED_ANNOTATIONS
+    fun isMappedAnnotation(descriptor: String): Boolean = descriptor in mappedAnnotations
+
     fun toSandboxClassName(type: Class<*>): String {
         val sandboxName = classResolver.resolve(Type.getInternalName(type))
         return if (Throwable::class.java.isAssignableFrom(type)) {
@@ -122,12 +127,21 @@ class AnalysisConfiguration private constructor(
         const val SANDBOX_PREFIX: String = "sandbox/"
 
         /**
+         * The unsandboxed descriptor for Kotlin's [Metadata] annotation.
+         */
+        const val KOTLIN_METADATA = "Lkotlin/Metadata;"
+
+        /**
          * These meta-annotations configure how the JVM handles annotations,
          * and these need to be preserved. Currently handling Kotlin's "magic"
          * [Metadata] annotation by default.
          */
         private val STITCHED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
             "Lsandbox/kotlin/Metadata;"
+        ))
+
+        private val MAPPED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
+            KOTLIN_METADATA
         ))
 
         /**
@@ -144,10 +158,6 @@ class AnalysisConfiguration private constructor(
             "Ljava/lang/annotation/Retention;",
             "Ljava/lang/annotation/Target;"
         ))
-
-        fun isUnmappedAnnotation(descriptor: String): Boolean {
-            return descriptor in UNMAPPED_ANNOTATIONS
-        }
 
         /**
          * These classes will be duplicated into every sandbox's
@@ -547,13 +557,22 @@ class AnalysisConfiguration private constructor(
         fun sandboxed(clazz: Class<*>): String = (SANDBOX_PREFIX + Type.getInternalName(clazz)).intern()
         fun Set<Class<*>>.sandboxed(): Set<String> = map(Companion::sandboxed).toSet()
 
-        private fun sandboxDescriptor(clazz: Class<*>): String = "L$SANDBOX_PREFIX${Type.getInternalName(clazz)};"
+        private fun toSandboxDescriptor(clazz: Class<*>): String = "L$SANDBOX_PREFIX${Type.getInternalName(clazz)};"
+        private fun toDescriptor(clazz: Class<*>): String = "L${Type.getInternalName(clazz)};"
+
+        private fun Set<String>.mergeSandboxed(extra: Collection<Class<out Annotation>>): Set<String> {
+            return merge(extra, ::toSandboxDescriptor)
+        }
 
         private fun Set<String>.merge(extra: Collection<Class<out Annotation>>): Set<String> {
+            return merge(extra, ::toDescriptor)
+        }
+
+        private fun Set<String>.merge(extra: Collection<Class<out Annotation>>, mapping: (Class<*>) -> String): Set<String> {
             return if (extra.isEmpty()) {
                 this
             } else {
-                unmodifiable(this + extra.map(::sandboxDescriptor))
+                unmodifiable(this + extra.map(mapping))
             }
         }
 
@@ -612,7 +631,8 @@ class AnalysisConfiguration private constructor(
                 parent = null,
                 whitelist = actualWhitelist,
                 pinnedClasses = actualPinnedClasses,
-                stitchedAnnotations = STITCHED_ANNOTATIONS.merge(visibleAnnotations),
+                mappedAnnotations = MAPPED_ANNOTATIONS.merge(visibleAnnotations),
+                stitchedAnnotations = STITCHED_ANNOTATIONS.mergeSandboxed(visibleAnnotations),
                 classResolver = classResolver,
                 exceptionResolver = ExceptionResolver(JVM_EXCEPTIONS, actualPinnedClasses, SANDBOX_PREFIX),
                 minimumSeverityLevel = minimumSeverityLevel,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -123,13 +123,31 @@ class AnalysisConfiguration private constructor(
 
         /**
          * These meta-annotations configure how the JVM handles annotations,
-         * and these need to be preserved. Currently handling meta-annotations
-         * that have an [Enum] value, and Kotlin's "magic" [Metadata] annotation.
+         * and these need to be preserved. Currently handling Kotlin's "magic"
+         * [Metadata] annotation by default.
          */
-        private val STITCHED_ANNOTATIONS: Set<String> = setOf("Lsandbox/kotlin/Metadata;").merge(setOf(
-            java.lang.annotation.Retention::class.java,
-            java.lang.annotation.Target::class.java
+        private val STITCHED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
+            "Lsandbox/kotlin/Metadata;"
         ))
+
+        /**
+         * These annotations cannot be mapped into the sandbox, e.g.
+         * because they have a method with an [Enum] value that the
+         * JVM cannot assign.
+         *
+         * Not mapping an annotation leaves the original annotation
+         * in place without also applying its sandboxed equivalent.
+         */
+        private val UNMAPPED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
+            "Lkotlin/annotation/Retention;",
+            "Lkotlin/annotation/Target;",
+            "Ljava/lang/annotation/Retention;",
+            "Ljava/lang/annotation/Target;"
+        ))
+
+        fun isUnmappedAnnotation(descriptor: String): Boolean {
+            return descriptor in UNMAPPED_ANNOTATIONS
+        }
 
         /**
          * These classes will be duplicated into every sandbox's

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
@@ -35,16 +35,20 @@ class SandboxClassRemapper(
         super.visit(version, access, name, signature, superName, interfaces)
     }
 
-    /**
-     * Remap all of the descriptors within Kotlin's [Metadata] annotation.
-     * THIS ASSUMES THAT WE WILL NEVER WHITELIST KOTLIN CLASSES!!
-     */
     override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
-        return super.visitAnnotation(descriptor, visible)?.let {
-            if (descriptor == KOTLIN_METADATA) {
-                KotlinMetadataVisitor(api, it, remapper)
-            } else {
-                it
+        return if (AnalysisConfiguration.isUnmappedAnnotation(descriptor)) {
+            nonClassMapper.visitAnnotation(descriptor, visible)
+        } else {
+            super.visitAnnotation(descriptor, visible)?.let {
+                /**
+                 * Remap all of the descriptors within Kotlin's [Metadata] annotation.
+                 * THIS ASSUMES THAT WE WILL NEVER WHITELIST KOTLIN CLASSES!!
+                 */
+                if (descriptor == KOTLIN_METADATA) {
+                    KotlinMetadataVisitor(api, it, remapper)
+                } else {
+                    it
+                }
             }
         }
     }

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static net.corda.djvm.SandboxType.JAVA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,7 @@ class AnnotatedJavaClassTest extends TestBase {
     void testSandboxAnnotation() {
         assertThat(UserJavaData.class.getAnnotation(JavaAnnotation.class)).isNotNull();
 
-        parentedSandbox(ctx -> {
+        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 @SuppressWarnings("unchecked")
@@ -43,7 +44,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testAnnotationInsideSandbox() {
-        parentedSandbox(ctx -> {
+        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
             try {
                 SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
                 ExecutionSummaryWithResult<String> success = WithJava.run(executor, ReadAnnotation.class, null);
@@ -58,7 +59,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testReflectionCanFetchAllAnnotations() {
-        parentedSandbox(ctx -> {
+        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 Annotation[] annotations = sandboxClass.getAnnotations();
@@ -66,7 +67,8 @@ class AnnotatedJavaClassTest extends TestBase {
                     .map(ann -> ann.annotationType().getName())
                     .collect(toList());
                 assertThat(names).containsExactlyInAnyOrder(
-                    "sandbox.net.corda.djvm.JavaAnnotation"
+                    "sandbox.net.corda.djvm.JavaAnnotation",
+                    "net.corda.djvm.JavaAnnotation"
                 );
             } catch (Exception e) {
                 fail(e);

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
@@ -94,6 +94,54 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
         assertEquals("sandbox.${UserKotlinData::class.java.name}", sandboxData::class.java.name)
         assertEquals("UserData: message='Sandbox Magic!', number=123, bigNumber=999", sandboxData.toString())
     }
+
+    @Test
+    fun `test reflection can fetch all annotations`() = parentedSandbox {
+        val sandboxClass = loadClass<UserKotlinData>().type
+        val kotlinAnnotations = sandboxClass.kotlin.annotations.map { ann ->
+            ann.annotationClass.qualifiedName
+        }
+        assertThat(kotlinAnnotations).containsExactlyInAnyOrder(
+            "sandbox.net.corda.djvm.KotlinAnnotation",
+            "sandbox.kotlin.Metadata"
+        )
+
+        val javaAnnotations = sandboxClass.annotations.map { ann ->
+            ann.annotationClass.qualifiedName
+        }
+        assertThat(javaAnnotations).containsExactlyInAnyOrder(
+            "sandbox.net.corda.djvm.KotlinAnnotation",
+            "sandbox.kotlin.Metadata",
+            "kotlin.Metadata"
+        )
+    }
+
+    @Test
+    fun `test reflection can fetch all meta-annotations`() = parentedSandbox {
+        @Suppress("unchecked_cast")
+        val sandboxAnnotation = loadClass<KotlinAnnotation>().type as Class<out Annotation>
+
+        val kotlinAnnotations = sandboxAnnotation.kotlin.annotations.map { ann ->
+            ann.annotationClass.qualifiedName
+        }
+        assertThat(kotlinAnnotations).containsExactlyInAnyOrder(
+            "kotlin.annotation.Retention",
+            "kotlin.annotation.Target",
+            "sandbox.kotlin.Metadata"
+        )
+
+        val javaAnnotations = sandboxAnnotation.annotations.map { ann ->
+            ann.annotationClass.qualifiedName
+        }
+        assertThat(javaAnnotations).containsExactlyInAnyOrder(
+            "kotlin.annotation.Retention",
+            "kotlin.annotation.Target",
+            "sandbox.kotlin.Metadata",
+            "kotlin.Metadata",
+            "java.lang.annotation.Retention",
+            "java.lang.annotation.Target"
+        )
+    }
 }
 
 @KotlinAnnotation("Hello Kotlin!")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
@@ -18,7 +18,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     private val kotlinMetadata: Class<out Annotation> = Class.forName("kotlin.Metadata") as Class<out Annotation>
 
     @Test
-    fun testSandboxAnnotation() = parentedSandbox {
+    fun testSandboxAnnotation() = parentedSandbox(visibleAnnotations = setOf(KotlinAnnotation::class.java)) {
         assertThat(UserKotlinData::class.findAnnotation<KotlinAnnotation>()).isNotNull
 
         @Suppress("unchecked_cast")
@@ -96,13 +96,14 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test reflection can fetch all annotations`() = parentedSandbox {
+    fun `test reflection can fetch all annotations`() = parentedSandbox(visibleAnnotations = setOf(KotlinAnnotation::class.java)) {
         val sandboxClass = loadClass<UserKotlinData>().type
         val kotlinAnnotations = sandboxClass.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName
         }
         assertThat(kotlinAnnotations).containsExactlyInAnyOrder(
             "sandbox.net.corda.djvm.KotlinAnnotation",
+            "net.corda.djvm.KotlinAnnotation",
             "sandbox.kotlin.Metadata"
         )
 
@@ -111,6 +112,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
         }
         assertThat(javaAnnotations).containsExactlyInAnyOrder(
             "sandbox.net.corda.djvm.KotlinAnnotation",
+            "net.corda.djvm.KotlinAnnotation",
             "sandbox.kotlin.Metadata",
             "kotlin.Metadata"
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-kotlin.incremental=true
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
+kotlin.incremental=true
 
 corda_djvm_version=5.0-SNAPSHOT
 


### PR DESCRIPTION
We cannot map any annotation that has an `Enum` method with a `default` value into the sandbox, because the JVM would try (and fail) to assign `Enum` to `sandbox.Enum` when asked to parse it.

The JPA annotations such as `@OneToMany` and `@ManyToMany` are examples of this, c.f. `FetchType`.