### PR TITLE
CORDA-3377: Remove even more Kotlinisms from DJVM API.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -102,9 +102,9 @@ abstract class TestBase(type: SandboxType) {
                     it.setSandboxOnlyAnnotations(sandboxOnlyAnnotations)
                     it.setVisibleAnnotations(visibleAnnotations)
                     it.setExternalCache(externalCache)
-                })).use {
-                    action(this)
-                }
+                })).use(Consumer { ctx ->
+                    ctx.action()
+                })
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -15,6 +15,7 @@ import java.io.IOException
 import java.net.URL
 import java.util.Collections.unmodifiableList
 import java.util.function.Consumer
+import java.util.function.Function
 import java.util.zip.ZipInputStream
 
 /**
@@ -79,8 +80,8 @@ class SandboxConfiguration private constructor(
     fun preload() {
         val preloadURLs = getPreloadURLs()
         if (preloadURLs.isNotEmpty()) {
-            IsolatedTask(PRELOAD_THREAD_PREFIX, this).run {
-                val knownReferences = HashSet<String>(INITIAL_CLASSES)
+            IsolatedTask(PRELOAD_THREAD_PREFIX, this).run<Any>(Function { classLoader ->
+                val knownReferences = HashSet(INITIAL_CLASSES)
 
                 /**
                  * Generate sandbox byte-code for all of these jars.
@@ -110,7 +111,7 @@ class SandboxConfiguration private constructor(
 
                 log.info("Preloaded {} classes into sandbox.",
                           knownReferences.size - INITIAL_CLASSES.size)
-            }
+            })
         }
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -2,6 +2,7 @@ package net.corda.djvm
 
 import net.corda.djvm.costing.RuntimeCostSummary
 import net.corda.djvm.rewiring.SandboxClassLoader
+import java.util.function.Consumer
 
 /**
  * The context in which a sandboxed operation is run.
@@ -37,11 +38,11 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
     /**
      * Run a set of actions within the provided sandbox context.
      */
-    fun use(action: SandboxRuntimeContext.() -> Unit) {
+    fun use(action: Consumer<SandboxRuntimeContext>) {
         classLoader.use {
             instance = this
             try {
-                action(this)
+                action.accept(this)
             } finally {
                 threadLocalContext.remove()
             }

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
@@ -7,6 +7,8 @@ import net.corda.djvm.rewiring.SandboxClassLoader
 import net.corda.djvm.rewiring.SandboxClassLoadingException
 import net.corda.djvm.utilities.loggerFor
 import java.util.concurrent.atomic.AtomicLong
+import java.util.function.Consumer
+import java.util.function.Function
 import kotlin.concurrent.thread
 
 /**
@@ -20,20 +22,20 @@ class IsolatedTask(
     /**
      * Run an action in an isolated environment.
      */
-    fun <T> run(action: IsolatedTask.() -> T?): Result<T> {
+    fun <T> run(action: Function<SandboxClassLoader, T?>): Result<T> {
         val threadName = "DJVM-$identifier-${uniqueIdentifier.getAndIncrement()}"
         var output: T? = null
         var costs = CostSummary.empty
         var exception: Throwable? = null
         thread(start = false, isDaemon = true, name = threadName) {
             logger.trace("Entering isolated runtime environment...")
-            SandboxRuntimeContext(configuration).use {
+            SandboxRuntimeContext(configuration).use(Consumer { ctx ->
                 output = try {
-                    action(this@IsolatedTask)
+                    action.apply(ctx.classLoader)
                 } finally {
-                    costs = CostSummary(runtimeCosts)
+                    costs = CostSummary(ctx.runtimeCosts)
                 }
-            }
+            })
             logger.trace("Exiting isolated runtime environment...")
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->

--- a/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/execution/IsolatedTask.kt
@@ -77,12 +77,6 @@ class IsolatedTask(
             val exception: Throwable?
     )
 
-    /**
-     * The class loader to use for loading the [java.util.function.Function] and any referenced code in [SandboxExecutor.run].
-     */
-    val classLoader: SandboxClassLoader
-        get() = SandboxRuntimeContext.instance.classLoader
-
     // TODO Caching can transcend thread-local contexts by taking the sandbox configuration into account in the key derivation
 
     private companion object {

--- a/djvm/src/test/kotlin/net/corda/djvm/SandboxConfigurationTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/SandboxConfigurationTest.kt
@@ -17,6 +17,7 @@ class SandboxConfigurationTest : TestBase(KOTLIN) {
     companion object {
         private lateinit var testJar: DummyJar
 
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@TempDir testProjectDir: Path) {

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -243,10 +243,10 @@ abstract class TestBase(type: SandboxType) {
                     enableTracing,
                     analysisConfiguration,
                     externalCache
-                )).use {
-                    assertThat(runtimeCosts).areZero()
-                    action(this)
-                }
+                )).use(Consumer { ctx ->
+                    assertThat(ctx.runtimeCosts).areZero()
+                    ctx.action()
+                })
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->
@@ -285,10 +285,10 @@ abstract class TestBase(type: SandboxType) {
                     it.setSandboxOnlyAnnotations(sandboxOnlyAnnotations)
                     it.setVisibleAnnotations(visibleAnnotations)
                     it.setExternalCache(externalCache)
-                })).use {
-                    assertThat(runtimeCosts).areZero()
-                    action(this)
-                }
+                })).use(Consumer { ctx ->
+                    assertThat(ctx.runtimeCosts).areZero()
+                    ctx.action()
+                })
             }
         }.apply {
             uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, ex ->


### PR DESCRIPTION
- Replace more Kotlin function references with `Consumer` and `Function`
- Remove unused `IsolatedTask.classLoader` property.