### PR TITLE
CORDA-3137: Allow the sandbox to handle annotations that match given patterns.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -19,6 +19,9 @@ repositories {
     maven {
         url "$artifactory_contextUrl/corda-lib"
     }
+    maven {
+        url "$artifactory_contextUrl/corda-dependencies"
+    }
     mavenCentral()
 }
 

--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -78,16 +78,21 @@ abstract class TestBase(type: SandboxType) {
     }
 
     fun sandbox(action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, emptySet(), false, action)
+        return sandbox(WARNING, emptySet(), emptySet(), false, action)
+    }
+
+    fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, sandboxOnlyAnnotations: Set<String>, action: SandboxRuntimeContext.() -> Unit) {
+        return sandbox(WARNING, visibleAnnotations, sandboxOnlyAnnotations, false, action)
     }
 
     fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, visibleAnnotations, false, action)
+        return sandbox(WARNING, visibleAnnotations, emptySet(), false, action)
     }
 
     fun sandbox(
         minimumSeverityLevel: Severity,
         visibleAnnotations: Set<Class<out Annotation>>,
+        sandboxOnlyAnnotations: Set<String>,
         enableTracing: Boolean,
         action: SandboxRuntimeContext.() -> Unit
     ) {
@@ -98,7 +103,8 @@ abstract class TestBase(type: SandboxType) {
                     val analysisConfiguration = configuration.analysisConfiguration.createChild(
                         userSource = userSource,
                         newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations
+                        visibleAnnotations = visibleAnnotations,
+                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
                     )
                     SandboxRuntimeContext(SandboxConfiguration.of(
                         configuration.executionProfile,

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static net.corda.djvm.SandboxType.JAVA;
@@ -25,7 +26,7 @@ class AnnotatedJavaClassTest extends TestBase {
     void testSandboxAnnotation() {
         assertThat(UserJavaData.class.getAnnotation(JavaAnnotation.class)).isNotNull();
 
-        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
+        parentedSandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 @SuppressWarnings("unchecked")
@@ -44,7 +45,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testAnnotationInsideSandbox() {
-        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
+        parentedSandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
             try {
                 SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
                 ExecutionSummaryWithResult<String> success = WithJava.run(executor, ReadAnnotation.class, null);
@@ -58,7 +59,26 @@ class AnnotatedJavaClassTest extends TestBase {
     }
 
     @Test
-    void testReflectionCanFetchAllAnnotations() {
+    void testReflectionCanFetchAllSandboxedAnnotations() {
+        parentedSandbox(emptySet(), singleton("net.corda.djvm.**"), ctx -> {
+            try {
+                Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
+                Annotation[] annotations = sandboxClass.getAnnotations();
+                List<String> names = Arrays.stream(annotations)
+                    .map(ann -> ann.annotationType().getName())
+                    .collect(toList());
+                assertThat(names).containsExactlyInAnyOrder(
+                    "sandbox.net.corda.djvm.JavaAnnotation"
+                );
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    @Test
+    void testReflectionCanFetchAllStitchedAnnotations() {
         parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
@@ -25,7 +25,7 @@ class SandboxExecutorJavaTest extends TestBase {
         //TODO: Transaction should not be a pinned class! It needs
         //      to be marshalled into and out of the sandbox.
         Set<Class<?>> pinnedClasses = singleton(Transaction.class);
-        sandbox(new Object[0], pinnedClasses, emptySet(), WARNING, true, ctx -> {
+        sandbox(new Object[0], pinnedClasses, emptySet(), emptySet(), WARNING, true, ctx -> {
             SandboxExecutor<Transaction, Void> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Transaction tx = new Transaction(TX_ID);
             assertThatExceptionOfType(IllegalArgumentException.class)

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -107,7 +107,7 @@ class SandboxThrowableJavaTest extends TestBase {
     @Test
     void testMultiCatchWithDisallowedExceptions() {
         Set<Class<?>> pinnedClasses = singleton(Utilities.class);
-        sandbox(new Object[0], pinnedClasses, emptySet(), WARNING, true, ctx -> {
+        sandbox(new Object[0], pinnedClasses, emptySet(), emptySet(), WARNING, true, ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -186,6 +186,7 @@ abstract class TestBase(type: SandboxType) {
         vararg options: Any,
         pinnedClasses: Set<Class<*>> = emptySet(),
         visibleAnnotations: Set<Class<out Annotation>> = emptySet(),
+        sandboxOnlyAnnotations: Set<String> = emptySet(),
         minimumSeverityLevel: Severity = WARNING,
         enableTracing: Boolean = true,
         action: SandboxRuntimeContext.() -> Unit
@@ -221,6 +222,7 @@ abstract class TestBase(type: SandboxType) {
                         whitelist = whitelist,
                         pinnedClasses = pinnedTestClasses,
                         visibleAnnotations = visibleAnnotations,
+                        sandboxOnlyAnnotations = sandboxOnlyAnnotations,
                         minimumSeverityLevel = minimumSeverityLevel,
                         bootstrapSource = bootstrapClassLoader
                     )
@@ -244,14 +246,18 @@ abstract class TestBase(type: SandboxType) {
     }
 
     fun parentedSandbox(visibleAnnotations: Set<Class<out Annotation>>, action: SandboxRuntimeContext.() -> Unit)
-            = parentedSandbox(WARNING, visibleAnnotations, true, action)
+            = parentedSandbox(WARNING, visibleAnnotations, emptySet(), true, action)
+
+    fun parentedSandbox(visibleAnnotations: Set<Class<out Annotation>>, sandboxOnlyAnnotations: Set<String>, action: SandboxRuntimeContext.() -> Unit)
+            = parentedSandbox(WARNING, visibleAnnotations, sandboxOnlyAnnotations, true, action)
 
     fun parentedSandbox(action: SandboxRuntimeContext.() -> Unit)
-            = parentedSandbox(WARNING, emptySet(), true, action)
+            = parentedSandbox(WARNING, emptySet(), emptySet(), true, action)
 
     fun parentedSandbox(
         minimumSeverityLevel: Severity,
         visibleAnnotations: Set<Class<out Annotation>>,
+        sandboxOnlyAnnotations: Set<String>,
         enableTracing: Boolean,
         action: SandboxRuntimeContext.() -> Unit
     ) {
@@ -262,7 +268,8 @@ abstract class TestBase(type: SandboxType) {
                     val analysisConfiguration = parentConfiguration.analysisConfiguration.createChild(
                         userSource = userSource,
                         newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations
+                        visibleAnnotations = visibleAnnotations,
+                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
                     )
                     SandboxRuntimeContext(SandboxConfiguration.of(
                         parentConfiguration.executionProfile,

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -23,6 +23,9 @@ allprojects {
         maven {
             url "$artifactory_contextUrl/corda-dev"
         }
+        maven {
+            url "$artifactory_contextUrl/corda-dependencies"
+        }
     }
 
     configurations {

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
@@ -81,16 +81,21 @@ abstract class TestBase(type: SandboxType) {
     }
 
     fun sandbox(action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, emptySet(), false, action)
+        return sandbox(WARNING, emptySet(), emptySet(), false, action)
     }
 
     fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, visibleAnnotations, false, action)
+        return sandbox(WARNING, visibleAnnotations, emptySet(), false, action)
+    }
+
+    fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, sandboxOnlyAnnotations: Set<String>, action: SandboxRuntimeContext.() -> Unit) {
+        return sandbox(WARNING, visibleAnnotations, sandboxOnlyAnnotations, false, action)
     }
 
     fun sandbox(
         minimumSeverityLevel: Severity,
         visibleAnnotations: Set<Class<out Annotation>>,
+        sandboxOnlyAnnotations: Set<String>,
         enableTracing: Boolean,
         action: SandboxRuntimeContext.() -> Unit
     ) {
@@ -101,7 +106,8 @@ abstract class TestBase(type: SandboxType) {
                     val analysisConfiguration = configuration.analysisConfiguration.createChild(
                         userSource = userSource,
                         newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations
+                        visibleAnnotations = visibleAnnotations,
+                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
                     )
                     SandboxRuntimeContext(SandboxConfiguration.of(
                         configuration.executionProfile,


### PR DESCRIPTION
Not every annotation needs to be stitched back into the unsandboxed package space. Allow us to configure the sandbox to accept globs of "safe" annotation classes. By "safe", I mean ones that do not have any `Enum` values.