### PR TITLE
Tolerate exceptions inside ExceptionInInitializerError and InvocationTargetException being null.

### DIFF
--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -130,8 +130,8 @@ private fun kotlin.Throwable.safeCopy(): kotlin.Throwable {
          * [InvocationTargetException] and [java.lang.ExceptionInInitializerError] can
          * contain a sandbox exception as their underlying target / cause.
          */
-        is InvocationTargetException -> InvocationTargetException(targetException.escapeSandbox()).also(::copyExtraTo)
-        is java.lang.ExceptionInInitializerError -> ExceptionInInitializerError(exception.escapeSandbox()).also(::copyExtraTo)
+        is InvocationTargetException -> InvocationTargetException(targetException?.escapeSandbox()).also(::copyExtraTo)
+        is java.lang.ExceptionInInitializerError -> ExceptionInInitializerError(exception?.escapeSandbox()).also(::copyExtraTo)
         else -> this
     }
 }


### PR DESCRIPTION
The exceptions inside `ExceptionInInitializerError` and `InvocationTargetException` are both allowed to be `null`, so disable Kotlin's null-check when marshalling instances out of the sandbox.