### PR TITLE
Add calendars.properties to the DJVM.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -118,7 +118,7 @@ shadowJar {
     exclude 'sandbox/java/util/*List*.class'
     exclude 'sandbox/java/util/*Map*.class'
     exclude 'sandbox/java/util/*Set*.class'
-    exclude 'sandbox/java/util/Collection.class'
+    exclude 'sandbox/java/util/Collection*.class'
     exclude 'sandbox/java/util/Comparator.class'
     exclude 'sandbox/java/util/Currency.class'
     exclude "sandbox/java/util/Date.class"

--- a/djvm/src/main/java/sandbox/java/util/Collections.java
+++ b/djvm/src/main/java/sandbox/java/util/Collections.java
@@ -1,0 +1,14 @@
+package sandbox.java.util;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.Collections}
+ * to allow us to compile {@link sandbox.java.util.ServiceLoader}.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class Collections extends sandbox.java.lang.Object {
+    private static final String NOT_IMPLEMENTED = "Dummy class - not implemented";
+
+    public static <T> Iterator<T> emptyIterator() {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+    }
+}

--- a/djvm/src/main/java/sandbox/java/util/Properties.java
+++ b/djvm/src/main/java/sandbox/java/util/Properties.java
@@ -1,13 +1,17 @@
 package sandbox.java.util;
 
+import sandbox.java.io.InputStream;
 import sandbox.java.lang.String;
+
+import java.io.IOException;
 
 /**
  * This is a dummy class that implements just enough of {@link java.util.Properties}
  * to allow us to compile {@link sandbox.java.lang.DJVM}.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"RedundantThrows", "WeakerAccess", "unused"})
 public final class Properties extends Hashtable<Object, Object> {
+    private static final java.lang.String NOT_IMPLEMENTED = "Dummy class - not implemented";
 
     public Object setProperty(String key, String value) {
         return put(key, value);
@@ -20,5 +24,9 @@ public final class Properties extends Hashtable<Object, Object> {
     public String getProperty(String key, String defaultValue) {
         String value = getProperty(key);
         return (value == null) ? defaultValue : value;
+    }
+
+    public void load(InputStream inStream) throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 }

--- a/djvm/src/main/java/sandbox/java/util/ServiceLoader.java
+++ b/djvm/src/main/java/sandbox/java/util/ServiceLoader.java
@@ -1,0 +1,43 @@
+package sandbox.java.util;
+
+import sandbox.java.lang.Iterable;
+import sandbox.java.lang.String;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("unused")
+public final class ServiceLoader<T> extends sandbox.java.lang.Object implements Iterable<T> {
+    private final Class<T> service;
+
+    private ServiceLoader(Class<T> service, ClassLoader cl) {
+        this.service = service;
+    }
+
+    public void reload() {}
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @NotNull
+    public static <S> ServiceLoader<S> load(Class<S> service, ClassLoader loader) {
+        return new ServiceLoader<>(service, loader);
+    }
+
+    @NotNull
+    public static <S> ServiceLoader<S> load(Class<S> service) {
+        return ServiceLoader.load(service, null);
+    }
+
+    @NotNull
+    public static <S> ServiceLoader<S> loadInstalled(Class<S> service) {
+        return ServiceLoader.load(service, null);
+    }
+
+    @Override
+    @NotNull
+    public String toDJVMString() {
+        return String.toDJVM("java.util.ServiceLoader[" + service.getName() + ']');
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -248,6 +248,7 @@ class AnalysisConfiguration private constructor(
             java.lang.Throwable::class.java,
             java.lang.ref.Reference::class.java,
             java.security.AccessController::class.java,
+            java.util.ServiceLoader::class.java,
             java.util.concurrent.ConcurrentHashMap::class.java,
             java.util.concurrent.ConcurrentHashMap.KeySetView::class.java,
             java.util.concurrent.atomic.AtomicInteger::class.java,
@@ -419,6 +420,7 @@ class AnalysisConfiguration private constructor(
          * trying to invoke [sun.misc.Unsafe] and other assorted native methods.
          */
         private val STITCHED_CLASSES: Map<String, List<Member>> = unmodifiable((
+            generateJavaCalendarMethods() +
             generateJavaTimeMethods() +
             generateJavaResourceBundleMethods() +
             generateJavaUuidMethods() +

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaCalendarConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaCalendarConfiguration.kt
@@ -1,0 +1,29 @@
+@file:JvmName("JavaCalendarConfiguration")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.code.DJVM_NAME
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.references.Member
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ACC_STATIC
+
+/**
+ * Generate [Member] objects that will be stitched into [sandbox.sun.util.calendar.CalendarSystem].
+ */
+fun generateJavaCalendarMethods(): List<Member> = listOf(
+        object : MethodBuilder(
+            access = ACC_PUBLIC or ACC_STATIC,
+            className = "sandbox/sun/util/calendar/CalendarSystem",
+            memberName = "getCalendarProperties",
+            descriptor = "()Lsandbox/java/util/Properties;"
+        ) {
+            /**
+             * Replace getCalendarProperties():
+             *     return DJVM.getCalendarProperties()
+             */
+            override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                invokeStatic(DJVM_NAME, memberName, descriptor)
+                returnObject()
+            }
+        }.withBody().build()
+)

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -14,6 +14,7 @@ import sandbox.isEntryPoint
 import sandbox.java.io.*
 import sandbox.java.nio.ByteOrder
 import sandbox.java.util.*
+import java.io.IOException
 import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 
@@ -344,6 +345,16 @@ fun getSystemResourceAsStream(name: kotlin.String): InputStream? {
 fun loadSystemResource(name: kotlin.String): DataInputStream {
     val input = getSystemResourceAsStream(name) ?: throw InternalError("Missing $name")
     return DataInputStream(BufferedInputStream(input))
+}
+
+/**
+ * Return [Properties] containing system's calendars.properties file.
+ */
+@Throws(IOException::class)
+fun getCalendarProperties(): Properties {
+    return Properties().apply {
+        load(loadSystemResource("calendars.properties"))
+    }
 }
 
 /**

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaChronologyTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaChronologyTest.java
@@ -1,0 +1,48 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import org.junit.jupiter.api.Test;
+
+import java.time.chrono.Chronology;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JavaChronologyTest extends TestBase {
+    JavaChronologyTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testAvailableChronologies() {
+        sandbox(ctx -> {
+            try {
+                Function<? super Object, ? extends Function<? super Object, ?>> taskFactory = ctx.getClassLoader().createTaskFactory();
+
+                Function<? super String, String[]> chronologyTask = typedTaskFor(ctx.getClassLoader(), taskFactory, GetChronologyNames.class);
+                String[] chronologies = chronologyTask.apply(null);
+                assertThat(chronologies).contains(
+                    "Hijrah-umalqura",
+                    "ISO",
+                    "Japanese",
+                    "Minguo",
+                    "ThaiBuddhist"
+                );
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class GetChronologyNames implements Function<String, String[]> {
+        @Override
+        public String[] apply(String s) {
+            return Chronology.getAvailableChronologies().stream()
+                .map(Chronology::getId)
+                .toArray(String[]::new);
+        }
+    }
+}


### PR DESCRIPTION
Reimplement `sun.util.calendar.CalendarSystem.getCalendarProperties()` to fetch the `calendars.properties` file from the DJVM's system resources.

This allows us to instantiate the JVM's built-in `Chronology` objects.