### PR TITLE
CORDA-3286: Update the DJVM to run on Java 11,

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/String.java
+++ b/djvm/src/main/java/sandbox/java/lang/String.java
@@ -27,12 +27,14 @@ public final class String extends Object implements Comparable<String>, CharSequ
     private static final Constructor SHARED;
 
     static {
+        Constructor ctor;
         try {
-            SHARED = java.lang.String.class.getDeclaredConstructor(char[].class, java.lang.Boolean.TYPE);
-            SHARED.setAccessible(true);
+            ctor = java.lang.String.class.getDeclaredConstructor(char[].class, java.lang.Boolean.TYPE);
+            ctor.setAccessible(true);
         } catch (NoSuchMethodException e) {
-            throw new NoSuchMethodError(e.getMessage());
+            ctor = null;
         }
+        SHARED = ctor;
     }
 
     private final java.lang.String value;
@@ -106,14 +108,19 @@ public final class String extends Object implements Comparable<String>, CharSequ
     }
 
     String(char[] value, boolean share) {
-        java.lang.String newValue;
-        try {
-            // This is (presumably) an optimisation for memory usage.
-            newValue = (java.lang.String) SHARED.newInstance(value, share);
-        } catch (Exception e) {
-            newValue = new java.lang.String(value);
+        if (SHARED == null) {
+            // No exact equivalent for this constructor exists in Java 11.
+            this.value = new java.lang.String(value);
+        } else {
+            java.lang.String newValue;
+            try {
+                // This is (presumably) an optimisation for memory usage.
+                newValue = (java.lang.String) SHARED.newInstance(value, share);
+            } catch (Exception e) {
+                newValue = new java.lang.String(value);
+            }
+            this.value = newValue;
         }
-        this.value = newValue;
     }
 
     @Override

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -525,7 +525,7 @@ class AnalysisConfiguration private constructor(
                 descriptor = "()Lsandbox/javax/security/auth/x500/X500Principal;"
             ) {
                 /**
-                 * Reimplement [X500Name.asX500Principal] without reflection.
+                 * Reimplement [sandbox.sun.security.x509.X500Name.asX500Principal] without reflection.
                  *     return DJVM.create(this)
                  */
                 override fun writeBody(emitter: EmitterModule) = with(emitter) {
@@ -546,7 +546,7 @@ class AnalysisConfiguration private constructor(
                 descriptor = "(Lsandbox/javax/security/auth/x500/X500Principal;)Lsandbox/sun/security/x509/X500Name;"
             ) {
                 /**
-                 * Reimplement [X500Name.asX500Name] without reflection.
+                 * Reimplement [sandbox.sun.security.x509.X500Name.asX500Name] without reflection.
                  *     X500Name name = DJVM.unwrap(principal)
                  *     name.x500Principal = principal
                  *     return name

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -4,10 +4,7 @@ import net.corda.djvm.code.*
 import net.corda.djvm.formatting.MemberFormatter
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.references.*
-import net.corda.djvm.source.ApiSource
-import net.corda.djvm.source.EmptyApi
-import net.corda.djvm.source.SourceClassLoader
-import net.corda.djvm.source.UserSource
+import net.corda.djvm.source.*
 import org.objectweb.asm.Label
 import org.objectweb.asm.Opcodes.*
 import org.objectweb.asm.Type
@@ -83,9 +80,9 @@ class AnalysisConfiguration private constructor(
     fun isMappedAnnotation(descriptor: String): Boolean
                 = descriptor in allowedAnnotations || sandboxAnnotations.any { ann -> ann.matcher(descriptor).matches() }
 
-    fun toSandboxClassName(type: Class<*>): String {
-        val sandboxName = classResolver.resolve(Type.getInternalName(type))
-        return if (Throwable::class.java.isAssignableFrom(type)) {
+    fun toSandboxClassName(header: ClassHeader): String {
+        val sandboxName = classResolver.resolve(header.internalName)
+        return if (header.isThrowable) {
             exceptionResolver.getThrowableOwnerName(sandboxName)
         } else {
             sandboxName

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -308,8 +308,8 @@ class EmitterModule(
             type1 == OBJECT_NAME -> type1
             type2 == OBJECT_NAME -> type2
             else -> {
-                val class1 = configuration.supportingClassLoader.loadClass(type1.asPackagePath)
-                val class2 = configuration.supportingClassLoader.loadClass(type2.asPackagePath)
+                val class1 = configuration.supportingClassLoader.loadClassHeader(type1.asPackagePath)
+                val class2 = configuration.supportingClassLoader.loadClassHeader(type2.asPackagePath)
                 when {
                     class1.isAssignableFrom(class2) -> type1
                     class2.isAssignableFrom(class1) -> type2
@@ -317,9 +317,9 @@ class EmitterModule(
                     else -> {
                         var commonClass = class1
                         do {
-                            commonClass = commonClass.superclass
+                            commonClass = commonClass.superclass ?: break
                         } while (!commonClass.isAssignableFrom(class2))
-                        Type.getInternalName(commonClass)
+                        commonClass.internalName
                     }
                 }
             }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -293,7 +293,7 @@ class SandboxClassLoader private constructor(
                 if (!isSandboxClass || parent is SandboxClassLoader) {
                     try {
                         clazz = super.loadClass(name, false)
-                    } catch (e: ClassNotFoundException) {
+                    } catch (_: ClassNotFoundException) {
                     }
                 }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassWriter.kt
@@ -35,18 +35,18 @@ open class SandboxClassWriter(
      * Get the common super type of [type1] and [type2].
      */
     override fun getCommonSuperClass(type1: String, type2: String): String {
-        // Need to override [getCommonSuperClass] to ensure that we use SourceClassLoader.loadSourceClass().
+        // Need to override [getCommonSuperClass] to ensure that we use SourceClassLoader.loadSourceHeader().
         return when {
             type1 == OBJECT_NAME -> type1
             type2 == OBJECT_NAME -> type2
             else -> {
                 val class1 = try {
-                    classLoader.loadSourceClass(type1.asPackagePath)
+                    classLoader.loadSourceHeader(type1.asPackagePath)
                 } catch (exception: Exception) {
                     throw TypeNotPresentException(type1, exception)
                 }
                 val class2 = try {
-                    classLoader.loadSourceClass(type2.asPackagePath)
+                    classLoader.loadSourceHeader(type2.asPackagePath)
                 } catch (exception: Exception) {
                     throw TypeNotPresentException(type2, exception)
                 }
@@ -57,7 +57,7 @@ open class SandboxClassWriter(
                     else -> {
                         var clazz = class1
                         do {
-                            clazz = clazz.superclass
+                            clazz = clazz.superclass ?: break
                         } while (!clazz.isAssignableFrom(class2))
 
                         // Return name of a common superclass within the sandbox.

--- a/djvm/src/main/kotlin/net/corda/djvm/source/ClassHeader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/ClassHeader.kt
@@ -1,0 +1,44 @@
+package net.corda.djvm.source
+
+import net.corda.djvm.code.THROWABLE_NAME
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * A "cut to the bone" replacement for [Class] so that we can compute
+ * two classes' common superclass without actually loading them.
+ */
+class ClassHeader(
+    val classLoader: SourceClassLoader,
+    val name: String,
+    val internalName: String,
+    val superclass: ClassHeader?,
+    val interfaces: Set<ClassHeader>,
+    val flags: Int
+) {
+    private fun isAssignableFromClass(header: ClassHeader): Boolean {
+        var current = header
+        while (true) {
+            if (current.internalName == internalName) {
+                return true
+            }
+            current = current.superclass ?: break
+        }
+        return false
+    }
+
+    private fun isAssignableFromInterface(header: ClassHeader): Boolean {
+        return internalName == header.internalName || header.interfaces.any(::isAssignableFromInterface)
+    }
+
+    fun isAssignableFrom(header: ClassHeader): Boolean {
+        return if (isInterface) {
+            isAssignableFromInterface(header)
+        } else {
+            isAssignableFromClass(header)
+        }
+    }
+
+    val isInterface: Boolean get() = (flags and ACC_INTERFACE) != 0
+
+    val isThrowable: Boolean get() = internalName == THROWABLE_NAME || (superclass != null && superclass.isThrowable)
+}


### PR DESCRIPTION
- Update `sandbox.java.lang.String` to be compatible with Java 11.
- Rewrite `SourceClassLoader` to load `ClassHeader` instead of `Class` for sake of ASM's "common superclass" algorithm.

The "common superclass" algorithm needs to be able to load `java.*` byte-code from `deterministic-rt.jar` in order to determine whether `A` is assignable to `B`. This means that we _*cannot*_ load `Class` instances because a Java `ClassLoader` refuses to create new classes for the `java.*` package space. (Only the bootstrap classloader can do that.) So I've created `ClassHeader` as a bare-bones replacement for `Class` that is _just_ enough for ASM's "common superclass" algorithm to use instead.

This should also effectively fix #27, although some of the DJVM's unit tests will still fail due to their expectations being based around Java 8.