### PR TITLE
CORDA-2871: Remove pinned classes from AnalysisConfiguration.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMThrowableWrapper.java
@@ -3,7 +3,7 @@ package sandbox.java.lang;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Pinned exceptions inherit from {@link java.lang.Throwable}, but we
+ * DJVM exceptions inherit from {@link java.lang.Throwable}, but we
  * still need to be able to pass them through the sandbox's
  * exception handlers. In which case we will wrap them inside
  * one of these.

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -131,8 +131,7 @@ open class ClassAndMemberVisitor(
      * Check if a class should be processed or not.
      */
     protected fun shouldClassBeProcessed(className: String): Boolean {
-        return !configuration.whitelist.inNamespace(className) &&
-                !configuration.isPinnedClass(className)
+        return !configuration.whitelist.inNamespace(className)
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ExceptionResolver.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ExceptionResolver.kt
@@ -4,7 +4,6 @@ import org.objectweb.asm.Type
 
 class ExceptionResolver(
     private val jvmExceptionClasses: Set<String>,
-    private val pinnedClasses: Set<String>,
     private val sandboxPrefix: String
 ) {
     companion object {
@@ -26,8 +25,6 @@ class ExceptionResolver(
     fun getThrowableOwnerName(className: String): String {
         return if (className in jvmExceptionClasses) {
             className.unsandboxed
-        } else if (className in pinnedClasses) {
-            className
         } else {
             getDJVMException(className)
         }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
@@ -121,7 +121,7 @@ open class Whitelist private constructor(
         val EMPTY: Whitelist = Whitelist(null, emptySet(), emptySet())
 
         /**
-         * The minimum set of classes that needs to be pinned from standard Java libraries.
+         * The minimum set of classes that needs to be whitelisted from standard Java libraries.
          */
         val MINIMAL: Whitelist = Whitelist(Whitelist(null, minimumSet, emptySet()), minimumSet, emptySet())
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -326,7 +326,7 @@ class SandboxClassLoader private constructor(
         } else {
             loadClassAndBytes(source, context).also { clazz ->
                 /**
-                 * Check whether we've just loaded an unpinned sandboxed throwable class.
+                 * Check whether we've just loaded a sandboxed throwable class.
                  * If we have, we may also need to synthesise a throwable wrapper for it.
                  */
                 if (throwableClass.isAssignableFrom(clazz) && !analysisConfiguration.isJvmException(source.internalClassName)) {
@@ -350,11 +350,6 @@ class SandboxClassLoader private constructor(
         val requestedPath = request.internalClassName
         val sourceName = analysisConfiguration.classResolver.reverseNormalized(request.qualifiedClassName)
         val resolvedName = analysisConfiguration.classResolver.resolveNormalized(sourceName)
-
-        if (analysisConfiguration.isPinnedClass(requestedPath)) {
-            logger.error("Class {} should not be loaded here", request.qualifiedClassName)
-            throw SandboxClassLoadingException("Refusing to load pinned ${request.qualifiedClassName}", context)
-        }
 
         val byteCode = if (analysisConfiguration.isTemplateClass(requestedPath)) {
             loadUnmodifiedByteCode(requestedPath)

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
@@ -79,19 +79,19 @@ class SandboxClassRemapper(
     }
 
     override fun createMethodRemapper(mv: MethodVisitor): MethodVisitor {
-        return MethodRemapperWithPinning(mv, super.createMethodRemapper(mv))
+        return MethodRemapperWithTemplating(mv, super.createMethodRemapper(mv))
     }
 
     /**
-     * Do not attempt to remap references to methods and fields on pinned classes.
+     * Do not attempt to remap references to methods and fields on templated classes.
      * For example, the methods on [sandbox.RuntimeCostAccounter] really DO use
      * [java.lang.String] rather than [sandbox.java.lang.String].
      */
-    private inner class MethodRemapperWithPinning(private val nonMethodMapper: MethodVisitor, remapper: MethodVisitor)
+    private inner class MethodRemapperWithTemplating(private val nonMethodMapper: MethodVisitor, remapper: MethodVisitor)
         : MethodVisitor(API_VERSION, remapper) {
 
         private fun mapperFor(element: Element): MethodVisitor {
-            return if (configuration.isPinnedClass(element.className) || configuration.isTemplateClass(element.className) || isUnmapped(element)) {
+            return if (configuration.isTemplateClass(element.className) || isUnmapped(element)) {
                 nonMethodMapper
             } else {
                 mv

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxRemapper.kt
@@ -45,7 +45,7 @@ open class SandboxRemapper(
      * All [Object.toString] methods must be transformed to [sandbox.java.lang.Object.toDJVMString],
      * to allow the return type to change to [sandbox.java.lang.String].
      *
-     * The [sandbox.java.lang.Object] class is pinned and not mapped.
+     * The [sandbox.java.lang.Object] class is a template and not mapped.
      */
     override fun mapMethodName(owner: String, name: String, descriptor: String): String {
         val newName = if (name == "toString" && descriptor == "()Ljava/lang/String;") {

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowNonDeterministicMethods.kt
@@ -5,7 +5,7 @@ import net.corda.djvm.code.instructions.MemberAccessInstruction
 import org.objectweb.asm.Opcodes.*
 
 /**
- * Some non-deterministic APIs belong to pinned classes and so cannot be stubbed out.
+ * Some non-deterministic APIs belong to whitelisted classes and so cannot be stubbed out.
  * Replace their invocations with safe alternatives, e.g. throwing an exception.
  */
 object DisallowNonDeterministicMethods : Emitter {

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
@@ -6,7 +6,7 @@ import net.corda.djvm.references.Member
 import org.objectweb.asm.Opcodes.*
 
 /**
- * Replace reflection APIs with stubs that throw exceptions. Only for unpinned classes.
+ * Replace reflection APIs with stubs that throw exceptions. Only for non-whitelisted classes.
  */
 object StubOutReflectionMethods : MemberDefinitionProvider {
     private val ALLOWS_REFLECTION: Set<String> = setOf(

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -297,7 +297,7 @@ fun getClassLoader(type: Class<*>): ClassLoader {
     /**
      * We expect [Class.getClassLoader] to return one of the following:
      * - [net.corda.djvm.rewiring.SandboxClassLoader] for sandbox classes
-     * - the application class loader for pinned classes
+     * - the application class loader for whitelisted classes
      * - null for basic Java classes.
      *
      * So "don't do that". Always return the sandbox classloader instead.

--- a/djvm/src/test/java/net/corda/djvm/Utilities.java
+++ b/djvm/src/test/java/net/corda/djvm/Utilities.java
@@ -4,7 +4,7 @@ import net.corda.djvm.costing.ThresholdViolationError;
 import net.corda.djvm.rules.RuleViolationError;
 
 /**
- * Pin this {@link Utilities} class inside the sandbox to allow
+ * Whitelist this {@link Utilities} class inside the sandbox to allow
  * tests to invoke these functions.
  */
 public final class Utilities {

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -2,7 +2,6 @@ package net.corda.djvm.execution;
 
 import greymalkin.PureEvil;
 import net.corda.djvm.TestBase;
-import net.corda.djvm.Utilities;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rewiring.SandboxClassLoader;
 import net.corda.djvm.rules.RuleViolationError;
@@ -129,21 +128,21 @@ class MaliciousClassLoaderTest extends TestBase {
     }
 
     @Test
-    void testClassLoaderForPinnedClass() {
+    void testClassLoaderForWhitelistedClass() {
         parentedSandbox(ctx -> {
             SandboxExecutor<String, ClassLoader> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
-            ClassLoader result = WithJava.run(executor, GetPinnedClassLoader.class, "").getResult();
+            ClassLoader result = WithJava.run(executor, GetWhitelistedClassLoader.class, "").getResult();
             assertThat(result)
                 .isExactlyInstanceOf(SandboxClassLoader.class);
             return null;
         });
     }
 
-    public static class GetPinnedClassLoader implements Function<String, ClassLoader> {
+    public static class GetWhitelistedClassLoader implements Function<String, ClassLoader> {
         @Override
         public ClassLoader apply(String input) {
-            // A pinned class belongs to the application classloader.
-            return Utilities.class.getClassLoader();
+            // A whitelisted class belongs to the application classloader.
+            return ClassLoader.class.getClassLoader();
         }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -1,7 +1,6 @@
 package net.corda.djvm.execution;
 
 import net.corda.djvm.TestBase;
-import net.corda.djvm.Utilities;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rules.RuleViolationError;
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +16,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -106,8 +104,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testMultiCatchWithDisallowedExceptions() {
-        Set<Class<?>> pinnedClasses = singleton(Utilities.class);
-        sandbox(new Object[0], pinnedClasses, emptySet(), emptySet(), WARNING, true, ctx -> {
+        sandbox(new Object[0], emptySet(), emptySet(), WARNING, true, ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/ClassResolverTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/ClassResolverTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 
 class ClassResolverTest {
 
-    private val resolver = ClassResolver(emptySet(), emptySet(), Whitelist.MINIMAL, SANDBOX_PREFIX)
+    private val resolver = ClassResolver(emptySet(), Whitelist.MINIMAL, SANDBOX_PREFIX)
 
     @Test
     fun `can resolve class name`() {

--- a/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
 
 class SourceClassLoaderTest {
 
-    private val classResolver = ClassResolver(emptySet(), emptySet(), Whitelist.MINIMAL, "")
+    private val classResolver = ClassResolver(emptySet(), Whitelist.MINIMAL, "")
 
     @Test
     fun `can load class from Java's lang package when no files are provided to the class loader`() {


### PR DESCRIPTION
Pinned classes are a concept left over from the early days of the DJVM. They were only being used in a few tests, and we can replace these use-cases by extending the tests' whitelist instead.

Delete all reference to pinned classes from the DJVM, _ad good riddance!_