### PR TITLE
CORDA-3309; Remove explicit try-catch in favour of UncaughtExceptionHandler.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -90,18 +90,14 @@ abstract class TestBase(type: SandboxType) {
     ) {
         var thrownException: Throwable? = null
         thread(start = false) {
-            try {
-                UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
-                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
-                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
-                            .withVisibleAnnotations(visibleAnnotations)
-                    })).use {
-                        action(this)
-                    }
+            UserPathSource(classPaths).use { userSource ->
+                SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                    it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                        .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                        .withVisibleAnnotations(visibleAnnotations)
+                })).use {
+                    action(this)
                 }
-            } catch (exception: Throwable) {
-                thrownException = exception
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -216,30 +216,26 @@ abstract class TestBase(type: SandboxType) {
         }
         var thrownException: Throwable? = null
         thread(start = false) {
-            try {
-                UserPathSource(classPaths).use { userSource ->
-                    val analysisConfiguration = AnalysisConfiguration.createRoot(
-                        userSource = userSource,
-                        whitelist = whitelist,
-                        visibleAnnotations = visibleAnnotations,
-                        sandboxOnlyAnnotations = sandboxOnlyAnnotations,
-                        minimumSeverityLevel = minimumSeverityLevel,
-                        bootstrapSource = bootstrapClassLoader
-                    )
-                    SandboxRuntimeContext(SandboxConfiguration.of(
-                        executionProfile,
-                        rules.distinctBy(Any::javaClass),
-                        emitters.distinctBy(Any::javaClass),
-                        definitionProviders.distinctBy(Any::javaClass),
-                        enableTracing,
-                        analysisConfiguration
-                    )).use {
-                        assertThat(runtimeCosts).areZero()
-                        action(this)
-                    }
+            UserPathSource(classPaths).use { userSource ->
+                val analysisConfiguration = AnalysisConfiguration.createRoot(
+                    userSource = userSource,
+                    whitelist = whitelist,
+                    visibleAnnotations = visibleAnnotations,
+                    sandboxOnlyAnnotations = sandboxOnlyAnnotations,
+                    minimumSeverityLevel = minimumSeverityLevel,
+                    bootstrapSource = bootstrapClassLoader
+                )
+                SandboxRuntimeContext(SandboxConfiguration.of(
+                    executionProfile,
+                    rules.distinctBy(Any::javaClass),
+                    emitters.distinctBy(Any::javaClass),
+                    definitionProviders.distinctBy(Any::javaClass),
+                    enableTracing,
+                    analysisConfiguration
+                )).use {
+                    assertThat(runtimeCosts).areZero()
+                    action(this)
                 }
-            } catch (exception: Throwable) {
-                thrownException = exception
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
@@ -268,19 +264,15 @@ abstract class TestBase(type: SandboxType) {
     ) {
         var thrownException: Throwable? = null
         thread(start = false) {
-            try {
-                UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
-                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
-                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
-                            .withVisibleAnnotations(visibleAnnotations)
-                    })).use {
-                        assertThat(runtimeCosts).areZero()
-                        action(this)
-                    }
+            UserPathSource(classPaths).use { userSource ->
+                SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                    it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                        .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                        .withVisibleAnnotations(visibleAnnotations)
+                })).use {
+                    assertThat(runtimeCosts).areZero()
+                    action(this)
                 }
-            } catch (exception: Throwable) {
-                thrownException = exception
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->

--- a/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
+++ b/serialization/src/test/kotlin/net/corda/djvm/serialization/TestBase.kt
@@ -92,18 +92,14 @@ abstract class TestBase(type: SandboxType) {
     ) {
         var thrownException: Throwable? = null
         thread(start = false) {
-            try {
-                UserPathSource(classPaths).use { userSource ->
-                    SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
-                        it.withNewMinimumSeverityLevel(minimumSeverityLevel)
-                            .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
-                            .withVisibleAnnotations(visibleAnnotations)
-                    })).use {
-                        action(this)
-                    }
+            UserPathSource(classPaths).use { userSource ->
+                SandboxRuntimeContext(parentConfiguration.createChild(userSource, Consumer {
+                    it.withNewMinimumSeverityLevel(minimumSeverityLevel)
+                        .withSandboxOnlyAnnotations(sandboxOnlyAnnotations)
+                        .withVisibleAnnotations(visibleAnnotations)
+                })).use {
+                    action(this)
                 }
-            } catch (exception: Throwable) {
-                thrownException = exception
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->


### PR DESCRIPTION
Use `UncaughtExceptionHandler` to catch _all_ task exceptions. This should make the exception-handling logic simpler. by removing some "magic" from `IsolatedTask` concerning "provisional" `SandboxClassLoader` errors,