### PR TITLE
More robust handling for exceptions thrown by Constructor.newInstance().

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -89,6 +89,11 @@ class AnalysisConfiguration private constructor(
         }
     }
 
+    @Throws(ClassNotFoundException::class)
+    fun getSourceHeader(internalClassName: String): ClassHeader {
+        return supportingClassLoader.loadClassHeader(internalClassName.asPackagePath)
+    }
+
     /**
      * Creates a [ChildBuilder], which will build a child [AnalysisConfiguration]
      * with this instance as its parent. The child inherits the same [whitelist].

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -3,6 +3,7 @@ package net.corda.djvm.code
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.references.MemberInformation
 import net.corda.djvm.references.MethodBody
+import net.corda.djvm.source.ClassHeader
 import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes.*
@@ -308,8 +309,8 @@ class EmitterModule(
             type1 == OBJECT_NAME -> type1
             type2 == OBJECT_NAME -> type2
             else -> {
-                val class1 = configuration.supportingClassLoader.loadClassHeader(type1.asPackagePath)
-                val class2 = configuration.supportingClassLoader.loadClassHeader(type2.asPackagePath)
+                val class1 = configuration.getSourceHeader(type1)
+                val class2 = configuration.getSourceHeader(type2)
                 when {
                     class1.isAssignableFrom(class2) -> type1
                     class2.isAssignableFrom(class1) -> type2

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutReflectionMethods.kt
@@ -14,7 +14,7 @@ object StubOutReflectionMethods : MemberDefinitionProvider {
     )
 
     override fun define(context: AnalysisRuntimeContext, member: Member): Member = when {
-        member.isMethod && isConcreteApi(member) && isReflection(member) && !isAllowedFor(member)
+        member.isMethod && isConcreteApi(member) && isReflection(member) && !isAllowedFor(context, member)
              -> member.copy(body = member.body + MemberRuleEnforcer(member)::forbidReflection)
         else -> member
     }
@@ -29,5 +29,7 @@ object StubOutReflectionMethods : MemberDefinitionProvider {
                || member.className == "sun/misc/Unsafe"
     }
 
-    private fun isAllowedFor(member: Member): Boolean = member.className in ALLOWS_REFLECTION
+    private fun isAllowedFor(context: AnalysisRuntimeContext, member: Member): Boolean {
+        return member.className in ALLOWS_REFLECTION || context.configuration.getSourceHeader(member.className).isThrowable
+    }
 }

--- a/djvm/src/test/kotlin/com/example/testing/HasBrokenConstructor.kt
+++ b/djvm/src/test/kotlin/com/example/testing/HasBrokenConstructor.kt
@@ -1,0 +1,14 @@
+package com.example.testing
+
+/**
+ * The DJVM refuses even to try loading classes from the
+ * net.corda.djvm package into the sandbox. And so this
+ * class lives in a "safe" package "com.example.testing".
+ */
+@Suppress("unused")
+class HasBrokenConstructor(initialValue: Int) {
+    // This constructor should trigger an integer overflow.
+    constructor() : this(1)
+
+    val number: Int = Int.MAX_VALUE + initialValue
+}

--- a/djvm/src/test/kotlin/com/example/testing/HasProtectedConstructor.kt
+++ b/djvm/src/test/kotlin/com/example/testing/HasProtectedConstructor.kt
@@ -1,0 +1,15 @@
+package com.example.testing
+
+/**
+ * The DJVM refuses even to try loading classes from the
+ * net.corda.djvm package into the sandbox. And so this
+ * class lives in a "safe" package "com.example.testing".
+ */
+open class HasProtectedConstructor(val message: String) {
+    @Suppress("unused")
+    protected constructor() : this("Protected!")
+
+    override fun toString(): String {
+        return "HasProtectedConstructor: message=$message"
+    }
+}

--- a/djvm/src/test/kotlin/com/example/testing/HasUserExceptionConstructor.kt
+++ b/djvm/src/test/kotlin/com/example/testing/HasUserExceptionConstructor.kt
@@ -1,0 +1,14 @@
+package com.example.testing
+
+import java.io.FileNotFoundException
+
+/**
+ * The DJVM refuses even to try loading classes from the
+ * net.corda.djvm package into the sandbox. And so this
+ * class lives in a "safe" package "com.example.testing".
+ */
+class HasUserExceptionConstructor {
+    init {
+        throw FileNotFoundException("missing.dat")
+    }
+}

--- a/djvm/src/test/kotlin/com/example/testing/ImpossibleInstance.kt
+++ b/djvm/src/test/kotlin/com/example/testing/ImpossibleInstance.kt
@@ -1,0 +1,8 @@
+package com.example.testing
+
+/**
+ * The DJVM refuses even to try loading classes from the
+ * net.corda.djvm package into the sandbox. And so this
+ * class lives in a "safe" package "com.example.testing".
+ */
+abstract class ImpossibleInstance

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/BasicCryptoTest.kt
@@ -3,7 +3,6 @@ package net.corda.djvm.execution
 import net.corda.djvm.SandboxType.KOTLIN
 import net.corda.djvm.TestBase
 import org.assertj.core.api.Assertions.assertThat
