### PR TITLE
CORDA-2877: Refactor how we create child SandboxConfiguration objects.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -20,8 +20,10 @@ import java.nio.file.Files.exists
 import java.nio.file.Files.isDirectory
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.function.Consumer
 import kotlin.concurrent.thread
 
+@Suppress("unused")
 abstract class TestBase(type: SandboxType) {
     companion object {
         @JvmField
@@ -90,12 +92,11 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(
-                        userSource = userSource,
-                        newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations,
-                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
-                    )).use {
+                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                            .withVisibleAnnotations(visibleAnnotations)
+                    })).use {
                         action(this)
                     }
                 }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -35,10 +35,12 @@ import java.nio.file.Files.isDirectory
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Collections.unmodifiableList
+import java.util.function.Consumer
 import java.util.function.Function
 import kotlin.concurrent.thread
 import kotlin.reflect.jvm.jvmName
 
+@Suppress("unused")
 abstract class TestBase(type: SandboxType) {
 
     companion object {
@@ -262,12 +264,11 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(
-                        userSource = userSource,
-                        newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations,
-                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
-                    )).use {
+                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                            .withVisibleAnnotations(visibleAnnotations)
+                    })).use {
                         assertThat(runtimeCosts).areZero()
                         action(this)
                     }

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
@@ -2,7 +2,6 @@ package net.corda.djvm.rewiring
 
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.Whitelist
-import net.corda.djvm.messages.Severity
 import net.corda.djvm.source.UserPathSource
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -21,12 +20,7 @@ class ByteCodeCacheTest {
     @Test
     fun testCacheWithParent() {
         val parentConfiguration = createAnalysisConfiguration()
-        val configuration = parentConfiguration.createChild(
-            userSource = UserPathSource(emptyList()),
-            newMinimumSeverityLevel = Severity.WARNING,
-            sandboxOnlyAnnotations = emptySet(),
-            visibleAnnotations = emptySet()
-        )
+        val configuration = parentConfiguration.createChild(UserPathSource(emptyList())).build()
         assertNotNull(configuration.parent)
         assertNull(configuration.parent!!.parent)
 

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
@@ -20,6 +20,7 @@ import java.nio.file.Files.exists
 import java.nio.file.Files.isDirectory
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.function.Consumer
 import kotlin.concurrent.thread
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
@@ -93,12 +94,11 @@ abstract class TestBase(type: SandboxType) {
         thread {
             try {
                 UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(
-                        userSource = userSource,
-                        newMinimumSeverityLevel = minimumSeverityLevel,
-                        visibleAnnotations = visibleAnnotations,
-                        sandboxOnlyAnnotations = sandboxOnlyAnnotations
-                    )).use {
+                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                            .withVisibleAnnotations(visibleAnnotations)
+                    })).use {
                         action(this)
                     }
                 }


### PR DESCRIPTION
Uncouple the `SandboxConfiguration` object from the `AnalysisConfiguration` object when creating a child sandbox by using a `Consumer` function.