### PR TITLE
CORDA-3286: Detect when a superclass can be assigned to an interface.

### DIFF
--- a/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
@@ -109,7 +109,7 @@ class SourceClassLoaderTest {
     }
 
     @Test
-    fun `test interface headers are assignable`() {
+    fun `test interfaces are assignable to interfaces`() {
         UserPathSource(arrayOf(Action::class.java.protectionDomain.codeSource.location)).use { parentSource ->
             val parentLoader = SourceClassLoader(classResolver, parentSource)
 
@@ -127,7 +127,7 @@ class SourceClassLoaderTest {
     }
 
     @Test
-    fun `test class headers are assignable`() {
+    fun `test classes are assignable to classes`() {
         UserPathSource(arrayOf(Action::class.java.protectionDomain.codeSource.location)).use { parentSource ->
             val parentLoader = SourceClassLoader(classResolver, parentSource)
 
@@ -161,24 +161,44 @@ class SourceClassLoaderTest {
     }
 
     @Test
-    fun `test loading throwables`() {
+    fun `test classes are assignable to superinterfaces`() {
         UserPathSource(arrayOf(Action::class.java.protectionDomain.codeSource.location)).use { parentSource ->
             val parentLoader = SourceClassLoader(classResolver, parentSource)
 
+            val iterable = parentLoader.loadClassHeader("java.lang.Iterable")
+            assertTrue(iterable.isInterface)
+
+            val linkedHashSet = parentLoader.loadClassHeader("java.util.LinkedHashSet")
+            assertFalse(linkedHashSet.isInterface)
+            assertTrue(iterable.isAssignableFrom(linkedHashSet))
+        }
+    }
+
+    @Test
+    fun `test loading throwables`() {
+        UserPathSource(arrayOf(Action::class.java.protectionDomain.codeSource.location)).use { parentSource ->
+            val parentLoader = SourceClassLoader(classResolver, parentSource)
+            val serializable = parentLoader.loadClassHeader("java.io.Serializable")
+
             val throwable = parentLoader.loadClassHeader("java.lang.Throwable")
             assertTrue(throwable.isThrowable)
+            assertTrue(serializable.isAssignableFrom(throwable))
 
             val exception = parentLoader.loadClassHeader("java.lang.Exception")
             assertTrue(exception.isThrowable)
+            assertTrue(serializable.isAssignableFrom(exception))
 
             val runtimeException = parentLoader.loadClassHeader("java.lang.RuntimeException")
             assertTrue(runtimeException.isThrowable)
+            assertTrue(serializable.isAssignableFrom(runtimeException))
 
             val error = parentLoader.loadClassHeader("java.lang.Error")
             assertTrue(error.isThrowable)
+            assertTrue(serializable.isAssignableFrom(error))
 
             val baseObject = parentLoader.loadClassHeader("java.lang.Object")
             assertFalse(baseObject.isThrowable)
+            assertFalse(serializable.isAssignableFrom(baseObject))
         }
     }
 


### PR DESCRIPTION
There are four cases to consider for `class1.isAssignableFrom(class2)`:
- `class1`, `class2` are both classes: `class1.internalName` must match either `class2.internalName` or the `internalName` for any of `class2`'s superclasses.
- `class1` is a class and `class2` is an interface: This can never succeed.
- `class1` is an interface and `class2` is a class: `class1.internalName` must match either the `internalName`  for any of `class2`'s interfaces, any interface implemented by one of `class2`'s superclasses, or any superinterface of any of these interfaces.
- `class1`, `class2` are both interfaces: `class1.internalName` must match either `class2.internalName`, the `internalName` for any of `class2`'s interfaces, or any of their superinterfaces.

We need to cover all of these cases and ensure that sufficient tests are in place.