-import java.util.function.Function
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -14,6 +13,7 @@ import java.security.*
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.X509EncodedKeySpec
+import java.util.function.Function
 import java.util.stream.Stream
 
 class BasicCryptoTest : TestBase(KOTLIN) {

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ExpectedException.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ExpectedException.kt
@@ -1,0 +1,6 @@
+package net.corda.djvm.execution
+
+class ExpectedException(message: String?, cause: Throwable?) : RuntimeException(message, cause) {
+    constructor(message: String?) : this(message, null)
+    constructor() : this(null, null)
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/NewInstanceFailureTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/NewInstanceFailureTest.kt
@@ -1,0 +1,71 @@
+package net.corda.djvm.execution
+
+import com.example.testing.HasBrokenConstructor
+import com.example.testing.HasProtectedConstructor
+import com.example.testing.HasUserExceptionConstructor
+import com.example.testing.ImpossibleInstance
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.FileNotFoundException
+import java.util.function.Function
+
+class NewInstanceFailureTest : TestBase(KOTLIN) {
+    @Test
+    fun `new instance permission failure`() = sandbox {
+        val taskFactory = classLoader.createTaskFactory()
+        val newInstance = classLoader.typedTaskFor(taskFactory, FailingNewInstance::class.java)
+        val t = assertThrows<RuntimeException> { newInstance.apply(HasProtectedConstructor::class.java.name) }
+        assertThat(t)
+            .hasCauseExactlyInstanceOf(IllegalAccessException::class.java)
+            .hasMessageStartingWith("sandbox.net.corda.djvm.execution.ExpectedException -> REFLECTION,sandbox.java.lang.IllegalAccessException,")
+            .hasMessageContaining(HasProtectedConstructor::class.java.name)
+            .hasMessageContaining("protected strictfp")
+    }
+
+    @Test
+    fun `new instance constructor failure`() = sandbox {
+        val taskFactory = classLoader.createTaskFactory()
+        val newInstance = classLoader.typedTaskFor(taskFactory, FailingNewInstance::class.java)
+        val t = assertThrows<RuntimeException> { newInstance.apply(HasBrokenConstructor::class.java.name) }
+        assertThat(t)
+            .hasCauseExactlyInstanceOf(ArithmeticException::class.java)
+            .hasMessage("sandbox.net.corda.djvm.execution.ExpectedException -> sandbox.java.lang.ArithmeticException,integer overflow")
+    }
+
+    @Test
+    fun `new instance instantiate failure`() = sandbox {
+        val taskFactory = classLoader.createTaskFactory()
+        val newInstance = classLoader.typedTaskFor(taskFactory, FailingNewInstance::class.java)
+        val t = assertThrows<RuntimeException> { newInstance.apply(ImpossibleInstance::class.java.name) }
+        assertThat(t)
+            .hasCauseExactlyInstanceOf(InstantiationException::class.java)
+            .hasMessageStartingWith("sandbox.net.corda.djvm.execution.ExpectedException -> REFLECTION,sandbox.java.lang.InstantiationException,")
+    }
+
+    @Test
+    fun `new instance constructor user failure`() = sandbox {
+        val taskFactory = classLoader.createTaskFactory()
+        val newInstance = classLoader.typedTaskFor(taskFactory, FailingNewInstance::class.java)
+        val t = assertThrows<Exception> { newInstance.apply(HasUserExceptionConstructor::class.java.name) }
+        assertThat(t)
+            .hasCauseExactlyInstanceOf(Exception::class.java)
+            .hasMessage("sandbox.net.corda.djvm.execution.ExpectedException -> FILE-NOT-FOUND,sandbox.java.io.FileNotFoundException,missing.dat")
+    }
+
+    class FailingNewInstance : Function<String, String?> {
+        override fun apply(className: String): String? {
+            try {
+                return javaClass.classLoader.loadClass(className).newInstance().toString()
+            } catch (e: ReflectiveOperationException) {
+                throw ExpectedException("REFLECTION,${e::class.java.name},${e.message}", e)
+            } catch (e: FileNotFoundException) {
+                throw ExpectedException("FILE-NOT-FOUND,${e::class.java.name},${e.message}", e)
+            } catch (e: Exception) {
+                throw ExpectedException("${e::class.java.name},${e.message}", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Do not stub out methods on java.lang.reflect.* exception classes.
- Similarly for java.lang.invoke.* exceptions too.
- Also handle exception constructor with args (Throwable, String).