### PR TITLE
CORDA-3309: Install UncaughtExceptionHandler for DJVM tasks.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -89,7 +89,7 @@ abstract class TestBase(type: SandboxType) {
         action: SandboxRuntimeContext.() -> Unit
     ) {
         var thrownException: Throwable? = null
-        thread {
+        thread(start = false) {
             try {
                 UserPathSource(classPaths).use { userSource ->
                     SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
@@ -103,7 +103,13 @@ abstract class TestBase(type: SandboxType) {
             } catch (exception: Throwable) {
                 thrownException = exception
             }
-        }.join()
+        }.apply {
+            uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
+                thrownException = ex
+            }
+            start()
+            join()
+        }
         throw thrownException ?: return
     }
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -215,7 +215,7 @@ abstract class TestBase(type: SandboxType) {
             }
         }
         var thrownException: Throwable? = null
-        thread {
+        thread(start = false) {
             try {
                 UserPathSource(classPaths).use { userSource ->
                     val analysisConfiguration = AnalysisConfiguration.createRoot(
@@ -241,7 +241,13 @@ abstract class TestBase(type: SandboxType) {
             } catch (exception: Throwable) {
                 thrownException = exception
             }
-        }.join()
+        }.apply {
+            uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
+                thrownException = ex
+            }
+            start()
+            join()
+        }
         throw thrownException ?: return
     }
 
@@ -261,7 +267,7 @@ abstract class TestBase(type: SandboxType) {
         action: SandboxRuntimeContext.() -> Unit
     ) {
         var thrownException: Throwable? = null
-        thread {
+        thread(start = false) {
             try {
                 UserPathSource(classPaths).use { userSource ->
                     SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
@@ -276,7 +282,13 @@ abstract class TestBase(type: SandboxType) {
             } catch (exception: Throwable) {
                 thrownException = exception
             }
-        }.join()
+        }.apply {
+            uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
+                thrownException = ex
+            }
+            start()
+            join()
+        }
         throw thrownException ?: return
     }
 

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
@@ -91,7 +91,7 @@ abstract class TestBase(type: SandboxType) {
         action: SandboxRuntimeContext.() -> Unit
     ) {
         var thrownException: Throwable? = null
-        thread {
+        thread(start = false) {
             try {
                 UserPathSource(classPaths).use { userSource ->
                     SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
@@ -105,7 +105,13 @@ abstract class TestBase(type: SandboxType) {
             } catch (exception: Throwable) {
                 thrownException = exception
             }
-        }.join()
+        }.apply {
+            uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
+                thrownException = ex
+            }
+            start()
+            join()
+        }
         throw thrownException ?: return
     }
 }


### PR DESCRIPTION
Install an `UncaughtExceptionHandler` for each DJVM task thread so that any exceptions from (say) creating the `SandboxClassLoader` are not lost.

Avian _does_ support `Thread.UncaughtExceptionHandler` :wink:.