### PR TITLE
CORDA-2877: Load bytecode from a persistent cache to prevent repeated rewriting.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -4,16 +4,12 @@ import net.corda.core.serialization.ConstructorForDeserialization
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.djvm.SandboxConfiguration
-import net.corda.djvm.SandboxConfiguration.Companion.ALL_DEFINITION_PROVIDERS
-import net.corda.djvm.SandboxConfiguration.Companion.ALL_EMITTERS
-import net.corda.djvm.SandboxConfiguration.Companion.ALL_RULES
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.execution.ExecutionProfile.*
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.messages.Severity.*
-import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.UserPathSource
 import org.junit.jupiter.api.AfterAll
@@ -37,14 +33,13 @@ abstract class TestBase(type: SandboxType) {
                 .split(File.pathSeparator).map { Paths.get(it) }.filter { exists(it) }
 
         private lateinit var bootstrapSource: BootstrapClassLoader
-        private lateinit var configuration: SandboxConfiguration
-        private lateinit var classLoader: SandboxClassLoader
+        private lateinit var rootConfiguration: AnalysisConfiguration
 
         @BeforeAll
         @JvmStatic
         fun setupClassLoader() {
             bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
-            val rootConfiguration = AnalysisConfiguration.createRoot(
+            rootConfiguration = AnalysisConfiguration.createRoot(
                 userSource = UserPathSource(emptyList()),
                 whitelist = MINIMAL,
                 visibleAnnotations = setOf(
@@ -54,15 +49,6 @@ abstract class TestBase(type: SandboxType) {
                 ),
                 bootstrapSource = bootstrapSource
             )
-            configuration = SandboxConfiguration.of(
-                UNLIMITED,
-                ALL_RULES,
-                ALL_EMITTERS,
-                ALL_DEFINITION_PROVIDERS,
-                true,
-                rootConfiguration
-            )
-            classLoader = SandboxClassLoader.createFor(configuration)
         }
 
         @AfterAll
@@ -100,20 +86,16 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 UserPathSource(classPaths).use { userSource ->
-                    val analysisConfiguration = configuration.analysisConfiguration.createChild(
+                    val analysisConfiguration = rootConfiguration.createChild(
                         userSource = userSource,
                         newMinimumSeverityLevel = minimumSeverityLevel,
                         visibleAnnotations = visibleAnnotations,
                         sandboxOnlyAnnotations = sandboxOnlyAnnotations
                     )
-                    SandboxRuntimeContext(SandboxConfiguration.of(
-                        configuration.executionProfile,
-                        configuration.rules,
-                        configuration.emitters,
-                        configuration.definitionProviders,
-                        enableTracing,
+                    SandboxRuntimeContext(SandboxConfiguration.createFor(
                         analysisConfiguration,
-                        classLoader
+                        UNLIMITED,
+                        enableTracing
                     )).use {
                         action(this)
                     }

--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -33,13 +33,13 @@ abstract class TestBase(type: SandboxType) {
                 .split(File.pathSeparator).map { Paths.get(it) }.filter { exists(it) }
 
         private lateinit var bootstrapSource: BootstrapClassLoader
-        private lateinit var rootConfiguration: AnalysisConfiguration
+        private lateinit var parentConfiguration: SandboxConfiguration
 
         @BeforeAll
         @JvmStatic
         fun setupClassLoader() {
             bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
-            rootConfiguration = AnalysisConfiguration.createRoot(
+            val rootConfiguration = AnalysisConfiguration.createRoot(
                 userSource = UserPathSource(emptyList()),
                 whitelist = MINIMAL,
                 visibleAnnotations = setOf(
@@ -48,6 +48,11 @@ abstract class TestBase(type: SandboxType) {
                     DeprecatedConstructorForDeserialization::class.java
                 ),
                 bootstrapSource = bootstrapSource
+            )
+            parentConfiguration = SandboxConfiguration.createFor(
+                analysisConfiguration = rootConfiguration,
+                profile = UNLIMITED,
+                enableTracing = false
             )
         }
 
@@ -64,38 +69,32 @@ abstract class TestBase(type: SandboxType) {
     }
 
     fun sandbox(action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, emptySet(), emptySet(), false, action)
+        return sandbox(WARNING, emptySet(), emptySet(), action)
     }
 
     fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, sandboxOnlyAnnotations: Set<String>, action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, visibleAnnotations, sandboxOnlyAnnotations, false, action)
+        return sandbox(WARNING, visibleAnnotations, sandboxOnlyAnnotations, action)
     }
 
     fun sandbox(visibleAnnotations: Set<Class<out Annotation>>, action: SandboxRuntimeContext.() -> Unit) {
-        return sandbox(WARNING, visibleAnnotations, emptySet(), false, action)
+        return sandbox(WARNING, visibleAnnotations, emptySet(), action)
     }
 
     fun sandbox(
         minimumSeverityLevel: Severity,
         visibleAnnotations: Set<Class<out Annotation>>,
         sandboxOnlyAnnotations: Set<String>,
-        enableTracing: Boolean,
         action: SandboxRuntimeContext.() -> Unit
     ) {
         var thrownException: Throwable? = null
         thread {
             try {
                 UserPathSource(classPaths).use { userSource ->
-                    val analysisConfiguration = rootConfiguration.createChild(
+                    SandboxRuntimeContext(parentConfiguration.createChild(
                         userSource = userSource,
                         newMinimumSeverityLevel = minimumSeverityLevel,
                         visibleAnnotations = visibleAnnotations,
                         sandboxOnlyAnnotations = sandboxOnlyAnnotations
-                    )
-                    SandboxRuntimeContext(SandboxConfiguration.createFor(
-                        analysisConfiguration,
-                        UNLIMITED,
-                        enableTracing
                     )).use {
                         action(this)
                     }

--- a/djvm/src/main/java/net/corda/djvm/rewiring/ByteCodeCache.java
+++ b/djvm/src/main/java/net/corda/djvm/rewiring/ByteCodeCache.java
@@ -1,0 +1,49 @@
+package net.corda.djvm.rewiring;
+
+import net.corda.djvm.analysis.AnalysisConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * An internal cache of class byte-code, indexed by the class's internal name.
+ * It has been written in Java so that {@link #update} can be package private.
+ */
+public final class ByteCodeCache {
+    private final ConcurrentMap<String, ByteCode> byteCodeCache;
+    private final ByteCodeCache parent;
+
+    public ByteCodeCache(ByteCodeCache parent) {
+        this.byteCodeCache = new ConcurrentHashMap<>();
+        this.parent = parent;
+    }
+
+    public ByteCodeCache getParent() {
+        return parent;
+    }
+
+    public ByteCode get(String name) {
+        return byteCodeCache.get(name);
+    }
+
+    void update(@NotNull Map<String, ByteCode> loadedClasses) {
+        for (Map.Entry<String, ByteCode> entry : loadedClasses.entrySet()) {
+            byteCodeCache.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Create a chain of {@link ByteCodeCache} objects that will underlie
+     * the sandbox's chain of {@link SandboxClassLoader} objects.
+     * @param configuration An {@link AnalysisConfiguration} object.
+     * @return A chain of {@link ByteCodeCache} objects with the same length as the
+     * chain of {@link AnalysisConfiguration} objects.
+     */
+    @NotNull
+    public static ByteCodeCache createFor(@NotNull AnalysisConfiguration configuration) {
+        AnalysisConfiguration parentConfig = configuration.getParent();
+        return new ByteCodeCache(parentConfig != null ? createFor(parentConfig) : null);
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -39,14 +39,16 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
      * Run a set of actions within the provided sandbox context.
      */
     fun use(action: SandboxRuntimeContext.() -> Unit) {
-        instance = this
-        try {
-            action(this)
-        } catch (e: SandboxClassLoadingException) {
-            e.messages.acceptProvisional()
-            throw e
-        } finally {
-            threadLocalContext.remove()
+        classLoader.use {
+            instance = this
+            try {
+                action(this)
+            } catch (e: SandboxClassLoadingException) {
+                e.messages.acceptProvisional()
+                throw e
+            } finally {
+                threadLocalContext.remove()
+            }
         }
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -4,7 +4,6 @@ import net.corda.djvm.code.*
 import net.corda.djvm.formatting.MemberFormatter
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.*
-import net.corda.djvm.rewiring.ByteCode
 import net.corda.djvm.source.ApiSource
 import net.corda.djvm.source.EmptyApi
 import net.corda.djvm.source.SourceClassLoader
@@ -21,7 +20,6 @@ import java.security.SecureRandom
 import java.security.Security
 import java.util.*
 import java.util.Collections.*
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.regex.Pattern
 import javax.security.auth.x500.X500Principal
@@ -63,15 +61,6 @@ class AnalysisConfiguration private constructor(
         val supportingClassLoader: SourceClassLoader,
         private val memberFormatter: MemberFormatter
 ) {
-    private val _byteCodeCache: MutableMap<String, ByteCode> = ConcurrentHashMap()
-
-    val byteCodeCache: Map<String, ByteCode> get() = unmodifiableMap(_byteCodeCache)
-
-    internal fun updateCache(loadedClasses: Map<String, ByteCode>) {
-        loadedClasses.entries.forEach {
-            _byteCodeCache.putIfAbsent(it.key, it.value)
-        }
-    }
 
     fun formatFor(member: MemberInformation): String = memberFormatter.format(member)
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -4,6 +4,7 @@ import net.corda.djvm.code.*
 import net.corda.djvm.formatting.MemberFormatter
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.*
+import net.corda.djvm.rewiring.ByteCode
 import net.corda.djvm.source.ApiSource
 import net.corda.djvm.source.EmptyApi
 import net.corda.djvm.source.SourceClassLoader
@@ -20,6 +21,7 @@ import java.security.SecureRandom
 import java.security.Security
 import java.util.*
 import java.util.Collections.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.regex.Pattern
 import javax.security.auth.x500.X500Principal
@@ -61,6 +63,15 @@ class AnalysisConfiguration private constructor(
         val supportingClassLoader: SourceClassLoader,
         private val memberFormatter: MemberFormatter
 ) {
+    private val _byteCodeCache: MutableMap<String, ByteCode> = ConcurrentHashMap()
+
+    val byteCodeCache: Map<String, ByteCode> get() = unmodifiableMap(_byteCodeCache)
+
+    internal fun updateCache(loadedClasses: Map<String, ByteCode>) {
+        loadedClasses.entries.forEach {
+            _byteCodeCache.putIfAbsent(it.key, it.value)
+        }
+    }
 
     fun formatFor(member: MemberInformation): String = memberFormatter.format(member)
 

--- a/djvm/src/main/kotlin/net/corda/djvm/utilities/Logging.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/utilities/Logging.kt
@@ -1,3 +1,4 @@
+@file:JvmName("Logging")
 package net.corda.djvm.utilities
 
 import org.slf4j.Logger

--- a/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
+++ b/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
@@ -18,10 +18,8 @@ import net.corda.djvm.costing.RuntimeCostSummary
 
 /**
  * The field from the sandbox context which is used to keep track of the costs.
- * We cannot cache the value in a static field because we may wish to reuse
- * this class across multiple sandboxes.
  */
-private val runtimeCosts: RuntimeCostSummary get() = SandboxRuntimeContext.instance.runtimeCosts
+private val runtimeCosts: RuntimeCostSummary = SandboxRuntimeContext.instance.runtimeCosts
 
 /**
  * Known / estimated allocation costs.

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -285,9 +285,7 @@ val nativeOrder: ByteOrder = when (java.nio.ByteOrder.nativeOrder()) {
 /**
  * Replacement function for [ClassLoader.getSystemClassLoader].
  */
-val systemClassLoader: ClassLoader get() {
-    return SandboxRuntimeContext.instance.classLoader
-}
+val systemClassLoader: ClassLoader = SandboxRuntimeContext.instance.classLoader
 
 /**
  * Filter function for [Class.getClassLoader].

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -26,7 +26,7 @@ class AnnotatedJavaClassTest extends TestBase {
     void testSandboxAnnotation() {
         assertThat(UserJavaData.class.getAnnotation(JavaAnnotation.class)).isNotNull();
 
-        parentedSandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
+        sandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 @SuppressWarnings("unchecked")
@@ -45,7 +45,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testAnnotationInsideSandbox() {
-        parentedSandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
+        sandbox(emptySet(), singleton("net.corda.djvm.*"), ctx -> {
             try {
                 SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
                 ExecutionSummaryWithResult<String> success = WithJava.run(executor, ReadAnnotation.class, null);
@@ -60,7 +60,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testReflectionCanFetchAllSandboxedAnnotations() {
-        parentedSandbox(emptySet(), singleton("net.corda.djvm.**"), ctx -> {
+        sandbox(emptySet(), singleton("net.corda.djvm.**"), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 Annotation[] annotations = sandboxClass.getAnnotations();
@@ -79,7 +79,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testReflectionCanFetchAllStitchedAnnotations() {
-        parentedSandbox(singleton(JavaAnnotation.class), ctx -> {
+        sandbox(singleton(JavaAnnotation.class), ctx -> {
             try {
                 Class<?> sandboxClass = loadClass(ctx, UserJavaData.class.getName()).getType();
                 Annotation[] annotations = sandboxClass.getAnnotations();
@@ -99,7 +99,7 @@ class AnnotatedJavaClassTest extends TestBase {
 
     @Test
     void testReflectionCanFetchAllMetaAnnotations() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 @SuppressWarnings("unchecked")
                 Class<? extends Annotation> sandboxAnnotation

--- a/djvm/src/test/java/net/corda/djvm/execution/Base64Test.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/Base64Test.java
@@ -22,7 +22,7 @@ class Base64Test extends TestBase {
 
     @Test
     void testBase64ToBinary() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, byte[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<byte[]> success = WithJava.run(executor, Base64ToBytes.class, BASE64);
             assertNotNull(success.getResult());
@@ -40,7 +40,7 @@ class Base64Test extends TestBase {
 
     @Test
     void testBinaryToBase64() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<byte[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, BytesToBase64.class, MESSAGE.getBytes(UTF_8));
             assertThat(success.getResult()).isEqualTo(BASE64);

--- a/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
@@ -21,7 +21,7 @@ class BasicInputOutputTest extends TestBase {
 
     @Test
     void testBasicInput() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
                 Object sandboxObject = inputTask.apply(MESSAGE);
@@ -36,7 +36,7 @@ class BasicInputOutputTest extends TestBase {
 
     @Test
     void testBasicOutput() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ?> inputTask = ctx.getClassLoader().createBasicInput();
                 Object sandboxObject = inputTask.apply(BIG_NUMBER);
@@ -55,7 +55,7 @@ class BasicInputOutputTest extends TestBase {
 
     @Test
     void testImportTask() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 SandboxClassLoader classLoader = ctx.getClassLoader();
                 Function<? super String, ?> importTask = classLoader.createForImport(new DoMagic());

--- a/djvm/src/test/java/net/corda/djvm/execution/BitSetTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BitSetTest.java
@@ -22,7 +22,7 @@ class BitSetTest extends TestBase {
     void testCreatingBitSet() {
         BitSet bitset = BitSet.valueOf(BITS);
 
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<byte[], int[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<int[]> success = WithJava.run(executor, CreateBitSet.class, BITS);
             assertThat(success.getResult())

--- a/djvm/src/test/java/net/corda/djvm/execution/DataInputStreamTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DataInputStreamTest.java
@@ -31,7 +31,7 @@ class DataInputStreamTest extends TestBase {
         }
         InputStream input = new ByteArrayInputStream(baos.toByteArray());
 
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<InputStream, Object[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Object[]> success = WithJava.run(executor, DataStreamer.class, input);
             assertThat(success.getResult()).isEqualTo(new Object[]{

--- a/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
@@ -20,7 +20,7 @@ class DatatypeConverterTest extends TestBase {
 
     @Test
     void testHexToBinary() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, byte[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<byte[]> success = WithJava.run(executor, HexToBytes.class, TEXT);
             assertThat(success.getResult()).isEqualTo(BINARY);
@@ -37,7 +37,7 @@ class DatatypeConverterTest extends TestBase {
 
     @Test
     void testBinaryToHex() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<byte[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, BytesToHex.class, BINARY);
             assertThat(success.getResult()).isEqualTo(TEXT);

--- a/djvm/src/test/java/net/corda/djvm/execution/JarInputStreamTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JarInputStreamTest.java
@@ -62,7 +62,7 @@ class JarInputStreamTest extends TestBase {
             Files.copy(testJar.getPath(), baos);
             input = new ByteArrayInputStream(baos.toByteArray());
         }
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<InputStream, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> success = WithJava.run(executor, JarStreamer.class, input);
             assertNotNull(success.getResult());

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
@@ -18,7 +18,7 @@ class JavaPackageTest extends TestBase {
 
     @Test
     void testFetchingPackage() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
                 Function<String, String> fetchPackage = typedTaskFor(ctx.getClassLoader(), taskFactory, FetchPackage.class);
@@ -40,7 +40,7 @@ class JavaPackageTest extends TestBase {
 
     @Test
     void testFetchingAllPackage() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
                 Function<Object, String[]> fetchAllPackages = typedTaskFor(ctx.getClassLoader(), taskFactory, FetchAllPackages.class);

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -23,7 +23,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testInstant() {
         Instant instant = Instant.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -45,7 +45,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testDuration() {
         Duration duration = Duration.ofHours(2);
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -67,7 +67,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testLocalDate() {
         LocalDate localDate = LocalDate.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -89,7 +89,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testLocalTime() {
         LocalTime localTime = LocalTime.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -111,7 +111,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testLocalDateTime() {
         LocalDateTime localDateTime = LocalDateTime.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -133,7 +133,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testMonthDay() {
         MonthDay monthDay = MonthDay.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -155,7 +155,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testOffsetDateTime() {
         OffsetDateTime offsetDateTime = OffsetDateTime.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -177,7 +177,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testOffsetTime() {
         OffsetTime offsetTime = OffsetTime.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -199,7 +199,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testPeriod() {
         Period period = Period.of(1, 2, 3);
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -221,7 +221,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testYear() {
         Year year = Year.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -243,7 +243,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testYearMonth() {
         YearMonth yearMonth = YearMonth.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -265,7 +265,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testZonedDateTime() {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -287,7 +287,7 @@ class JavaTimeTest extends TestBase {
     @Test
     void testZoneOffset() {
         ZoneOffset zoneOffset = ZoneOffset.ofHours(7);
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
 
@@ -308,7 +308,7 @@ class JavaTimeTest extends TestBase {
 
     @Test
     void testAllZoneIDs() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
                 Function<?, String[]> allZoneIDs = typedTaskFor(ctx.getClassLoader(), taskFactory, AllZoneIDs.class);
@@ -323,7 +323,7 @@ class JavaTimeTest extends TestBase {
 
     @Test
     void testDefaultZoneID() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
                 Function<?, String> defaultZoneIdTask = typedTaskFor(ctx.getClassLoader(), taskFactory, DefaultZoneId.class);
@@ -338,14 +338,6 @@ class JavaTimeTest extends TestBase {
 
     @Test
     void testDefaultTimeZone() {
-        // We need to use a standalone sandbox here until we can
-        // recreate parent classloaders from cached byte-code.
-        // The problem is that each sandbox should know about those
-        // strings which have already been interned by the parent
-        // classloader when (e.g.) they were loaded into static
-        // final fields.
-        //
-        // THIS ISSUE AFFECTS ANYTHING THAT LOADS RESOURCE BUNDLES.
         sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
@@ -363,14 +355,6 @@ class JavaTimeTest extends TestBase {
     void testDate() {
         Date now = new Date();
 
-        // We need to use a standalone sandbox here until we can
-        // recreate parent classloaders from cached byte-code.
-        // The problem is that each sandbox should know about those
-        // strings which have already been interned by the parent
-        // classloader when (e.g.) they were loaded into static
-        // final fields.
-        //
-        // THIS ISSUE AFFECTS ANYTHING THAT LOADS RESOURCE BUNDLES.
         sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
@@ -389,7 +373,7 @@ class JavaTimeTest extends TestBase {
         Date now = new Date();
         Date later = new AddToDate().apply(now);
 
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
                 Function<Date, Date> addToDate = typedTaskFor(ctx.getClassLoader(), taskFactory, AddToDate.class);

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaUUIDTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaUUIDTest.java
@@ -16,13 +16,13 @@ class JavaUUIDTest extends TestBase {
     @Test
     void testUUID() {
         UUID uuid = UUID.randomUUID();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             try {
-                Object sandboxUUID = parentClassLoader.createBasicInput().apply(uuid);
+                Object sandboxUUID = ctx.getClassLoader().createBasicInput().apply(uuid);
                 assertEquals("sandbox.java.util.UUID", sandboxUUID.getClass().getName());
                 assertEquals(uuid.toString(), sandboxUUID.toString());
 
-                Object revert = parentClassLoader.createBasicOutput().apply(sandboxUUID);
+                Object revert = ctx.getClassLoader().createBasicOutput().apply(sandboxUUID);
                 assertNotSame(uuid, revert);
                 assertEquals(uuid, revert);
             } catch (Exception e) {

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -21,7 +21,7 @@ class MaliciousClassTest extends TestBase {
 
     @Test
     void testImplementingToDJVMString() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(SandboxClassLoadingException.class, () -> WithJava.run(executor, EvilToString.class, ""));
             assertThat(ex)
@@ -44,7 +44,7 @@ class MaliciousClassTest extends TestBase {
 
     @Test
     void testImplementingFromDJVM() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Object> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(SandboxClassLoadingException.class, () -> WithJava.run(executor, EvilFromDJVM.class, null));
             assertThat(ex)
@@ -67,7 +67,7 @@ class MaliciousClassTest extends TestBase {
 
     @Test
     void testPassingClassIntoSandboxIsForbidden() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Class<?>, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilClass.class, String.class));
             assertThat(ex)
@@ -86,7 +86,7 @@ class MaliciousClassTest extends TestBase {
     @Test
     void testPassingConstructorIntoSandboxIsForbidden() throws NoSuchMethodException {
         Constructor<?> constructor = getClass().getDeclaredConstructor();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Constructor<?>, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilConstructor.class, constructor));
             assertThat(ex)
@@ -105,7 +105,7 @@ class MaliciousClassTest extends TestBase {
     @Test
     void testPassingClassLoaderIntoSandboxIsForbidden() {
         ClassLoader classLoader = getClass().getClassLoader();
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<ClassLoader, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(executor, EvilClassLoader.class, classLoader));
             assertThat(ex)
@@ -123,7 +123,7 @@ class MaliciousClassTest extends TestBase {
 
     @Test
     void testCannotInvokeSandboxMethodsExplicitly() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable ex = assertThrows(SandboxClassLoadingException.class,
                                () -> WithJava.run(executor, SelfSandboxing.class, "Victory is mine!"));

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxCloneableTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxCloneableTest.java
@@ -17,7 +17,7 @@ class SandboxCloneableTest extends TestBase {
 
     @Test
     void testCloningInsideSandbox() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, CloningMachine.class, "Jango Fett");
             assertThat(success.getResult()).isEqualTo("Jango Fett");
@@ -56,7 +56,7 @@ class SandboxCloneableTest extends TestBase {
 
     @Test
     void testFailedCloningInsideSandbox() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable throwable = assertThrows(RuntimeException.class, () -> WithJava.run(executor, ForceProjector.class, "Obi Wan"));
             assertThat(throwable)

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxConcurrentHashMapTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxConcurrentHashMapTest.java
@@ -20,7 +20,7 @@ class SandboxConcurrentHashMapTest extends TestBase {
     @Test
     void testJoiningIterableInsideSandbox() {
         String[] inputs = new String[]{ "one", "One", "ONE" };
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, CreateMap.class, inputs);
             assertThat(success.getResult()).isEqualTo("[one has 3]");
@@ -68,7 +68,7 @@ class SandboxConcurrentHashMapTest extends TestBase {
     @Test
     void testStreamOfKeys() {
         Integer[] inputs = new Integer[]{ 1, 2, 3 };
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer[], Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> success = WithJava.run(executor, KeyStreamMap.class, inputs);
             assertThat(success.getResult()).isEqualTo(6);

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxCurrencyTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxCurrencyTest.java
@@ -19,7 +19,7 @@ class SandboxCurrencyTest extends TestBase {
     @ParameterizedTest
     @CsvSource({"GBP,British Pound Sterling,GBP,2", "EUR,Euro,EUR,2", "USD,US Dollar,USD,2"})
     void testCurrencies(String currencyCode, String displayName, String symbol, int fractionDigits) {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, Object[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Object[]> output = WithJava.run(executor, GetCurrency.class, currencyCode);
             assertThat(output.getResult()).isEqualTo(new Object[]{ displayName, symbol, fractionDigits });

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
@@ -20,7 +20,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testEnumInsideSandbox() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, TransformEnum.class, 0);
             assertThat(output.getResult())
@@ -38,7 +38,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testReturnEnumFromSandbox() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, ExampleEnum> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<ExampleEnum> output = WithJava.run(executor, FetchEnum.class, "THREE");
             assertThat(output.getResult())
@@ -55,7 +55,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testWeCanIdentifyClassAsEnum() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, AssertEnum.class, ExampleEnum.THREE);
             assertThat(output.getResult()).isTrue();
@@ -72,7 +72,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testWeCanCreateEnumMap() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<ExampleEnum, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, UseEnumMap.class, ExampleEnum.TWO);
             assertThat(output.getResult()).isEqualTo(1);
@@ -91,7 +91,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testWeCanCreateEnumSet() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<ExampleEnum, Boolean> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Boolean> output = WithJava.run(executor, UseEnumSet.class, ExampleEnum.ONE);
             assertThat(output.getResult()).isTrue();
@@ -108,7 +108,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testWeCanReadConstantEnum() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, ExampleEnum> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<ExampleEnum> output = WithJava.run(executor, ConstantEnum.class, null);
             assertThat(output.getResult()).isEqualTo(ExampleEnum.ONE);
@@ -127,7 +127,7 @@ class SandboxEnumJavaTest extends TestBase {
 
     @Test
     void testWeCanReadStaticConstantEnum() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, ExampleEnum> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<ExampleEnum> output = WithJava.run(executor, StaticConstantEnum.class, null);
             assertThat(output.getResult()).isEqualTo(ExampleEnum.TWO);

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
-import static java.util.Collections.*;
 import static net.corda.djvm.SandboxType.JAVA;
-import static net.corda.djvm.messages.Severity.WARNING;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -21,7 +19,7 @@ class SandboxExecutorJavaTest extends TestBase {
 
     @Test
     void testTransaction() {
-        sandbox(new Object[0], emptySet(), emptySet(), WARNING, true, ctx -> {
+        sandbox(ctx -> {
             try {
                 Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createRawTaskFactory();
                 Function<? super Object, ?> verifyTask = ctx.getClassLoader().createTaskFor(taskFactory, ContractWrapper.class);

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
@@ -18,7 +18,7 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
 
     @Test
     void testHashForArray() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, ArrayHashCode.class, null);
             assertThat(output.getResult()).isEqualTo(0xfed_c0de + 1);
@@ -28,7 +28,7 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
 
     @Test
     void testHashForObjectInArray() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, ObjectInArrayHashCode.class, null);
             assertThat(output.getResult()).isEqualTo(0xfed_c0de + 1);
@@ -41,7 +41,7 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
         assertThatExceptionOfType(NullPointerException.class)
             .isThrownBy(() -> new HashCode().apply(null));
 
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> WithJava.run(executor, HashCode.class, null));
@@ -51,7 +51,7 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
 
     @Test
     void testHashForWrappedInteger() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, HashCode.class, 1234);
             assertThat(output.getResult()).isEqualTo(Integer.hashCode(1234));
@@ -61,7 +61,7 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
 
     @Test
     void testHashForWrappedString() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Object, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Integer> output = WithJava.run(executor, HashCode.class, "Burble");
             assertThat(output.getResult()).isEqualTo("Burble".hashCode());

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxStrictMathTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxStrictMathTest.java
@@ -22,7 +22,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictMathHasNoRandom() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Double> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable error = assertThrows(NoSuchMethodError.class, () -> WithJava.run(executor, StrictRandom.class, 0));
             assertThat(error)
@@ -41,7 +41,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictMathHasTrigonometry() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Double[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Double[]> success = WithJava.run(executor, StrictTrigonometry.class, 0);
             assertThat(success.getResult()).isEqualTo(new Double[] {
@@ -74,7 +74,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictMathRoots() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Double, Double[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Double[]> success = WithJava.run(executor, StrictRoots.class, 64.0);
             assertThat(success.getResult())
@@ -96,7 +96,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictMaxMin() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Object[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Object[]> success = WithJava.run(executor, StrictMaxMin.class, 100);
             assertThat(success.getResult())
@@ -123,7 +123,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictAbsolute() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Object[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Object[]> success = WithJava.run(executor, StrictAbsolute.class, -100);
             assertThat(success.getResult())
@@ -147,7 +147,7 @@ class SandboxStrictMathTest extends TestBase {
     @Test
     void testStrictRound() {
         Double[] inputs = new Double[] { 2019.3, 2020.9 };
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Double[], Object[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Object[]> success = WithJava.run(executor, StrictRound.class, inputs);
             assertThat(success.getResult())
@@ -170,7 +170,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictExponents() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Double[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Double[] result = WithJava.run(executor, StrictExponents.class, 0).getResult();
             assertNotNull(result);
@@ -203,7 +203,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictAngles() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, Double[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Double[]> success = WithJava.run(executor, StrictAngles.class, 0);
             assertThat(success.getResult())
@@ -224,7 +224,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictHyperbolics() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Double, Double[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<Double[]> success = WithJava.run(executor, StrictHyperbolics.class, 0.0);
             assertThat(success.getResult())
@@ -246,7 +246,7 @@ class SandboxStrictMathTest extends TestBase {
 
     @Test
     void testStrictRemainder() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Double, Double> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> assertThat(WithJava.run(executor, StrictRemainder.class, 10.0).getResult()).isEqualTo(3.0),

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxStringTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxStringTest.java
@@ -32,7 +32,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testJoiningIterableInsideSandbox() {
         String[] inputs = new String[]{"one", "two", "three"};
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, JoinIterableStrings.class, inputs);
             assertThat(success.getResult()).isEqualTo("one+two+three");
@@ -50,7 +50,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testJoiningVarargInsideSandbox() {
         String[] inputs = new String[]{"ONE", "TWO", "THREE"};
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, JoinVarargStrings.class, inputs);
             assertThat(success.getResult()).isEqualTo("ONE+TWO+THREE");
@@ -67,7 +67,7 @@ class SandboxStringTest extends TestBase {
 
     @Test
     void testStringConstant() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThat(WithJava.run(executor, StringConstant.class, "Wibble!").getResult())
                 .isEqualTo("Wibble!");
@@ -91,7 +91,7 @@ class SandboxStringTest extends TestBase {
 
     @Test
     void encodeStringWithUnknownCharset() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, byte[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable exception = assertThrows(RuntimeException.class, () -> WithJava.run(executor, GetEncoding.class, "Nonsense-101"));
             assertThat(exception)
@@ -116,7 +116,7 @@ class SandboxStringTest extends TestBase {
     @ParameterizedTest
     @ValueSource(strings = {"UTF-8", "UTF-16", "UTF-32"})
     void decodeStringWithCharset(String charsetName) {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, CreateString.class, charsetName);
             assertThat(success.getResult()).isEqualTo(UNICODE_MESSAGE);
@@ -137,7 +137,7 @@ class SandboxStringTest extends TestBase {
 
     @Test
     void testCaseInsensitiveComparison() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, Integer> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> assertThat(WithJava.run(executor, CaseInsensitiveCompare.class, "hello world!").getResult())
@@ -161,7 +161,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testStream() {
         String[] inputs = new String[] {"dog", "cat", "mouse", "squirrel"};
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThat(WithJava.run(executor, Concatenate.class, inputs).getResult())
                 .isEqualTo("{dog + cat + mouse + squirrel}");
@@ -179,7 +179,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testSorting() {
         String[] inputs = Stream.of("Wolf", "Cat", "Tree", "Pig").map(String::toUpperCase).toArray(String[]::new);
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThat(WithJava.run(executor, Sorted.class, inputs).getResult())
                  .containsExactly("CAT", "PIG", "TREE", "WOLF");
@@ -199,7 +199,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testComplexStream() {
         String[] inputs = new String[] { "one", "two", "three", "four", "five" };
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThat(WithJava.run(executor, ComplexStream.class, inputs).getResult())
                 .containsExactly("ONE", "TWO", "THREE", "FOUR", "FIVE");
@@ -217,7 +217,7 @@ class SandboxStringTest extends TestBase {
     @Test
     void testSpliterator() {
         String[] inputs = new String[] { "one", "two", "three", "four" };
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String[], String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertThat(WithJava.run(executor, Spliterate.class, inputs).getResult())
                 .containsExactlyInAnyOrder("one+two", "three+four");

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -6,10 +6,8 @@ import net.corda.djvm.rules.RuleViolationError;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import static java.util.Collections.*;
 import static net.corda.djvm.SandboxType.JAVA;
 import static net.corda.djvm.Utilities.*;
-import static net.corda.djvm.messages.Severity.*;
 
 import java.io.*;
 import java.net.URI;
@@ -28,7 +26,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testUserExceptionHandling() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> output = WithJava.run(executor, ThrowAndCatchJavaExample.class, "Hello World!");
             assertThat(output.getResult())
@@ -39,7 +37,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testCheckedExceptions() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {
@@ -57,7 +55,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testMultiCatchExceptions() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<Integer, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {
@@ -104,7 +102,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testMultiCatchWithDisallowedExceptions() {
-        sandbox(new Object[0], emptySet(), emptySet(), WARNING, true, ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             assertAll(
                 () -> {
@@ -126,7 +124,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testSuppressedJvmExceptions() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable exception = assertThrows(IllegalArgumentException.class,
                 () -> WithJava.run(executor, WithSuppressedJvmExceptions.class, "Hello World!")
@@ -145,7 +143,7 @@ class SandboxThrowableJavaTest extends TestBase {
 
     @Test
     void testSuppressedUserExceptions() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             Throwable exception = assertThrows(IllegalArgumentException.class,
                 () -> WithJava.run(executor, WithSuppressedUserExceptions.class, "Hello World!")

--- a/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
@@ -17,7 +17,7 @@ class SecurityManagerTest extends TestBase {
 
     @Test
     void testReplacingSecurityManager() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             RuntimeException ex = assertThrows(RuntimeException.class, () -> WithJava.run(executor, ReplacingSecurityManager.class, ""));
             assertThat(ex)

--- a/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
@@ -20,7 +20,7 @@ class X500Tests extends TestBase {
 
     @Test
     void testCreateX500Principal() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, CreateX500Principal.class, "CN=Example,O=Corda,C=GB");
             assertEquals("cn=example,o=corda,c=gb", success.getResult());
@@ -37,7 +37,7 @@ class X500Tests extends TestBase {
 
     @Test
     void testX500PrincipalToX500Name() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String[]> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String[]> success = WithJava.run(executor, X500PrincipalToX500Name.class, "CN=Example,O=Corda,C=GB");
             assertThat(success.getResult()).isEqualTo(new String[] {
@@ -56,7 +56,7 @@ class X500Tests extends TestBase {
 
     @Test
     void testX500NameToX500Principal() {
-        parentedSandbox(ctx -> {
+        sandbox(ctx -> {
             SandboxExecutor<String, String> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
             ExecutionSummaryWithResult<String> success = WithJava.run(executor, X500NameToX500Principal.class, "CN=Example,O=Corda,C=GB");
             assertEquals("cn=example,o=corda,c=gb", success.getResult());

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMExceptionTest.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 class DJVMExceptionTest : TestBase(KOTLIN) {
     @Test
-    fun testSingleException() = parentedSandbox {
+    fun testSingleException() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val singleExceptionTask = classLoader.typedTaskFor(taskFactory, SingleExceptionTask::class.java)
         val result = singleExceptionTask.apply( "Hello World")
@@ -26,7 +26,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testMultipleExceptions() = parentedSandbox {
+    fun testMultipleExceptions() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val multipleExceptionsTask = classLoader.typedTaskFor(taskFactory, MultipleExceptionsTask::class.java)
         val result = multipleExceptionsTask.apply("Hello World")
@@ -62,7 +62,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testJavaThrowableToSandbox() = parentedSandbox {
+    fun testJavaThrowableToSandbox() = sandbox {
         val djvm = DJVM(classLoader)
         val helloWorld = djvm.stringOf("Hello World")
 
@@ -79,7 +79,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testWeCreateCorrectJVMExceptionAtRuntime() = parentedSandbox {
+    fun testWeCreateCorrectJVMExceptionAtRuntime() = sandbox {
         val djvm = DJVM(classLoader)
         val helloWorld = djvm.stringOf("Hello World")
 
@@ -100,7 +100,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testWeCreateCorrectSyntheticExceptionAtRuntime() = parentedSandbox {
+    fun testWeCreateCorrectSyntheticExceptionAtRuntime() = sandbox {
         val djvm = DJVM(classLoader)
 
         val result = djvm.sandbox(EmptyStackException())
@@ -119,7 +119,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testWeCannotCreateSyntheticExceptionForNonException() = parentedSandbox {
+    fun testWeCannotCreateSyntheticExceptionForNonException() = sandbox {
         val djvm = DJVM(classLoader)
         assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.java.util.LinkedList\$1DJVM") }
@@ -131,7 +131,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
      * that the classloader can handle it.
      */
     @Test
-    fun testWeCannotCreateSyntheticExceptionForImaginaryJavaClass() = parentedSandbox {
+    fun testWeCannotCreateSyntheticExceptionForImaginaryJavaClass() = sandbox {
         val djvm = DJVM(classLoader)
         assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.java.util.DoesNotExist\$1DJVM") }
@@ -143,7 +143,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
      * that the classloader can handle it.
      */
     @Test
-    fun testWeCannotCreateSyntheticExceptionForImaginaryUserClass() = parentedSandbox {
+    fun testWeCannotCreateSyntheticExceptionForImaginaryUserClass() = sandbox {
         val djvm = DJVM(classLoader)
         assertThatExceptionOfType(ClassNotFoundException::class.java)
             .isThrownBy { djvm.classFor("sandbox.com.example.DoesNotExist\$1DJVM") }
@@ -151,7 +151,7 @@ class DJVMExceptionTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testExceptionWithSingleConstructor() = parentedSandbox {
+    fun testExceptionWithSingleConstructor() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val task = classLoader.typedTaskFor(taskFactory, HandleTypeNotPresentException::class.java)
         val result = task.apply("NoSuchType")

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -10,7 +10,7 @@ import java.util.function.Function
 class DJVMTest : TestBase(KOTLIN) {
 
     @Test
-    fun testDJVMString() = parentedSandbox {
+    fun testDJVMString() = sandbox {
         with(DJVM(classLoader)) {
             val djvmString = stringOf("New Value")
             assertNotEquals(djvmString, "New Value")
@@ -19,7 +19,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testSimpleIntegerFormats() = parentedSandbox {
+    fun testSimpleIntegerFormats() = sandbox {
         val result = with(DJVM(classLoader)) {
             stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null,
@@ -31,7 +31,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testHexFormat() = parentedSandbox {
+    fun testHexFormat() = sandbox {
         val result = with(DJVM(classLoader)) {
             stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%0#6x"), arrayOf(intOf(768))).toString()
@@ -40,7 +40,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testDoubleFormat() = parentedSandbox {
+    fun testDoubleFormat() = sandbox {
         val result = with(DJVM(classLoader)) {
             stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%9.4f"), arrayOf(doubleOf(1234.5678))).toString()
@@ -50,7 +50,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testFloatFormat() = parentedSandbox {
+    fun testFloatFormat() = sandbox {
         val result = with(DJVM(classLoader)) {
             stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("%7.2f"), arrayOf(floatOf(1234.5678f))).toString()
@@ -60,7 +60,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testCharFormat() = parentedSandbox {
+    fun testCharFormat() = sandbox {
         val result = with(DJVM(classLoader)) {
             stringClass.getMethod("format", stringClass, Array<Any>::class.java)
                 .invoke(null, stringOf("[%c]"), arrayOf(charOf('A'))).toString()
@@ -69,7 +69,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testObjectFormat() = parentedSandbox {
+    fun testObjectFormat() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val newObjectTask = classLoader.typedTaskFor(taskFactory, NewObject::class.java)
         val result = newObjectTask.apply(null)
@@ -83,7 +83,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testStringEquality() = parentedSandbox {
+    fun testStringEquality() = sandbox {
         with (DJVM(classLoader)) {
             val number = stringClass.getMethod("valueOf", Double::class.javaPrimitiveType)
                 .invoke(null, (Double.MIN_VALUE / 2.0) * 2.0)
@@ -92,7 +92,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testSandboxingArrays() = parentedSandbox {
+    fun testSandboxingArrays() = sandbox {
         with(DJVM(classLoader)) {
             val result = sandbox(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
             assertThat(result).isEqualTo(
@@ -101,7 +101,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testUnsandboxingObjectArray() = parentedSandbox {
+    fun testUnsandboxingObjectArray() = sandbox {
         val result = with(DJVM(classLoader)) {
             unsandbox(arrayOf(intOf(1), longOf(10L), stringOf("Hello World"), charOf('?'), booleanOf(false), doubleOf(1234.56)))
         }
@@ -110,7 +110,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testSandboxingPrimitiveArray() = parentedSandbox {
+    fun testSandboxingPrimitiveArray() = sandbox {
         val result = with(DJVM(classLoader)) {
             sandbox(intArrayOf(1, 2, 3, 10))
         }
@@ -118,7 +118,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testSandboxingIntegersAsObjectArray() = parentedSandbox {
+    fun testSandboxingIntegersAsObjectArray() = sandbox {
         with(DJVM(classLoader)) {
             val result = sandbox(arrayOf(1, 2, 3, 10))
             assertThat(result).isEqualTo(
@@ -128,7 +128,7 @@ class DJVMTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testUnsandboxingArrays() = parentedSandbox {
+    fun testUnsandboxingArrays() = sandbox {
         val (array, result) = with(DJVM(classLoader)) {
             val arr = arrayOf(
                 objectArrayOf(stringOf("Hello")),

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
@@ -18,7 +18,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     private val kotlinMetadata: Class<out Annotation> = Class.forName("kotlin.Metadata") as Class<out Annotation>
 
     @Test
-    fun testSandboxAnnotation() = parentedSandbox(
+    fun testSandboxAnnotation() = sandbox(
         visibleAnnotations = emptySet(),
         sandboxOnlyAnnotations = setOf("net.corda.djvm.*")
     ) {
@@ -35,7 +35,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
 
     @Disabled("This test needs java.lang.Class.getEnclosingMethod() inside the sandbox.")
     @Test
-    fun testAnnotationInsideSandbox() = parentedSandbox {
+    fun testAnnotationInsideSandbox() = sandbox {
         val executor = DeterministicSandboxExecutor<Any?, String>(configuration)
         executor.run<ReadAnnotation>(null).apply {
             assertThat(result)
@@ -50,7 +50,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun testPreservingKotlinMetadataAnnotation() = parentedSandbox {
+    fun testPreservingKotlinMetadataAnnotation() = sandbox {
         val sandboxClass = loadClass<UserKotlinData>().type
         @Suppress("unchecked_cast")
         val sandboxMetadataClass = loadClass(kotlinMetadata.name).type as Class<out Annotation>
@@ -86,7 +86,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test sandboxed class still knows its own primary constructor`() = parentedSandbox {
+    fun `test sandboxed class still knows its own primary constructor`() = sandbox {
         val sandboxClass = loadClass<UserKotlinData>().type
         val primaryConstructor = sandboxClass.kotlin.primaryConstructor ?: fail("Primary constructor missing!")
 
@@ -99,7 +99,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test reflection can fetch all annotations`() = parentedSandbox(
+    fun `test reflection can fetch all annotations`() = sandbox(
         visibleAnnotations = emptySet(),
         sandboxOnlyAnnotations = setOf("net.corda.djvm.**")
     ) {
@@ -123,32 +123,32 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test reflection can fetch all stitched annotations`() = parentedSandbox(
-        visibleAnnotations = setOf(KotlinAnnotation::class.java)
+    fun `test reflection can fetch all stitched annotations`() = sandbox(
+            visibleAnnotations = setOf(KotlinAnnotation::class.java)
     ) {
         val sandboxClass = loadClass<UserKotlinData>().type
         val kotlinAnnotations = sandboxClass.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName
         }
         assertThat(kotlinAnnotations).containsExactlyInAnyOrder(
-            "sandbox.net.corda.djvm.KotlinAnnotation",
-            "net.corda.djvm.KotlinAnnotation",
-            "sandbox.kotlin.Metadata"
+                "sandbox.net.corda.djvm.KotlinAnnotation",
+                "net.corda.djvm.KotlinAnnotation",
+                "sandbox.kotlin.Metadata"
         )
 
         val javaAnnotations = sandboxClass.annotations.map { ann ->
             ann.annotationClass.qualifiedName
         }
         assertThat(javaAnnotations).containsExactlyInAnyOrder(
-            "sandbox.net.corda.djvm.KotlinAnnotation",
-            "net.corda.djvm.KotlinAnnotation",
-            "sandbox.kotlin.Metadata",
-            "kotlin.Metadata"
+                "sandbox.net.corda.djvm.KotlinAnnotation",
+                "net.corda.djvm.KotlinAnnotation",
+                "sandbox.kotlin.Metadata",
+                "kotlin.Metadata"
         )
     }
 
     @Test
-    fun `test reflection can fetch all meta-annotations`() = parentedSandbox {
+    fun `test reflection can fetch all meta-annotations`() = sandbox {
         @Suppress("unchecked_cast")
         val sandboxAnnotation = loadClass<KotlinAnnotation>().type as Class<out Annotation>
 

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
@@ -23,7 +23,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @ValueSource(strings = [ "SHA", "SHA-256", "SHA-384", "SHA-512" ])
     @ParameterizedTest
-    fun `test SHA hashing`(algorithmName: String) = parentedSandbox {
+    fun `test SHA hashing`(algorithmName: String) = sandbox {
         val executor = DeterministicSandboxExecutor<Array<String>, ByteArray>(configuration)
         val summary = executor.run<Hashing>(arrayOf(algorithmName, SECRET_MESSAGE))
         assertThat(summary.result)
@@ -39,7 +39,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @CsvSource("RSA,SHA256withRSA", "RSA,SHA512withRSA", "DSA,SHA256withDSA")
     @ParameterizedTest
-    fun `test signatures`(algorithm: String, algorithmName: String) = parentedSandbox {
+    fun `test signatures`(algorithm: String, algorithmName: String) = sandbox {
         val keyPair = KeyPairGenerator.getInstance(algorithm).genKeyPair()
         val data = SECRET_MESSAGE.toByteArray()
         val signature = Signature.getInstance(algorithmName).run {
@@ -70,7 +70,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test security providers`() = parentedSandbox {
+    fun `test security providers`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
         val summary = executor.run<SecurityProviders>("")
         assertThat(summary.result).isEqualTo(arrayOf("SUN", "SunRsaSign"))
@@ -104,7 +104,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @ArgumentsSource(AlgorithmProvider::class)
     @ParameterizedTest
-    fun `test service algorithms`(serviceName: String, algorithms: Array<String>) = parentedSandbox {
+    fun `test service algorithms`(serviceName: String, algorithms: Array<String>) = sandbox {
         val executor = DeterministicSandboxExecutor<String, Array<String>>(configuration)
         val summary = executor.run<ServiceAlgorithms>(serviceName)
         assertThat(summary.result)
@@ -119,7 +119,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = [ "SUN", "SunRsaSign" ])
-    fun `test no secure random for`(serviceName: String) = parentedSandbox {
+    fun `test no secure random for`(serviceName: String) = sandbox {
         val executor = DeterministicSandboxExecutor<String, Double>(configuration)
         val exception = assertThrows<SandboxException> { executor.run<SecureRandomService>(serviceName) }
         assertThat(exception)
@@ -134,7 +134,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test secure random instance`() = parentedSandbox {
+    fun `test secure random instance`() = sandbox {
         val executor = DeterministicSandboxExecutor<ByteArray?, Double>(configuration)
         val exception = assertThrows<SandboxException> { executor.run<SecureRandomInstance>(null) }
         assertThat(exception)
@@ -150,7 +150,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
 
     @ValueSource(strings = [ "RSA", "DSA" ])
     @ParameterizedTest
-    fun `test decode public key`(algorithm: String) = parentedSandbox {
+    fun `test decode public key`(algorithm: String) = sandbox {
         val executor = DeterministicSandboxExecutor<Array<Any>, ByteArray>(configuration)
         val generator = KeyPairGenerator.getInstance(algorithm)
         val keyPair = generator.genKeyPair()
@@ -174,7 +174,7 @@ class BasicCryptoTest : TestBase(KOTLIN) {
             input.readBytes()
         } ?: fail("Certificate not found")
 
-        parentedSandbox {
+        sandbox {
             val executor = DeterministicSandboxExecutor<Array<Any>, String>(configuration)
             val summary = executor.run<DecodeCertificate>(arrayOf("X.509", certificate))
             assertThat(summary.result)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/KotlinNeedsKotlinTest.kt
@@ -11,7 +11,7 @@ class KotlinNeedsKotlinTest : TestBase(JAVA) {
     @Test
     fun `kotlin code needs kotlin libraries`() {
         val exception = assertThrows<NoClassDefFoundError> {
-            parentedSandbox {
+            sandbox {
                 val taskFactory = classLoader.createTaskFactory()
                 classLoader.typedTaskFor<String, String, UseKotlinForSomething>(taskFactory)
                     .apply("Hello Kotlin!")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/LinkedBlockingQueueTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/LinkedBlockingQueueTest.kt
@@ -10,7 +10,7 @@ import java.util.function.Function
 
 class LinkedBlockingQueueTest : TestBase(KOTLIN) {
     @Test
-    fun `elementary linked blocking queue test`() = parentedSandbox {
+    fun `elementary linked blocking queue test`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Int, CreateLinkedBlockingQueue>(taskFactory).apply("Message")
         assertThat(result).isEqualTo(1)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxCharsetTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxCharsetTest.kt
@@ -18,7 +18,7 @@ class SandboxCharsetTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = ["UTF-8", "UTF-16", "ISO-8859-1", "US-ASCII", "windows-1252"])
-    fun `test loading charsets`(charsetName: String) = parentedSandbox {
+    fun `test loading charsets`(charsetName: String) = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, String, LookupCharset>(taskFactory)
             .apply(charsetName)
@@ -26,7 +26,7 @@ class SandboxCharsetTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test unknown encoding`() = parentedSandbox {
+    fun `test unknown encoding`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val exception = assertThrows<RuntimeException> {
             classLoader.typedTaskFor<String, String, LookupCharset>(taskFactory)
@@ -45,7 +45,7 @@ class SandboxCharsetTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = ["UTF-8", "UTF-16", "ISO-8859-1", "US-ASCII", "windows-1252"])
-    fun `test string encoding`(charsetName: String) = parentedSandbox {
+    fun `test string encoding`(charsetName: String) = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, ByteArray, EncodeString>(taskFactory).apply(charsetName)
         assertNotNull(result)
@@ -60,7 +60,7 @@ class SandboxCharsetTest : TestBase(KOTLIN) {
 
     @ParameterizedTest
     @ValueSource(strings = ["UTF-8", "UTF-16", "ISO-8859-1", "US-ASCII", "windows-1252"])
-    fun `test string decoding`(charsetName: String) = parentedSandbox {
+    fun `test string decoding`(charsetName: String) = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, String, DecodeString>(taskFactory).apply(charsetName)
         assertThat(result).isEqualTo(MESSAGE)
@@ -75,7 +75,7 @@ class SandboxCharsetTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test default charset`() = parentedSandbox {
+    fun `test default charset`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<Void?, String, DefaultCharset>(taskFactory).apply(null)
         assertThat(result).isEqualTo("UTF-8")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxEnumTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxEnumTest.kt
@@ -9,7 +9,7 @@ import java.util.function.Function
 
 class SandboxEnumTest : TestBase(KOTLIN) {
     @Test
-    fun `test enum inside sandbox`() = parentedSandbox {
+    fun `test enum inside sandbox`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<Int, Array<String>, TransformEnum>(taskFactory)
             .apply(0)
@@ -17,7 +17,7 @@ class SandboxEnumTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `return enum from sandbox`() = parentedSandbox {
+    fun `return enum from sandbox`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, ExampleEnum, FetchEnum>(taskFactory)
             .apply("THREE")
@@ -25,7 +25,7 @@ class SandboxEnumTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test we can identify class as Enum`() = parentedSandbox {
+    fun `test we can identify class as Enum`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<ExampleEnum, Boolean, AssertEnum>(taskFactory)
             .apply(ExampleEnum.THREE)
@@ -33,7 +33,7 @@ class SandboxEnumTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test we can create EnumMap`() = parentedSandbox {
+    fun `test we can create EnumMap`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<ExampleEnum, Int, UseEnumMap>(taskFactory)
             .apply(ExampleEnum.TWO)
@@ -41,7 +41,7 @@ class SandboxEnumTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test we can create EnumSet`() = parentedSandbox {
+    fun `test we can create EnumSet`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<ExampleEnum, Boolean, UseEnumSet>(taskFactory)
             .apply(ExampleEnum.ONE)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -27,7 +27,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute runnable`() = sandbox(MINIMAL) {
+    fun `can load and execute runnable`() = customSandbox(MINIMAL) {
         val executor = DeterministicSandboxExecutor<Int, String>(configuration)
         val summary = executor.run<TestSandboxedRunnable>(1)
         val result = summary.result
@@ -41,7 +41,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute contract`() = sandbox(DEFAULT) {
+    fun `can load and execute contract`() = sandbox {
         val taskFactory = classLoader.createRawTaskFactory()
         val verifyTask = classLoader.createTaskFor(taskFactory, ContractWrapper::class.java)
         val sandboxClass = classLoader.toSandboxClass(Transaction::class.java)
@@ -71,7 +71,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     data class Transaction(val id: Int)
 
     @Test
-    fun `can load and execute code that overrides object hash code`() = parentedSandbox {
+    fun `can load and execute code that overrides object hash code`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         val summary = executor.run<TestObjectHashCode>(0)
         val result = summary.result
@@ -89,7 +89,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that overrides object hash code when derived`() = parentedSandbox {
+    fun `can load and execute code that overrides object hash code when derived`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         val summary = executor.run<TestObjectHashCodeWithHierarchy>(0)
         val result = summary.result
@@ -104,7 +104,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can detect breached threshold`() = sandbox(DEFAULT, ExecutionProfile.DEFAULT) {
+    fun `can detect breached threshold`() = customSandbox(DEFAULT, ExecutionProfile.DEFAULT) {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestThresholdBreach>(0) }
@@ -122,7 +122,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can detect stack overflow`() = parentedSandbox {
+    fun `can detect stack overflow`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestStackOverflow>(0) }
@@ -140,7 +140,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
 
 
     @Test
-    fun `can detect illegal references in Kotlin meta-classes`() = sandbox(DEFAULT, ExecutionProfile.DEFAULT) {
+    fun `can detect illegal references in Kotlin meta-classes`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Long>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestKotlinMetaClasses>(0) }
@@ -156,7 +156,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot execute runnable that references non-deterministic code`() = parentedSandbox {
+    fun `cannot execute runnable that references non-deterministic code`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Long>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestNonDeterministicCode>(0) }
@@ -171,7 +171,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot execute runnable that catches ThreadDeath`() = parentedSandbox {
+    fun `cannot execute runnable that catches ThreadDeath`() = sandbox {
         assertThat(TestCatchThreadDeath().apply(0))
             .isEqualTo(1)
 
@@ -192,7 +192,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot execute runnable that catches ThresholdViolationError`() = parentedSandbox {
+    fun `cannot execute runnable that catches ThresholdViolationError`() = sandbox {
         assertThat(TestCatchThresholdViolationError().apply(0))
             .isEqualTo(1)
 
@@ -215,7 +215,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot execute runnable that catches RuleViolationError`() = parentedSandbox {
+    fun `cannot execute runnable that catches RuleViolationError`() = sandbox {
         assertThat(TestCatchRuleViolationError().apply(0))
             .isEqualTo(1)
 
@@ -238,7 +238,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can catch Throwable`() = parentedSandbox {
+    fun `can catch Throwable`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         executor.run<TestCatchThrowableAndError>(1).apply {
             assertThat(result).isEqualTo(1)
@@ -246,7 +246,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can catch Error`() = parentedSandbox {
+    fun `can catch Error`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         executor.run<TestCatchThrowableAndError>(2).apply {
             assertThat(result).isEqualTo(2)
@@ -254,7 +254,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot catch ThreadDeath`() = parentedSandbox {
+    fun `cannot catch ThreadDeath`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestCatchThrowableErrorsAndThreadDeath>(3) }
@@ -309,7 +309,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot catch stack-overflow error`() = parentedSandbox {
+    fun `cannot catch stack-overflow error`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestCatchThrowableErrorsAndThreadDeath>(4) }
@@ -318,7 +318,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot catch out-of-memory error`() = parentedSandbox {
+    fun `cannot catch out-of-memory error`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<TestCatchThrowableErrorsAndThreadDeath>(5) }
@@ -327,7 +327,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `cannot persist state across sessions`() = parentedSandbox {
+    fun `cannot persist state across sessions`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         val result1 = executor.run<TestStatePersistence>(0)
         val result2 = executor.run<TestStatePersistence>(0)
@@ -349,7 +349,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses IO`() = parentedSandbox {
+    fun `can load and execute code that uses IO`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Int>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
             .isThrownBy { executor.run<TestIO>("test.dat") }
@@ -368,7 +368,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses reflection`() = parentedSandbox {
+    fun `can load and execute code that uses reflection`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Int>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestReflection>(0) }
         assertThat(ex)
@@ -389,7 +389,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses notify()`() = parentedSandbox {
+    fun `can load and execute code that uses notify()`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestMonitors>(1) }
         assertThat(ex)
@@ -401,7 +401,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses notifyAll()`() = parentedSandbox {
+    fun `can load and execute code that uses notifyAll()`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestMonitors>(2) }
         assertThat(ex)
@@ -413,7 +413,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses wait()`() = parentedSandbox {
+    fun `can load and execute code that uses wait()`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestMonitors>(3) }
         assertThat(ex)
@@ -425,7 +425,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses wait(long)`() = parentedSandbox {
+    fun `can load and execute code that uses wait(long)`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestMonitors>(4) }
         assertThat(ex)
@@ -437,7 +437,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that uses wait(long,int)`() = parentedSandbox {
+    fun `can load and execute code that uses wait(long,int)`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         val ex = assertThrows<SandboxException>{ executor.run<TestMonitors>(5) }
         assertThat(ex)
@@ -449,7 +449,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `code after forbidden APIs is intact`() = parentedSandbox {
+    fun `code after forbidden APIs is intact`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String?>(configuration)
         assertThat(executor.run<TestMonitors>(0).result)
                 .isEqualTo("unknown")
@@ -488,7 +488,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute code that has a native method`() = parentedSandbox {
+    fun `can load and execute code that has a native method`() = sandbox {
         assertThatExceptionOfType(UnsatisfiedLinkError::class.java)
             .isThrownBy { TestNativeMethod().apply(0) }
             .withMessageContaining("TestNativeMethod.evilDeeds()I")
@@ -509,7 +509,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `check arrays still work`() = parentedSandbox {
+    fun `check arrays still work`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Array<Int>>(configuration)
         executor.run<TestArray>(100).apply {
             assertThat(result).isEqualTo(arrayOf(100))
@@ -523,7 +523,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `check building a string`() = parentedSandbox {
+    fun `check building a string`() = sandbox {
         val executor = DeterministicSandboxExecutor<String?, String?>(configuration)
         executor.run<TestStringBuilding>("Hello Sandbox!").apply {
             assertThat(result)
@@ -548,7 +548,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `check System-arraycopy still works with Objects`() = parentedSandbox {
+    fun `check System-arraycopy still works with Objects`() = sandbox {
         val source = arrayOf("one", "two", "three")
         assertThat(TestArrayCopy().apply(source))
             .isEqualTo(source)
@@ -571,7 +571,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test System-arraycopy still works with CharArray`() = parentedSandbox {
+    fun `test System-arraycopy still works with CharArray`() = sandbox {
         val source = CharArray(10) { '?' }
         val executor = DeterministicSandboxExecutor<CharArray, CharArray>(configuration)
         executor.run<TestCharArrayCopy>(source).apply {
@@ -590,7 +590,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute class that has finalize`() = parentedSandbox {
+    fun `can load and execute class that has finalize`() = sandbox {
         assertThatExceptionOfType(UnsupportedOperationException::class.java)
             .isThrownBy { TestFinalizeMethod().apply(100) }
             .withMessageContaining("Very Bad Thing")
@@ -613,7 +613,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can execute parallel stream`() = parentedSandbox {
+    fun `can execute parallel stream`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, String>(configuration)
         executor.run<TestParallelStream>("Pebble").apply {
             assertThat(result).isEqualTo("Five,Four,One,Pebble,Three,Two")
@@ -650,7 +650,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "TaskTypes",
         "Task"
     ])
-    fun `users cannot load our sandboxed classes`(className: String) = parentedSandbox {
+    fun `users cannot load our sandboxed classes`(className: String) = sandbox {
         // Show the class exists to be found.
         assertThat(Class.forName("sandbox.$className")).isNotNull
 
@@ -663,7 +663,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `users can load sandboxed classes`() = parentedSandbox {
+    fun `users can load sandboxed classes`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Class<*>>(configuration)
         executor.run<TestClassForName>("java.util.List").apply {
             assertThat(result?.name).isEqualTo("sandbox.java.util.List")
@@ -677,7 +677,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test case-insensitive string sorting`() = parentedSandbox {
+    fun `test case-insensitive string sorting`() = sandbox {
         val executor = DeterministicSandboxExecutor<Array<String>, Array<String>>(configuration)
         executor.run<CaseInsensitiveSort>(arrayOf("Zelda", "angela", "BOB", "betsy", "ALBERT")).apply {
             assertThat(result).isEqualTo(arrayOf("ALBERT", "angela", "betsy", "BOB", "Zelda"))
@@ -691,7 +691,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test unicode characters`() = parentedSandbox {
+    fun `test unicode characters`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String>(configuration)
         executor.run<ExamineUnicodeBlock>(0x01f600).apply {
             assertThat(result).isEqualTo("EMOTICONS")
@@ -705,7 +705,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test unicode scripts`() = parentedSandbox {
+    fun `test unicode scripts`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Character.UnicodeScript?>(configuration)
         executor.run<ExamineUnicodeScript>("COMMON").apply {
             assertThat(result).isEqualTo(Character.UnicodeScript.COMMON)
@@ -720,7 +720,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot define new classes`() = parentedSandbox {
+    fun `test users cannot define new classes`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Class<*>>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<DefineNewClass>("sandbox.java.lang.DJVM") }
@@ -742,7 +742,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load new classes`() = parentedSandbox {
+    fun `test users cannot load new classes`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Class<*>>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<LoadNewClass>("sandbox.java.lang.DJVM") }
@@ -763,7 +763,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot lookup classes`() = parentedSandbox {
+    fun `test users cannot lookup classes`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Class<*>>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
                 .isThrownBy { executor.run<FindClass>("sandbox.java.lang.DJVM") }
@@ -784,7 +784,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load system resources`() = parentedSandbox {
+    fun `test users cannot load system resources`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Boolean>(configuration)
         executor.run<GetSystemResources>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isFalse()
@@ -798,7 +798,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load system resource URL`() = parentedSandbox {
+    fun `test users cannot load system resource URL`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, String?>(configuration)
         executor.run<GetSystemResourceURL>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isNull()
@@ -812,7 +812,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load system resource stream`() = parentedSandbox {
+    fun `test users cannot load system resource stream`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Int?>(configuration)
         executor.run<GetSystemResourceStream>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isNull()
@@ -826,7 +826,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load resources`() = parentedSandbox {
+    fun `test users cannot load resources`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Boolean>(configuration)
         executor.run<GetResources>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isFalse()
@@ -840,7 +840,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load resource URL`() = parentedSandbox {
+    fun `test users cannot load resource URL`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, String?>(configuration)
         executor.run<GetResourceURL>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isNull()
@@ -854,7 +854,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot load resource stream`() = parentedSandbox {
+    fun `test users cannot load resource stream`() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Int?>(configuration)
         executor.run<GetResourceStream>("META-INF/MANIFEST.MF").apply {
             assertThat(result).isNull()
@@ -868,7 +868,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test users cannot read package`() = parentedSandbox {
+    fun `test users cannot read package`() = sandbox {
         assertThat(GetClassPackage().apply(null))
             .isEqualTo(GetClassPackage::class.java.getPackage()?.toString())
 
@@ -885,7 +885,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test creating arrays of arrays`() = parentedSandbox {
+    fun `test creating arrays of arrays`() = sandbox {
         val executor = DeterministicSandboxExecutor<Any, Array<Any>>(configuration)
         executor.run<ArraysOfArrays>("THINGY").apply {
             assertThat(result).isEqualTo(arrayOf(arrayOf("THINGY")))
@@ -899,7 +899,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test creating arrays of int arrays`() = parentedSandbox {
+    fun `test creating arrays of int arrays`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, Array<IntArray>>(configuration)
         executor.run<ArrayOfIntArrays>(0).apply {
             assertThat(result).isEqualTo(arrayOf(intArrayOf(0)))
@@ -913,7 +913,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test class with protection domain`() = parentedSandbox {
+    fun `test class with protection domain`() = sandbox {
         val executor = DeterministicSandboxExecutor<Int, String>(configuration)
         assertThatExceptionOfType(SandboxException::class.java)
             .isThrownBy { executor.run<AccessClassProtectionDomain>(0) }
@@ -929,7 +929,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test kotlin class access`() = parentedSandbox {
+    fun `test kotlin class access`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val accessTask = classLoader.typedTaskFor(taskFactory, AccessKotlinClass::class.java)
         assertThat(accessTask.apply("Message")).isEqualTo(classLoader.toSandboxClass(String::class.java))

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxFieldUpdaterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxFieldUpdaterTest.kt
@@ -11,7 +11,7 @@ import java.util.function.Function
 
 class SandboxFieldUpdaterTest : TestBase(KOTLIN) {
     @Test
-    fun `test long field updater`() = parentedSandbox {
+    fun `test long field updater`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<Long, Long, HasLongField>(taskFactory)
             .apply(1234)
@@ -30,7 +30,7 @@ class SandboxFieldUpdaterTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test integer field updater`() = parentedSandbox {
+    fun `test integer field updater`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<Int, Int, HasIntegerField>(taskFactory)
             .apply(4567)
@@ -49,7 +49,7 @@ class SandboxFieldUpdaterTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test reference field updater`() = parentedSandbox {
+    fun `test reference field updater`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, String, HasReferenceField>(taskFactory)
             .apply("Hello World!")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxLocaleTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxLocaleTest.kt
@@ -12,7 +12,7 @@ import java.util.function.Function
 class SandboxLocaleTest : TestBase(KOTLIN) {
     @ParameterizedTest
     @CsvSource("en,en,''", "en-GB,en,GB", "en-US,en,US", "en-CA,en,CA", "en-AU,en,AU")
-    fun `test loading locales`(tagName: String, language: String, country: String) = parentedSandbox {
+    fun `test loading locales`(tagName: String, language: String, country: String) = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Array<String>, LookupLocale>(taskFactory)
             .apply(tagName)
@@ -28,7 +28,7 @@ class SandboxLocaleTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test locale languages`() = parentedSandbox {
+    fun `test locale languages`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Array<String>, GetAllLocaleLanguages>(taskFactory)
             .apply("")
@@ -44,7 +44,7 @@ class SandboxLocaleTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test locale countries`() = parentedSandbox {
+    fun `test locale countries`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Array<String>, GetAllLocaleCountries>(taskFactory)
             .apply("")
@@ -60,7 +60,7 @@ class SandboxLocaleTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test default locale`() = parentedSandbox {
+    fun `test default locale`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, String, GetDefaultLocale>(taskFactory)
             .apply("")

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxRawExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxRawExecutorTest.kt
@@ -11,7 +11,7 @@ import java.util.function.Function
 
 class SandboxRawExecutorTest : TestBase(KOTLIN) {
     @Test
-    fun `test raw executor`() = parentedSandbox {
+    fun `test raw executor`() = sandbox {
         val executor = SandboxRawExecutor(configuration)
         val inputData = "Hello World!".toByteArray()
         val result = executor.run(ClassSource.fromClassName(BackwardsUppercase::class.java.name), inputData).result
@@ -25,7 +25,7 @@ class SandboxRawExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test input unmarshalled`() = parentedSandbox {
+    fun `test input unmarshalled`() = sandbox {
         val executor = SandboxRawExecutor(configuration)
         val inputData = "Hello World!".toByteArray()
         val ex = assertThrows<SandboxException>{ executor.run(ClassSource.fromClassName(UnmarshalledInput::class.java.name), inputData) }
@@ -41,7 +41,7 @@ class SandboxRawExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test output is unmarshalled`() = parentedSandbox {
+    fun `test output is unmarshalled`() = sandbox {
         val executor = SandboxRawExecutor(configuration)
         val inputData = "Hello World!".toByteArray()
         val result = executor.run(ClassSource.fromClassName(UnmarshalledOutput::class.java.name), inputData).result

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxThrowableTest.kt
@@ -9,7 +9,7 @@ import java.util.function.Function
 class SandboxThrowableTest : TestBase(KOTLIN) {
 
     @Test
-    fun `test user exception handling`() = parentedSandbox {
+    fun `test user exception handling`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Array<String>, ThrowAndCatchExample>(taskFactory)
             .apply("Hello World")
@@ -18,7 +18,7 @@ class SandboxThrowableTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test rethrowing an exception`() = parentedSandbox {
+    fun `test rethrowing an exception`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<String, Array<String>, ThrowAndRethrowExample>(taskFactory)
             .apply("Hello World")
@@ -27,7 +27,7 @@ class SandboxThrowableTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `test JVM exceptions still propagate`() = parentedSandbox {
+    fun `test JVM exceptions still propagate`() = sandbox {
         val taskFactory = classLoader.createTaskFactory()
         val result = classLoader.typedTaskFor<Int, String, TriggerJVMException>(taskFactory)
             .apply(-1)

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
@@ -1,0 +1,44 @@
+package net.corda.djvm.rewiring
+
+import net.corda.djvm.analysis.AnalysisConfiguration
+import net.corda.djvm.analysis.Whitelist
+import net.corda.djvm.messages.Severity
+import net.corda.djvm.source.UserPathSource
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ByteCodeCacheTest {
+    @Test
+    fun testCacheWithNoParent() {
+        val configuration = createAnalysisConfiguration()
+        assertNull(configuration.parent)
+
+        val byteCodeCache = ByteCodeCache.createFor(configuration)
+        assertNull(byteCodeCache.parent)
+    }
+
+    @Test
+    fun testCacheWithParent() {
+        val parentConfiguration = createAnalysisConfiguration()
+        val configuration = parentConfiguration.createChild(
+            userSource = UserPathSource(emptyList()),
+            newMinimumSeverityLevel = Severity.WARNING,
+            sandboxOnlyAnnotations = emptySet(),
+            visibleAnnotations = emptySet()
+        )
+        assertNotNull(configuration.parent)
+        assertNull(configuration.parent!!.parent)
+
+        val byteCodeCache = ByteCodeCache.createFor(configuration)
+        assertNotNull(byteCodeCache.parent)
+        assertNull(byteCodeCache.parent!!.parent)
+    }
+
+    private fun createAnalysisConfiguration() = AnalysisConfiguration.createRoot(
+        userSource = UserPathSource(emptyList()),
+        whitelist = Whitelist.EMPTY,
+        visibleAnnotations = emptySet(),
+        sandboxOnlyAnnotations = emptySet()
+    )
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
         id 'net.corda.plugins.publish-utils' version '4.0.45'
         id 'com.github.johnrengelman.shadow' version '5.1.0'
         id 'com.jfrog.artifactory' version '4.9.6'
-        id 'com.jfrog.bintray' version '1.4'
+        id 'com.jfrog.bintray' version '1.7.3'
         id 'org.owasp.dependencycheck' version '5.1.0'
         id 'com.gradle.build-scan' version '2.2.1'
     }


### PR DESCRIPTION
- Add a persistent cache of bytecode to `AnalysisConfiguration` which `SandboxClassLoader` will consult before generating a new `sandbox.*` class. This cache is refreshed with new classes when the `SandboxClassLoader` is closed.
- Creating a new sandbox now involves creating an entirely new chain of `SandboxClassLoader`s. This ensures that `static` caches of interned `String`s and `Enum`s are recreated correctly too.
- Update as many tests as possible to create sandboxes using shared "parent sandbox" bytecode.

The net result is that we can create "fresh" new sandboxes without repeatedly transforming the same common classes such as the `java.*` APIs.