### PR TITLE
Fix some simple compiler warnings and errors with Java 11.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -72,7 +72,7 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
             }
 
             // Create the user's task object inside the sandbox.
-            val runnable = classLoader.loadClassForSandbox(runnableClass).newInstance()
+            val runnable = classLoader.loadClassForSandbox(runnableClass).getDeclaredConstructor().newInstance()
 
             val taskFactory = classLoader.createTaskFactory()
             val task = taskFactory.apply(runnable)

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxRawExecutor.kt
@@ -9,7 +9,7 @@ class SandboxRawExecutor(configuration: SandboxConfiguration) : Executor<Any?, A
     override fun run(runnableClass: ClassSource, input: Any?): ExecutionSummaryWithResult<Any?> {
         val result = IsolatedTask(runnableClass.qualifiedClassName, configuration).run {
             // Create the user's task object inside the sandbox.
-            val runnable = classLoader.loadClassForSandbox(runnableClass).newInstance()
+            val runnable = classLoader.loadClassForSandbox(runnableClass).getDeclaredConstructor().newInstance()
 
             val taskFactory = classLoader.createRawTaskFactory()
             val task = taskFactory.apply(runnable)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowDynamicInvocation.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowDynamicInvocation.kt
@@ -1,6 +1,5 @@
 package net.corda.djvm.rules.implementation
 
-import jdk.internal.org.objectweb.asm.Type
 import net.corda.djvm.code.Emitter
 import net.corda.djvm.code.EmitterContext
 import net.corda.djvm.code.EmitterModule
@@ -8,6 +7,7 @@ import net.corda.djvm.code.Instruction
 import net.corda.djvm.code.instructions.DynamicInvocationInstruction
 import net.corda.djvm.references.MemberReference
 import org.objectweb.asm.Handle
+import org.objectweb.asm.Type
 
 /**
  * Checks for invalid dynamic invocations.

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -164,6 +164,10 @@ class SourceClassLoader(
         val idx = name.lastIndexOf('.')
         if (idx > 0) {
             val packageName = name.substring(0, idx)
+            /**
+             * [getPackage] is deprecated in Java 9 and above.
+             */
+            @Suppress("deprecation")
             if (getPackage(packageName) == null) {
                 definePackage(packageName, null, null, null, null, null, null, null)
             }
@@ -196,7 +200,7 @@ class SourceClassLoader(
              * Without a special [ApiSource], we need
              * to fetch Java API classes from the JVM itself.
              */
-            return getSystemClassLoader().getResource(name)
+            return getSystemResource(name)
         }
 
         return userSource.findResource(name)

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -91,7 +91,7 @@ fun Throwable.escapeSandbox(): kotlin.Throwable {
             try {
                 escapingType.getDeclaredConstructor(kotlin.String::class.java).newInstance(String.fromDJVM(message))
             } catch (e: NoSuchMethodException) {
-                escapingType.newInstance()
+                escapingType.getDeclaredConstructor().newInstance()
             }
         } else {
             val escapingMessage = "$sandboxedName -> $message"
@@ -476,7 +476,7 @@ private fun Class<*>.createDJVMThrowable(t: kotlin.Throwable): Throwable {
         (try {
             getDeclaredConstructor(String::class.java).newInstance(String.toDJVM(t.message))
         } catch (_ : NoSuchMethodException) {
-            newInstance()
+            getDeclaredConstructor().newInstance()
         } as Throwable).apply {
             t.cause?.also {
                 initCause(it.toDJVMThrowable())
@@ -498,7 +498,7 @@ private fun Class<*>.createJavaThrowable(t: Throwable): kotlin.Throwable {
         (try {
             getDeclaredConstructor(kotlin.String::class.java).newInstance(String.fromDJVM(t.message))
         } catch (_ : NoSuchMethodException) {
-            newInstance()
+            getDeclaredConstructor().newInstance()
         }  as kotlin.Throwable).apply {
             t.cause?.also {
                 initCause(fromDJVM(it))
@@ -582,7 +582,7 @@ private fun loadResourceBundle(control: ResourceBundle.Control, key: DJVMResourc
     val bundle = try {
         val bundleClass = systemClassLoader.loadClass(toSandbox(bundleName.toString()))
         if (ResourceBundle::class.java.isAssignableFrom(bundleClass)) {
-            (bundleClass.newInstance() as ResourceBundle).also {
+            (bundleClass.getDeclaredConstructor().newInstance() as ResourceBundle).also {
                 it.init(key.baseName, key.locale)
             }
         } else {

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -297,7 +297,7 @@ abstract class TestBase(type: SandboxType) {
      * Run the entry-point of the loaded [Callable] class.
      */
     fun LoadedClass.createAndInvoke(methodName: String = "call") {
-        val instance = type.newInstance()
+        val instance = type.getDeclaredConstructor().newInstance()
         val method = instance.javaClass.getMethod(methodName)
         try {
             method.invoke(instance)

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -375,16 +375,15 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
             .isExactlyInstanceOf(SandboxException::class.java)
             .hasCauseExactlyInstanceOf(RuleViolationError::class.java)
             .hasMessageContaining("Disallowed reference to API;")
-            .hasMessageContaining("java.lang.Class.getMethods()")
+            .hasMessageContaining("java.lang.Class.getDeclaredConstructor(Class[])")
         assertThat(ex.cause).extracting { it.stackTrace.toList() }.asList().hasSize(2)
     }
 
     class TestReflection : Function<Int, Int> {
         override fun apply(input: Int): Int {
             val clazz = Object::class.java
-            val obj = clazz.newInstance()
-            val result = clazz.methods.first().invoke(obj)
-            return obj.hashCode() + result.hashCode()
+            val obj = clazz.getDeclaredConstructor().newInstance()
+            return obj.hashCode()
         }
     }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ClassRewriterTest.kt
@@ -87,7 +87,7 @@ class ClassRewriterTest : TestBase(KOTLIN) {
     @Test
     fun `cannot load internal Sun class that was deleted from Java runtime`() = sandbox {
         assertThatExceptionOfType(ClassNotFoundException::class.java)
-            .isThrownBy { loadClass<sun.misc.Timer>() }
+            .isThrownBy { loadClass("sun.misc.Timer") }
             .withMessageContaining("Class file not found: sun/misc/Timer.class")
     }
 


### PR DESCRIPTION
- Remove unnecessary references to `sun.*` classes.
- Replace `Class.newInstance()` with `Class.getDeclaredConstructor().newInstance()`.
- Use `Type` class from external ASM library instead of JDK's internal one.