### PR TITLE
Make API more Java-friendly by removing constructor default parameters.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -37,7 +37,7 @@ open class ClassAndMemberVisitor(
     /**
      * The current source location.
      */
-    private var sourceLocation = SourceLocation()
+    private var sourceLocation = SourceLocation.Builder().build()
 
     /**
      * Analyze class by using the provided qualified name of the class.
@@ -227,7 +227,7 @@ open class ClassAndMemberVisitor(
             ClassRepresentation(version, access, name, superClassName, interfaceNames, genericsDetails = signature ?: "").also {
                 currentClass = it
                 currentMember = null
-                sourceLocation = SourceLocation(className = name)
+                sourceLocation = SourceLocation.Builder(name).build()
             }
             captureExceptions {
                 currentClass = visitClass(currentClass!!)

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
@@ -4,11 +4,14 @@ package net.corda.djvm.analysis
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.references.Member
 import net.corda.djvm.references.MethodBody
-import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.ACC_BRIDGE
+import org.objectweb.asm.Opcodes.ACC_FINAL
+import org.objectweb.asm.Opcodes.ACC_PROTECTED
+import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 
 const val FROM_DJVM = "fromDJVM"
 
-open class MethodBuilder(
+internal open class MethodBuilder(
     protected val access: Int,
     protected val className: String,
     protected val memberName: String,
@@ -38,11 +41,14 @@ open class MethodBuilder(
     )
 }
 
-abstract class FromDJVMBuilder(
+internal abstract class FromDJVMBuilder(
     protected val className: String,
     private val bridgeDescriptor: String,
-    signature: String = ""
+    signature: String
 ) {
+    constructor(className: String, bridgeDescriptor: String)
+        : this(className, bridgeDescriptor, "")
+
     private val builder = MethodBuilder(
         access = ACC_FINAL or ACC_PROTECTED,
         className = className,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/SourceLocation.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/SourceLocation.kt
@@ -16,11 +16,11 @@ import net.corda.djvm.references.MemberModule
  * @property lineNumber The index of the line from which the instruction was compiled.
  */
 data class SourceLocation(
-        override val className: String = "",
-        val sourceFile: String = "",
-        override val memberName: String = "",
-        override val descriptor: String = "",
-        val lineNumber: Int = 0
+        override val className: String,
+        val sourceFile: String,
+        override val memberName: String,
+        override val descriptor: String,
+        val lineNumber: Int
 ) : MemberInformation {
 
     /**
@@ -81,6 +81,46 @@ data class SourceLocation(
                 append("|@")
             }
         }.toString()
+    }
+
+    @Suppress("unused")
+    class Builder(private val className: String) {
+        constructor() : this("")
+
+        private var sourceFile: String = ""
+        private var memberName: String = ""
+        private var descriptor: String = ""
+        private var lineNumber: Int = 0
+
+        fun withSourceFile(sourceFile: String): Builder {
+            this.sourceFile = sourceFile
+            return this
+        }
+
+        fun withMemberName(memberName: String): Builder {
+            this.memberName = memberName
+            return this
+        }
+
+        fun withDescriptor(descriptor: String): Builder {
+            this.descriptor = descriptor
+            return this
+        }
+
+        fun withLineNumber(lineNumber: Int): Builder {
+            this.lineNumber = lineNumber
+            return this
+        }
+
+        fun build(): SourceLocation {
+            return SourceLocation(
+                className = className,
+                sourceFile = sourceFile,
+                memberName = memberName,
+                descriptor = descriptor,
+                lineNumber = lineNumber
+            )
+        }
     }
 
     private companion object {

--- a/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
@@ -22,8 +22,8 @@ import org.objectweb.asm.Opcodes.*
 class ClassMutator(
         classVisitor: ClassVisitor,
         private val configuration: AnalysisConfiguration,
-        private val definitionProviders: List<DefinitionProvider> = emptyList(),
-        emitters: List<Emitter> = emptyList()
+        private val definitionProviders: List<DefinitionProvider>,
+        emitters: List<Emitter>
 ) : ClassAndMemberVisitor(configuration, classVisitor) {
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/code/instructions/MemberAccessInstruction.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/instructions/MemberAccessInstruction.kt
@@ -16,5 +16,12 @@ class MemberAccessInstruction(
         override val className: String,
         override val memberName: String,
         override val descriptor: String,
-        val ownerIsInterface: Boolean = false
-) : Instruction(operation), MemberInformation
+        val ownerIsInterface: Boolean
+) : Instruction(operation), MemberInformation {
+    constructor(
+        operation: Int,
+        className: String,
+        memberName: String,
+        descriptor: String
+    ) : this(operation, className, memberName, descriptor, false)
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/CostSummary.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/CostSummary.kt
@@ -31,6 +31,7 @@ data class CostSummary(
         /**
          * A blank summary of costs.
          */
+        @JvmField
         val empty = CostSummary(0, 0, 0, 0)
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionSummary.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionSummary.kt
@@ -8,5 +8,5 @@ package net.corda.djvm.execution
  * @property costs The costs accumulated when running the sandboxed code.
  */
 open class ExecutionSummary(
-        val costs: CostSummary = CostSummary.empty
+        val costs: CostSummary
 )

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionSummaryWithResult.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/ExecutionSummaryWithResult.kt
@@ -7,6 +7,6 @@ package net.corda.djvm.execution
  * @see ExecutionSummary
  */
 class ExecutionSummaryWithResult<out TResult>(
-        val result: TResult? = null,
-        costs: CostSummary = CostSummary.empty
+        val result: TResult?,
+        costs: CostSummary
 ) : ExecutionSummary(costs)

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/Message.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/Message.kt
@@ -14,8 +14,10 @@ import net.corda.djvm.rewiring.SandboxClassLoadingException
 data class Message(
         val message: String,
         val severity: Severity,
-        val location: SourceLocation = SourceLocation()
+        val location: SourceLocation
 ) {
+    constructor(message: String, severity: Severity)
+        : this(message, severity, SourceLocation.Builder().build())
 
     override fun toString() = location.toString().let {
         when {
@@ -29,7 +31,7 @@ data class Message(
         /**
          * Construct a message from a [Throwable] with an optional location.
          */
-        fun fromThrowable(throwable: Throwable, location: SourceLocation = SourceLocation()): Message {
+        fun fromThrowable(throwable: Throwable, location: SourceLocation): Message {
             return Message(getMessageFromException(throwable), Severity.ERROR, location)
         }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
@@ -12,9 +12,10 @@ import net.corda.djvm.references.MemberInformation
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class MessageCollection(
-        private val minimumSeverity: Severity = Severity.INFORMATIONAL,
-        private val prefixFilters: List<String> = emptyList()
+    private val minimumSeverity: Severity,
+    private val prefixFilters: List<String>
 ) {
+    constructor() : this(Severity.INFORMATIONAL, emptyList())
 
     private val seenEntries = mutableSetOf<String>()
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoadingException.kt
@@ -18,10 +18,12 @@ import net.corda.djvm.references.EntityReference
 class SandboxClassLoadingException(
         message: String,
         private val context: AnalysisContext,
-        val messages: MessageCollection = context.messages,
-        val classes: ClassHierarchy = context.classes,
-        val classOrigins: Map<String, Set<EntityReference>> = context.classOrigins
+        val messages: MessageCollection,
+        val classes: ClassHierarchy,
+        val classOrigins: Map<String, Set<EntityReference>>
 ) : SandboxRuntimeException(message) {
+    constructor(message: String, context: AnalysisContext)
+        : this(message, context, context.messages, context.classes, context.classOrigins)
 
     /**
      * The detailed description of the exception.

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -103,14 +103,20 @@ class UserPathSource(urls: Array<URL>) : URLClassLoader(urls, null), UserSource 
 class SourceClassLoader(
     private val classResolver: ClassResolver,
     private val userSource: UserSource,
-    private val bootstrap: ApiSource? = null,
-    parent: SourceClassLoader? = null
+    private val bootstrap: ApiSource?,
+    parent: SourceClassLoader?
 ) : ClassLoader(parent) {
     private companion object {
         private val logger = loggerFor<SourceClassLoader>()
     }
 
     private val headers = mutableMapOf<String, ClassHeader>()
+
+    // Java-friendly constructors
+    constructor(classResolver: ClassResolver, userSource: UserSource, bootstrap: ApiSource?)
+        : this(classResolver, userSource, bootstrap, null)
+    constructor(classResolver: ClassResolver, userSource: UserSource)
+        : this(classResolver, userSource, null, null)
 
     fun getURLs(): Array<URL> = userSource.getURLs()
 
@@ -137,7 +143,7 @@ class SourceClassLoader(
             context.messages.provisionalAdd(Message(
                 message = message,
                 severity = Severity.ERROR,
-                location = SourceLocation(origin ?: "")
+                location = SourceLocation.Builder(origin ?: "").build()
             ))
             throw SandboxClassLoadingException(message, context)
         }

--- a/djvm/src/main/kotlin/net/corda/djvm/utilities/Processor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/utilities/Processor.kt
@@ -22,7 +22,8 @@ object Processor {
             try {
                 processor(item)
             } catch (exception: Throwable) {
-                messages.add(Message.fromThrowable(exception, SourceLocation(item.toString())))
+                val location = SourceLocation.Builder(item.toString()).build()
+                messages.add(Message.fromThrowable(exception, location))
             }
         }
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/validation/RuleValidator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/validation/RuleValidator.kt
@@ -22,7 +22,7 @@ import org.objectweb.asm.MethodVisitor
  * @param configuration The configuration to use for class analysis.
  */
 class RuleValidator(
-        private val rules: List<Rule> = emptyList(),
+        private val rules: List<Rule>,
         configuration: AnalysisConfiguration
 ) : ClassAndMemberVisitor(configuration, STUB) {
     private companion object {

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/SourceLocationTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/SourceLocationTest.kt
@@ -7,7 +7,7 @@ class SourceLocationTest {
 
     @Test
     fun `can derive description of source location without source`() {
-        val location = SourceLocation(className = "net/foo/Bar")
+        val location = SourceLocation.Builder(className = "net/foo/Bar").build()
         assertThat(location.format())
                 .contains("net/foo/Bar")
         assertThat(location.copy(memberName = "baz").format())
@@ -23,7 +23,9 @@ class SourceLocationTest {
 
     @Test
     fun `can derive description of source location with source`() {
-        val location = SourceLocation(className = "net/foo/Bar", sourceFile = "Bar.kt")
+        val location = SourceLocation.Builder(className = "net/foo/Bar")
+            .withSourceFile("Bar.kt")
+            .build()
         assertThat(location.format())
                 .contains("Bar.kt")
         assertThat(location.copy(memberName = "baz").format())

--- a/djvm/src/test/kotlin/net/corda/djvm/code/ClassMutatorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/code/ClassMutatorTest.kt
@@ -22,7 +22,12 @@ class ClassMutatorTest : TestBase(KOTLIN) {
             }
         }
         val context = context
-        val mutator = ClassMutator(Writer(), configuration, listOf(definitionProvider))
+        val mutator = ClassMutator(
+            classVisitor = Writer(),
+            configuration = configuration,
+            definitionProviders = listOf(definitionProvider),
+            emitters = emptyList()
+        )
         mutator.analyze<TestClass>(context)
         assertThat(hasProvidedDefinition).isTrue()
         assertThat(context.classes.get<TestClass>().access or ACC_STRICT).isNotEqualTo(0)
@@ -40,7 +45,12 @@ class ClassMutatorTest : TestBase(KOTLIN) {
             }
         }
         val context = context
-        val mutator = ClassMutator(Writer(), configuration, listOf(definitionProvider))
+        val mutator = ClassMutator(
+            classVisitor = Writer(),
+            configuration = configuration,
+            definitionProviders = listOf(definitionProvider),
+            emitters = emptyList()
+        )
         mutator.analyze<TestClassWithMembers>(context)
         assertThat(hasProvidedDefinition).isTrue()
         for (member in context.classes.get<TestClassWithMembers>().members.values) {
@@ -68,7 +78,12 @@ class ClassMutatorTest : TestBase(KOTLIN) {
             }
         }
         val context = context
-        val mutator = ClassMutator(Writer(), configuration, emitters = listOf(emitter))
+        val mutator = ClassMutator(
+            classVisitor = Writer(),
+            configuration = configuration,
+            definitionProviders = emptyList(),
+            emitters = listOf(emitter)
+        )
         mutator.analyze<TestClassWithMembers>(context)
         assertThat(hasEmittedCode).isTrue()
         assertThat(shouldPreventDefault).isTrue()

--- a/djvm/src/test/kotlin/net/corda/djvm/code/EmitterModuleTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/code/EmitterModuleTest.kt
@@ -37,7 +37,12 @@ class EmitterModuleTest : TestBase(KOTLIN) {
 
         }
         val context = context
-        val mutator = ClassMutator(visitor, configuration, emitters = listOf(emitter))
+        val mutator = ClassMutator(
+            classVisitor = visitor,
+            configuration = configuration,
+            definitionProviders = emptyList(),
+            emitters = listOf(emitter)
+        )
         mutator.analyze<TestClass>(context)
         assertThat(hasEmittedTypeInstruction).isTrue()
     }


### PR DESCRIPTION
Adding default parameters to constructors in Kotlin has non-obvious implications for the ABI, i.e. the constructor signatures have `ILkotlin/jvm/internal/DefaultConstructorMarker;` silently appended to their arguments. This complicates extending these classes later in a backwards-compatible way.

Remove as many default parameters from as many constructors as possible before we release v1.0.