### PR TITLE
CORDA-3377: Add the API Scanner plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,22 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' apply false
+    id 'net.corda.plugins.api-scanner' apply false
     id 'net.corda.plugins.publish-utils'
     id 'com.jfrog.artifactory'
     id 'org.owasp.dependencycheck'
     id 'com.gradle.build-scan'
+    id 'base'
 }
 
 import static org.gradle.api.JavaVersion.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import net.corda.plugins.GenerateApi
 
 ext {
     artifactory_contextUrl = 'https://software.r3.com/artifactory'
 }
+
+version corda_djvm_version
 
 subprojects {
     group 'net.corda.djvm'
@@ -19,7 +24,6 @@ subprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     tasks.withType(JavaCompile) {
@@ -102,6 +106,10 @@ artifactory {
             }
         }
     }
+}
+
+task generateApi(type: GenerateApi) {
+    baseName = 'api-djvm'
 }
 
 wrapper {

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.github.johnrengelman.shadow'
     id 'net.corda.plugins.publish-utils'
+    id 'net.corda.plugins.api-scanner'
     id 'com.jfrog.artifactory'
     id 'com.jfrog.bintray'
     id 'idea'
@@ -147,6 +148,13 @@ tasks.withType(Test) {
 
 artifacts {
     publish shadowJar
+}
+
+scanApi {
+    excludePackages = [
+        'sandbox',
+        'djvm'
+    ]
 }
 
 publish {

--- a/djvm/src/main/java/net/corda/djvm/CordaInternal.java
+++ b/djvm/src/main/java/net/corda/djvm/CordaInternal.java
@@ -1,0 +1,20 @@
+package net.corda.djvm;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Target({
+   TYPE,
+   FIELD,
+   METHOD,
+   CONSTRUCTOR
+})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
@@ -1,6 +1,7 @@
 @file:JvmName("SewingKit")
 package net.corda.djvm.analysis
 
+import net.corda.djvm.CordaInternal
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.references.Member
 import net.corda.djvm.references.MethodBody
@@ -11,7 +12,8 @@ import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 
 const val FROM_DJVM = "fromDJVM"
 
-internal open class MethodBuilder(
+@CordaInternal
+open class MethodBuilder(
     protected val access: Int,
     protected val className: String,
     protected val memberName: String,
@@ -41,7 +43,8 @@ internal open class MethodBuilder(
     )
 }
 
-internal abstract class FromDJVMBuilder(
+@CordaInternal
+abstract class FromDJVMBuilder(
     protected val className: String,
     private val bridgeDescriptor: String,
     signature: String

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ kotlin.incremental=true
 
 corda_djvm_version=1.0-SNAPSHOT
 
+corda_plugins_version=5.0.5
 asm_version=7.2
 assertj_version=3.13.2
 class_graph_version=4.8.47

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,8 @@ pluginManagement {
 
     plugins {
         id 'org.jetbrains.kotlin.jvm' version kotlin_version
-        id 'net.corda.plugins.publish-utils' version '5.0.4'
+        id 'net.corda.plugins.publish-utils' version corda_plugins_version
+        id 'net.corda.plugins.api-scanner' version corda_plugins_version
         id 'com.github.johnrengelman.shadow' version '5.1.0'
         id 'com.jfrog.artifactory' version '4.9.6'
         id 'com.jfrog.bintray' version '1.7.3'


### PR DESCRIPTION
Use the API Scanner plugin to summarise the DJVM's public API. This should make it easier to find unwanted Kotlin-speoific elements, such as constructors with default parameter values.