### PR TITLE
CORDA-3380: Update the class signature when stitching generic interfaces.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -400,9 +400,22 @@ class AnalysisConfiguration private constructor(
                 descriptor = "()Ljava/util/Iterator;"
             ) {
                 override fun writeBody(emitter: EmitterModule) = with(emitter) {
+                    val doStart = Label()
+                    lineNumber(0, doStart)
                     pushObject(0)
                     invokeInterface(className, memberName, "()Lsandbox/java/util/Iterator;")
+                    val doEnd = Label()
+                    lineNumber(1, doEnd)
                     returnObject()
+                    newLocal(
+                        name = "this",
+                        descriptor = "Lsandbox/java/lang/Iterable;",
+                        // We are assuming that this interface is declared as "Iterable<T>".
+                        signature = "Lsandbox/java/lang/Iterable<TT;>;",
+                        start = doStart,
+                        end = doEnd,
+                        index = 0
+                    )
                 }
             }.withBody()
              .build()

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -3,7 +3,6 @@ package net.corda.djvm.code
 import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.references.MemberInformation
 import net.corda.djvm.references.MethodBody
-import net.corda.djvm.source.ClassHeader
 import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes.*
@@ -46,6 +45,21 @@ class EmitterModule(
      */
     inline fun <reified T> new() {
         new(Type.getInternalName(T::class.java))
+    }
+
+    /**
+     * Emit instruction for declaring a new local variable.
+     */
+    fun newLocal(
+        name: String,
+        descriptor: String,
+        signature: String?,
+        start: Label,
+        end: Label,
+        index: Int
+    ) {
+        hasEmittedCustomCode = true
+        methodVisitor.visitLocalVariable(name, descriptor, signature, start, end, index)
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -78,7 +78,8 @@ open class ClassRewriter(
                 if (stitchedSignature != null) {
                     /*
                      * All of our stitched interfaces have a single generic
-                     * parameter. This simplifies how we update the signature.
+                     * parameter. This simplifies how we update the signature
+                     * to include this new interface.
                      */
                     GENERIC_SIGNATURE.matchEntire(stitchedSignature)?.run {
                         val typeVar = groupValues[1]

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/ClassRewriter.kt
@@ -57,6 +57,7 @@ open class ClassRewriter(
 
     private companion object {
         private val logger = loggerFor<ClassRewriter>()
+        private val GENERIC_SIGNATURE = "^<([^:]++):.*>.*".toRegex()
     }
 
     /**
@@ -70,16 +71,28 @@ open class ClassRewriter(
         private val extraMethods = mutableListOf<Member>()
 
         override fun visit(version: Int, access: Int, className: String, signature: String?, superName: String?, interfaces: Array<String>?) {
+            var stitchedSignature = signature
             val stitchedInterfaces = analysisConfig.stitchedInterfaces[className]?.let { methods ->
                 extraMethods += methods
-                arrayOf(*(interfaces ?: emptyArray()), analysisConfig.classResolver.reverse(className))
+                val baseInterface = analysisConfig.classResolver.reverse(className)
+                if (stitchedSignature != null) {
+                    /*
+                     * All of our stitched interfaces have a single generic
+                     * parameter. This simplifies how we update the signature.
+                     */
+                    GENERIC_SIGNATURE.matchEntire(stitchedSignature)?.run {
+                        val typeVar = groupValues[1]
+                        stitchedSignature += "L$baseInterface<T$typeVar;>;"
+                    }
+                }
+                arrayOf(*(interfaces ?: emptyArray()), baseInterface)
             } ?: interfaces
 
             analysisConfig.stitchedClasses[className]?.also { methods ->
                 extraMethods += methods
             }
 
-            super.visit(version, access, className, signature, superName, stitchedInterfaces)
+            super.visit(version, access, className, stitchedSignature, superName, stitchedInterfaces)
         }
 
         override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {

--- a/djvm/src/test/java/net/corda/djvm/rewiring/StitchedInterfaceTest.java
+++ b/djvm/src/test/java/net/corda/djvm/rewiring/StitchedInterfaceTest.java
@@ -1,0 +1,43 @@
+package net.corda.djvm.rewiring;
+
+import net.corda.djvm.TestBase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class StitchedInterfaceTest extends TestBase {
+    StitchedInterfaceTest() {
+        super(JAVA);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "sandbox.java.lang.CharSequence,java.lang.CharSequence",
+        "sandbox.java.lang.Iterable,java.lang.Iterable<T>",
+        "sandbox.java.util.Iterator,java.util.Iterator<E>",
+        "sandbox.java.lang.Comparable,java.lang.Comparable<T>",
+        "sandbox.java.util.Comparator,java.util.Comparator<T>"
+    })
+    void testStitchedInterface(String sandboxName, String stitchedName) {
+        sandbox(ctx -> {
+            try {
+                Class<?> sandboxClass = Class.forName(sandboxName, true, ctx.getClassLoader());
+                List<String> generics = Arrays.stream(sandboxClass.getGenericInterfaces())
+                    .map(Type::getTypeName)
+                    .collect(toList());
+                assertThat(generics).containsExactly(stitchedName);
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Hotspot doesn't seem to mind that the generic signature is incorrect so long as the super-interface is still added.  However, the generated byte-code is still incorrect regardless.