### PR TITLE
CORDA-3292: Reimplement ExecutionProfile as an immutable data class.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -7,7 +7,7 @@ import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
-import net.corda.djvm.execution.ExecutionProfile.*
+import net.corda.djvm.execution.ExecutionProfile.Companion.UNLIMITED
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.messages.Severity.*
 import net.corda.djvm.source.BootstrapClassLoader

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionProfile.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionProfile.kt
@@ -1,5 +1,7 @@
 package net.corda.djvm.execution
 
+import kotlin.Long.Companion.MAX_VALUE
+
 /**
  * The execution profile of a [java.util.function.Function] when run in a sandbox.
  *
@@ -8,38 +10,55 @@ package net.corda.djvm.execution
  * @property jumpCostThreshold The threshold placed on jumps.
  * @property throwCostThreshold The threshold placed on throw statements.
  */
-enum class ExecutionProfile(
-        val allocationCostThreshold: Long = Long.MAX_VALUE,
-        val invocationCostThreshold: Long = Long.MAX_VALUE,
-        val jumpCostThreshold: Long = Long.MAX_VALUE,
-        val throwCostThreshold: Long = Long.MAX_VALUE
+data class ExecutionProfile(
+    val allocationCostThreshold: Long,
+    val invocationCostThreshold: Long,
+    val jumpCostThreshold: Long,
+    val throwCostThreshold: Long
 ) {
-
-    // TODO Define sensible runtime thresholds and make further improvements to instrumentation.
-
-    /**
-     * Profile with a set of default thresholds.
-     */
-    DEFAULT(
+    companion object {
+        /**
+         * Profile with a set of default thresholds.
+         */
+        @JvmField
+        val DEFAULT = ExecutionProfile(
             allocationCostThreshold = 1024 * 1024 * 1024,
             invocationCostThreshold = 1_000_000,
             jumpCostThreshold = 1_000_000,
             throwCostThreshold = 1_000_000
-    ),
+        )
 
-    /**
-     * Profile where no limitations have been imposed on the sandbox.
-     */
-    UNLIMITED(),
+        /**
+         * Profile where no limitations have been imposed on the sandbox.
+         */
+        @JvmField
+        val UNLIMITED = ExecutionProfile(
+            allocationCostThreshold = MAX_VALUE,
+            invocationCostThreshold = MAX_VALUE,
+            jumpCostThreshold = MAX_VALUE,
+            throwCostThreshold = MAX_VALUE
+        )
 
-    /**
-     * Profile where throw statements have been disallowed.
-     */
-    DISABLE_THROWS(throwCostThreshold = 0),
+        /**
+         * Profile where throw statements have been disallowed.
+         */
+        @JvmField
+        val DISABLE_THROWS = ExecutionProfile(
+            allocationCostThreshold = MAX_VALUE,
+            invocationCostThreshold = MAX_VALUE,
+            jumpCostThreshold = MAX_VALUE,
+            throwCostThreshold = 0
+        )
 
-    /**
-     * Profile where branching statements have been disallowed.
-     */
-    DISABLE_BRANCHING(jumpCostThreshold = 0)
-
+        /**
+         * Profile where branching statements have been disallowed.
+         */
+        @JvmField
+        val DISABLE_BRANCHING = ExecutionProfile(
+            allocationCostThreshold = MAX_VALUE,
+            invocationCostThreshold = MAX_VALUE,
+            jumpCostThreshold = 0,
+            throwCostThreshold = MAX_VALUE
+        )
+    }
 }

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
@@ -7,7 +7,7 @@ import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
-import net.corda.djvm.execution.ExecutionProfile.*
+import net.corda.djvm.execution.ExecutionProfile.Companion.UNLIMITED
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.messages.Severity.*
 import net.corda.djvm.source.BootstrapClassLoader


### PR DESCRIPTION
Reimplement `ExecutionProfile` as an immutable data class instead of an enum. This allows DJVM clients (i.e. the Corda Node) to create a tuned profile rather than relying on a limited set of predefined ones.