### PR TITLE
Refactor how SandboxClassLoader fetches source byte-code.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -2,7 +2,6 @@ package net.corda.djvm
 
 import net.corda.djvm.costing.RuntimeCostSummary
 import net.corda.djvm.rewiring.SandboxClassLoader
-import net.corda.djvm.rewiring.SandboxClassLoadingException
 
 /**
  * The context in which a sandboxed operation is run.
@@ -43,9 +42,6 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
             instance = this
             try {
                 action(this)
-            } catch (e: SandboxClassLoadingException) {
-                e.messages.acceptProvisional()
-                throw e
             } finally {
                 threadLocalContext.remove()
             }

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -155,8 +155,6 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
             } catch (exception: SandboxClassLoadingException) {
                 // Continue; all warnings and errors are captured in [context.messages]
                 false
-            } finally {
-                context.messages.acceptProvisional()
             }
             if (didLoad) {
                 context.classes[className]?.apply {

--- a/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/messages/MessageCollection.kt
@@ -23,7 +23,6 @@ class MessageCollection(
 
     private val memberMessages = mutableMapOf<String, MutableList<Message>>()
 
-    private val provisional = mutableListOf<Message>()
     private var cachedEntries: List<Message>? = null
 
     /**
@@ -58,29 +57,6 @@ class MessageCollection(
         for (message in messages) {
             add(message)
         }
-    }
-
-    /**
-     * Hold this message until we've decided whether or not it's real.
-     */
-    fun provisionalAdd(message: Message) {
-        provisional.add(message)
-    }
-
-    /**
-     * Discard all provisional messages.
-     */
-    fun clearProvisional() {
-        provisional.clear()
-    }
-
-    /**
-     * Accept all provisional messages.
-     */
-    fun acceptProvisional(): MessageCollection {
-        addAll(provisional)
-        clearProvisional()
-        return this
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -134,13 +134,13 @@ class SourceClassLoader(
      * Open a [ClassReader] for the provided class name.
      */
     fun classReader(
-        className: String, context: AnalysisContext, origin: String? = null
+        className: String, context: AnalysisContext, origin: String?
     ): ClassReader {
         val originalName = classResolver.reverse(className.asResourcePath)
 
         fun throwClassLoadingError(): Nothing {
             val message = "Class file not found: $originalName.class"
-            context.messages.provisionalAdd(Message(
+            context.messages.add(Message(
                 message = message,
                 severity = Severity.ERROR,
                 location = SourceLocation.Builder(origin ?: "").build()
@@ -148,9 +148,10 @@ class SourceClassLoader(
             throw SandboxClassLoadingException(message, context)
         }
 
+        val resource = getResource("$originalName.class") ?: run(::throwClassLoadingError)
         return try {
             logger.trace("Opening ClassReader for class {}...", originalName)
-            getResourceAsStream("$originalName.class")?.use(::ClassReader) ?: run(::throwClassLoadingError)
+            resource.openStream().use(::ClassReader)
         } catch (_: IOException) {
             throwClassLoadingError()
         }


### PR DESCRIPTION
Provisional error messages were a workaround for `SandboxClassLoader` aborting loading a new class when it failed to find that class in the very first `SourceClassLoader` it searched.

Both `SandboxClassLoader` and `SourceClassLoader` have since evolved, making provisional error messages obsolete.