### PR TITLE
CORDA-3377: Remove more Kotlinisms from the DJVM's API

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
@@ -10,6 +10,7 @@ import net.corda.djvm.utilities.Processor
 import net.corda.djvm.utilities.loggerFor
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Opcodes.*
+import java.util.function.Consumer
 
 /**
  * Helper class for applying a set of definition providers and emitters to a class or set of classes.
@@ -60,9 +61,9 @@ class ClassMutator(
      */
     override fun visitClass(clazz: ClassRepresentation): ClassRepresentation {
         var resultingClass = clazz
-        Processor.processEntriesOfType<ClassDefinitionProvider>(definitionProviders, analysisContext.messages) {
+        Processor.processEntriesOfType<ClassDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingClass = it.define(currentAnalysisContext(), resultingClass)
-        }
+        })
         if (clazz != resultingClass) {
             logger.trace("Type has been mutated {}", clazz)
             hasBeenModified = true
@@ -99,9 +100,9 @@ class ClassMutator(
      */
     override fun visitMethod(clazz: ClassRepresentation, method: Member): Member {
         var resultingMethod = method
-        Processor.processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages) {
+        Processor.processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingMethod = it.define(currentAnalysisContext(), resultingMethod)
-        }
+        })
         if (method != resultingMethod) {
             logger.trace("Method has been mutated {}", method)
             hasBeenModified = true
@@ -115,9 +116,9 @@ class ClassMutator(
      */
     override fun visitField(clazz: ClassRepresentation, field: Member): Member {
         var resultingField = field
-        Processor.processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages) {
+        Processor.processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingField = it.define(currentAnalysisContext(), resultingField)
-        }
+        })
         if (field != resultingField) {
             logger.trace("Field has been mutated {}", field)
             initializers += resultingField.body
@@ -132,9 +133,9 @@ class ClassMutator(
      */
     override fun visitInstruction(method: Member, emitter: EmitterModule, instruction: Instruction) {
         val context = EmitterContext(currentAnalysisContext(), configuration, emitter)
-        Processor.processEntriesOfType<Emitter>(emitters, analysisContext.messages) {
+        Processor.processEntriesOfType<Emitter>(emitters, analysisContext.messages, Consumer {
             it.emit(context, instruction)
-        }
+        })
         if (!emitter.emitDefaultInstruction || emitter.hasEmittedCustomCode) {
             hasBeenModified = true
         }

--- a/djvm/src/main/kotlin/net/corda/djvm/costing/RuntimeCost.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/costing/RuntimeCost.kt
@@ -1,5 +1,9 @@
 package net.corda.djvm.costing
 
+import java.util.function.Function
+import java.util.function.Predicate
+import java.util.function.UnaryOperator
+
 /**
  * Cost metric to be used in a sandbox environment. The metric has a threshold and a mechanism for reporting violations.
  * The implementation assumes that each metric is tracked on a per-thread basis, i.e., that each sandbox runs on its own
@@ -10,13 +14,12 @@ package net.corda.djvm.costing
  */
 class RuntimeCost(
         threshold: Long,
-        errorMessage: (Thread) -> String
+        errorMessage: Function<Thread, String>
 ) : TypedRuntimeCost<Long>(
         0,
-        { value: Long -> value > threshold },
+        Predicate { it > threshold },
         errorMessage
 ) {
-
     /**
      * Increment the accumulated cost by an integer.
      */
@@ -25,6 +28,12 @@ class RuntimeCost(
     /**
      * Increment the accumulated cost by a long integer.
      */
-    fun increment(incrementBy: Long = 1) = incrementAndCheck { value -> Math.addExact(value, incrementBy) }
+    fun increment(incrementBy: Long) = incrementAndCheck(UnaryOperator { value ->
+        Math.addExact(value, incrementBy)
+    })
 
+    /**
+     * Increment the accumulated cost by one.
+     */
+    fun increment() = increment(1L)
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/costing/RuntimeCostSummary.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/costing/RuntimeCostSummary.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm.costing
 
 import net.corda.djvm.execution.ExecutionProfile
+import java.util.function.Function
 
 /**
  * This class provides a summary of the accumulated costs for the runtime metrics that are being tracked. It also keeps
@@ -29,29 +30,29 @@ class RuntimeCostSummary private constructor(
     /**
      * Accumulated cost of memory allocations.
      */
-    val allocationCost = RuntimeCost(allocationCostThreshold) {
+    val allocationCost = RuntimeCost(allocationCostThreshold, Function {
         "Sandbox [${it.name}] terminated due to over-allocation"
-    }
+    })
 
     /**
      * Accumulated cost of jump operations.
      */
-    val jumpCost = RuntimeCost(jumpCostThreshold) {
+    val jumpCost = RuntimeCost(jumpCostThreshold, Function {
         "Sandbox [${it.name}] terminated due to excessive use of looping"
-    }
+    })
 
     /**
      * Accumulated cost of method invocations.
      */
-    val invocationCost = RuntimeCost(invocationCostThreshold) {
+    val invocationCost = RuntimeCost(invocationCostThreshold, Function {
         "Sandbox [${it.name}] terminated due to excessive method calling"
-    }
+    })
 
     /**
      * Accumulated cost of throw operations.
      */
-    val throwCost = RuntimeCost(throwCostThreshold) {
+    val throwCost = RuntimeCost(throwCostThreshold, Function {
         "Sandbox [${it.name}] terminated due to excessive exception throwing"
-    }
+    })
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/QueueProcessor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/QueueProcessor.kt
@@ -2,11 +2,11 @@ package net.corda.djvm.execution
 
 import net.corda.djvm.utilities.loggerFor
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.function.BiConsumer
 
 /**
  * Helper class for processing queued entities.
  */
-@Suppress("MemberVisibilityCanBePrivate")
 class QueueProcessor<T>(
         private val deduplicationKeyExtractor: (T) -> String,
         vararg elements: T
@@ -45,10 +45,10 @@ class QueueProcessor<T>(
     /**
      * Process the current queue with provided action per element.
      */
-    inline fun process(action: QueueProcessor<T>.(T) -> Unit) {
+    fun process(action: BiConsumer<QueueProcessor<T>, T>) {
         while (isNotEmpty()) {
             val element = dequeue()
-            action(this, element)
+            action.accept(this, element)
         }
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -12,6 +12,7 @@ import net.corda.djvm.rewiring.SandboxClassLoadingException
 import net.corda.djvm.source.ClassSource
 import net.corda.djvm.utilities.loggerFor
 import net.corda.djvm.validation.ReferenceValidationSummary
+import java.util.function.BiConsumer
 
 /**
  * The executor is responsible for spinning up a sandboxed environment and launching the referenced code block inside
@@ -176,15 +177,15 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
     /**
      * Process a dynamic queue of [ClassSource] entries.
      */
-    private inline fun processClassQueue(
+    private fun processClassQueue(
             vararg elements: ClassSource, action: QueueProcessor<ClassSource>.(ClassSource, String) -> Unit
     ) {
-        QueueProcessor(ClassSource::qualifiedClassName, *elements).process { classSource ->
+        QueueProcessor(ClassSource::qualifiedClassName, *elements).process(BiConsumer { processor, classSource ->
             val className = classResolver.reverse(classModule.getBinaryClassName(classSource.qualifiedClassName))
             if (!whitelist.matches(className)) {
-                action(classSource, className)
+                processor.action(classSource, className)
             }
-        }
+        })
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/SandboxExecutor.kt
@@ -160,11 +160,11 @@ open class SandboxExecutor<in INPUT, out OUTPUT>(
             if (didLoad) {
                 context.classes[className]?.apply {
                     context.references.referencesFromLocation(className)
+                            .asSequence()
                             .map(ReferenceWithLocation::reference)
                             .filterIsInstance<ClassReference>()
                             .filter { it.className != className }
-                            .distinct()
-                            .map { ClassSource.fromClassName(it.className, className) }
+                            .mapTo(LinkedHashSet()) { ClassSource.fromClassName(it.className, className) }
                             .forEach(::enqueue)
                 }
             }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -28,7 +28,7 @@ import java.util.function.Function
  * Class loader that enables registration of rewired classes.
  *
  * @property analysisConfiguration The configuration to use for the analysis.
- * @property ruleValidator The instance used to validate that any loaded class complies with the specified rules.
+ * @property analyzer The instance used to validate that any loaded class complies with the specified rules.
  * @property supportingClassLoader The class loader used to find classes on the extended class path.
  * @property rewriter The re-writer to use for registered classes.
  * @property context The context in which analysis and processing is performed.
@@ -39,7 +39,7 @@ import java.util.function.Function
  */
 class SandboxClassLoader private constructor(
     private val analysisConfiguration: AnalysisConfiguration,
-    private val ruleValidator: RuleValidator,
+    private val analyzer: ClassAndMemberVisitor,
     private val supportingClassLoader: SourceClassLoader,
     private val rewriter: ClassRewriter,
     private val context: AnalysisContext,
@@ -48,12 +48,6 @@ class SandboxClassLoader private constructor(
     throwableClass: Class<*>?,
     parent: ClassLoader?
 ) : ClassLoader(parent ?: getSystemClassLoader()), AutoCloseable {
-
-    /**
-     * The analyzer used to traverse the class hierarchy.
-     */
-    private val analyzer: ClassAndMemberVisitor
-        get() = ruleValidator
 
     /**
      * Set of classes that should be left untouched due to whitelisting.
@@ -101,7 +95,7 @@ class SandboxClassLoader private constructor(
      */
     fun copyEmpty(newContext: AnalysisContext) = SandboxClassLoader(
         analysisConfiguration,
-        ruleValidator,
+        analyzer,
         supportingClassLoader,
         rewriter,
         newContext,
@@ -568,8 +562,8 @@ class SandboxClassLoader private constructor(
             return SandboxClassLoader(
                 analysisConfiguration = analysisConfiguration,
                 supportingClassLoader = supportingClassLoader,
-                ruleValidator = RuleValidator(rules = configuration.rules,
-                                              configuration = analysisConfiguration),
+                analyzer = RuleValidator(rules = configuration.rules,
+                                         configuration = analysisConfiguration),
                 rewriter = ClassRewriter(configuration, supportingClassLoader),
                 context = parentClassLoader?.context ?: AnalysisContext.fromConfiguration(analysisConfiguration),
                 byteCodeCache = byteCodeCache ?: ByteCodeCache(parentClassLoader?.byteCodeCache),

--- a/djvm/src/main/kotlin/net/corda/djvm/utilities/Processor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/utilities/Processor.kt
@@ -3,6 +3,7 @@ package net.corda.djvm.utilities
 import net.corda.djvm.analysis.SourceLocation
 import net.corda.djvm.messages.Message
 import net.corda.djvm.messages.MessageCollection
+import java.util.function.Consumer
 
 /**
  * Utility for processing a set of entries in a list matching a particular type.
@@ -16,11 +17,11 @@ object Processor {
     inline fun <reified T> processEntriesOfType(
             list: List<*>,
             messages: MessageCollection,
-            processor: (T) -> Unit
+            processor: Consumer<T>
     ) {
         for (item in list.filterIsInstance<T>()) {
             try {
-                processor(item)
+                processor.accept(item)
             } catch (exception: Throwable) {
                 val location = SourceLocation.Builder(item.toString()).build()
                 messages.add(Message.fromThrowable(exception, location))

--- a/djvm/src/main/kotlin/net/corda/djvm/validation/RuleValidator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/validation/RuleValidator.kt
@@ -14,6 +14,7 @@ import net.corda.djvm.utilities.Processor
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.FieldVisitor
 import org.objectweb.asm.MethodVisitor
+import java.util.function.Consumer
 
 /**
  * Helper class for validating a set of rules for a class or set of classes.
@@ -36,9 +37,9 @@ class RuleValidator(
     override fun visitClass(clazz: ClassRepresentation): ClassRepresentation {
         if (shouldClassBeProcessed(clazz.name)) {
             val context = RuleContext(currentAnalysisContext())
-            Processor.processEntriesOfType<ClassRule>(rules, analysisContext.messages) {
+            Processor.processEntriesOfType<ClassRule>(rules, analysisContext.messages, Consumer {
                 it.validate(context, clazz)
-            }
+            })
         }
         return super.visitClass(clazz)
     }
@@ -49,9 +50,9 @@ class RuleValidator(
     override fun visitMethod(clazz: ClassRepresentation, method: Member): Member {
         if (shouldClassBeProcessed(clazz.name) && shouldMemberBeProcessed(method.reference)) {
             val context = RuleContext(currentAnalysisContext())
-            Processor.processEntriesOfType<MemberRule>(rules, analysisContext.messages) {
+            Processor.processEntriesOfType<MemberRule>(rules, analysisContext.messages, Consumer {
                 it.validate(context, method)
-            }
+            })
         }
         return super.visitMethod(clazz, method)
     }
@@ -62,9 +63,9 @@ class RuleValidator(
     override fun visitField(clazz: ClassRepresentation, field: Member): Member {
         if (shouldClassBeProcessed(clazz.name) && shouldMemberBeProcessed(field.reference)) {
             val context = RuleContext(currentAnalysisContext())
-            Processor.processEntriesOfType<MemberRule>(rules, analysisContext.messages) {
+            Processor.processEntriesOfType<MemberRule>(rules, analysisContext.messages, Consumer {
                 it.validate(context, field)
-            }
+            })
         }
         return super.visitField(clazz, field)
     }
@@ -75,9 +76,9 @@ class RuleValidator(
     override fun visitInstruction(method: Member, emitter: EmitterModule, instruction: Instruction) {
         if (shouldClassBeProcessed(method.className) && shouldMemberBeProcessed(method.reference)) {
             val context = RuleContext(currentAnalysisContext())
-            Processor.processEntriesOfType<InstructionRule>(rules, analysisContext.messages) {
+            Processor.processEntriesOfType<InstructionRule>(rules, analysisContext.messages, Consumer {
                 it.validate(context, instruction)
-            }
+            })
         }
         super.visitInstruction(method, emitter, instruction)
     }

--- a/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
+++ b/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
@@ -66,7 +66,7 @@ fun recordAllocation(typeName: String) {
 fun recordArrayAllocation(length: Int, typeName: String) {
     require(length >= 0) { "Length must be a positive integer" }
     val size = allocationCosts.getOrDefault(typeName, 16)
-    runtimeCosts.allocationCost.increment(length * size)
+    runtimeCosts.allocationCost.increment(length.toLong() * size)
 }
 
 /**
@@ -78,7 +78,7 @@ fun recordArrayAllocation(length: Int, typeName: String) {
 fun recordArrayAllocation(length: Int, typeSize: Int) {
     require(length >= 0) { "Length must be a positive integer" }
     require(typeSize > 0) { "Type size must be a positive integer" }
-    runtimeCosts.allocationCost.increment(length * typeSize)
+    runtimeCosts.allocationCost.increment(length.toLong() * typeSize)
 }
 
 /**

--- a/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
@@ -11,7 +11,7 @@ class RuntimeCostTest {
     @Test
     fun `can increment cost`() {
         val cost = RuntimeCost(10, Function { "failed" })
-        cost.increment(1)
+        cost.increment()
         assertThat(cost.value).isEqualTo(1)
     }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/costing/RuntimeCostTest.kt
@@ -3,13 +3,14 @@ package net.corda.djvm.costing
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
+import java.util.function.Function
 import kotlin.concurrent.thread
 
 class RuntimeCostTest {
 
     @Test
     fun `can increment cost`() {
-        val cost = RuntimeCost(10) { "failed" }
+        val cost = RuntimeCost(10, Function { "failed" })
         cost.increment(1)
         assertThat(cost.value).isEqualTo(1)
     }
@@ -17,7 +18,7 @@ class RuntimeCostTest {
     @Test
     fun `cannot increment cost beyond threshold`() {
         thread(name = "Foo") {
-            val cost = RuntimeCost(10) { "failed in ${it.name}" }
+            val cost = RuntimeCost(10, Function { "failed in ${it.name}" })
             assertThatExceptionOfType(ThresholdViolationError::class.java)
                     .isThrownBy { cost.increment(11) }
                     .withMessage("failed in Foo")

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'com.jfrog.artifactory' version '4.9.6'
         id 'com.jfrog.bintray' version '1.7.3'
         id 'org.owasp.dependencycheck' version '5.1.0'
-        id 'com.gradle.build-scan' version '2.2.1'
+        id 'com.gradle.build-scan' version '2.4.2'
     }
 }
 


### PR DESCRIPTION
Replace Kotlin function references with Java functional interfaces.
Remove superfluous properties.
Resolve some minor compiler warnings.