### PR TITLE
Update JVM options for testing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ subprojects {
 
         // Configure the host timezone to match the DJVM's.
         systemProperty 'user.timezone', 'UTC'
+
+        // Choose which garbage-collector to use.
+        jvmArgs '-XX:+UseG1GC'
     }
 }
 

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -137,6 +137,10 @@ assemble.dependsOn shadowJar
 tasks.withType(Test) {
     systemProperty 'deterministic-rt.path', configurations.jdkRt.asPath
     systemProperty 'sandbox-libraries.path', configurations.sandboxTesting.asPath
+
+    // Disable JIT compilation of sandbox.* classes because they are discarded after use.
+    // https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
+    jvmArgs '-XX:CompileCommand=quiet', '-XX:CompileCommand=exclude,sandbox/*.*'
 }
 
 artifacts {


### PR DESCRIPTION
- Enable the G1 garbage collector.
- Disable JIT compilation for all `sandbox.*` classes because the effort is always wasted.