### PR TITLE
CORDA-2963: Migrate create-jdk8 module from Corda into deterministic-rt.

### DIFF
--- a/deterministic-rt/.gitignore
+++ b/deterministic-rt/.gitignore
@@ -1,0 +1,2 @@
+jdk8u/
+libs/

--- a/deterministic-rt/Makefile
+++ b/deterministic-rt/Makefile
@@ -1,0 +1,25 @@
+.DEFAULT_GOAL=all
+
+jdk8u:
+	git clone -b deterministic-jvm8 --single-branch https://github.com/corda/openjdk $@
+
+jdk8u/common/autoconf/configure: jdk8u
+
+jdk8u/build/%/spec.gmk: jdk8u/common/autoconf/configure
+	cd jdk8u && $(SHELL) configure
+
+.PHONY: jdk-image clean all
+jdk-image: jdk8u/build/linux-x86_64-normal-server-release/spec.gmk
+	$(MAKE) -C jdk8u images docs
+
+all: libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat libs/calendars.properties
+
+clean: jdk8u/build/%/spec.gmk
+	$(MAKE) -C jdk8u clean
+
+libs:
+	mkdir $@
+
+libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat libs/calendars.properties: libs jdk-image
+	cp -f jdk8u/build/*/images/j2re-image/lib/$(@F) $@
+

--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -1,0 +1,189 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "net.sf.proguard:proguard-gradle:$proguard_version"
+    }
+}
+
+plugins {
+    id 'base'
+    id 'maven-publish'
+    id 'com.jfrog.artifactory'
+}
+
+ext {
+    artifactory_contextUrl = 'https://software.r3.com/artifactory'
+}
+
+/*
+ * This is a nested and independent Gradle project,
+ * and so has its own group and version.
+ *
+ * NOTE: The deterministic APIs are Open Source.
+ */
+group 'net.corda'
+version deterministic_rt_version
+
+task cleanJdk(type: Exec) {
+    commandLine 'make', 'clean'
+}
+
+task makeJdk(type: Exec) {
+    // See: https://github.com/corda/openjdk/tree/deterministic-jvm8
+    commandLine 'make'
+}
+
+task runtimeJar(type: Jar, dependsOn: makeJdk) {
+    baseName 'deterministic-rt'
+    inputs.dir 'libs'
+
+    from(zipTree('libs/rt.jar'))
+    from(zipTree('libs/jce.jar'))
+    from(zipTree('libs/jsse.jar'))
+    from 'libs/calendars.properties'
+    from 'libs/currency.data'
+    from 'libs/tzdb.dat'
+
+    reproducibleFileOrder = true
+    includeEmptyDirs = false
+}
+
+import proguard.gradle.ProGuardTask
+task validate(type: ProGuardTask) {
+    injars runtimeJar
+
+    dontwarn 'java.lang.invoke.**'
+    dontwarn 'javax.lang.model.**'
+    dontwarn 'jdk.Exported'
+
+    keepattributes '*'
+    dontpreverify
+    dontobfuscate
+    dontoptimize
+    verbose
+
+    keep 'class *'
+}
+runtimeJar.finalizedBy validate
+
+task apiJar(type: Jar, dependsOn: runtimeJar) {
+    baseName 'deterministic-rt'
+    classifier 'api'
+
+    from(zipTree(runtimeJar.outputs.files.singleFile)) {
+        include 'java/'
+        include 'javax/'
+        exclude 'java/awt/'
+        exclude 'java/beans/Weak*.class'
+        exclude 'java/lang/invoke/'
+        exclude 'java/lang/*Thread*.class'
+        exclude 'java/lang/Shutdown*.class'
+        exclude 'java/lang/ref/'
+        exclude 'java/lang/reflect/InvocationHandler.class'
+        exclude 'java/lang/reflect/Proxy*.class'
+        exclude 'java/lang/reflect/Weak*.class'
+        exclude 'java/io/File.class'
+        exclude 'java/io/File$*.class'
+        exclude 'java/io/*FileSystem.class'
+        exclude 'java/io/Filename*.class'
+        exclude 'java/io/FileDescriptor*.class'
+        exclude 'java/io/FileFilter*.class'
+        exclude 'java/io/FilePermission*.class'
+        exclude 'java/io/FileReader*.class'
+        exclude 'java/io/FileSystem*.class'
+        exclude 'java/io/File*Stream*.class'
+        exclude 'java/io/ObjectInputStream*.class'
+        exclude 'java/io/ObjectOutputStream*.class'
+        exclude 'java/io/ObjectStreamClass.class'
+        exclude 'java/io/ObjectStreamConstants.class'
+        exclude 'java/io/ObjectStreamField.class'
+        exclude 'java/net/*Content*.class'
+        exclude 'java/net/Host*.class'
+        exclude 'java/net/Inet*.class'
+        exclude 'java/nio/channels/FileChannel*.class'
+        exclude 'java/nio/channels/spi/'
+        exclude 'java/nio/file/Path.class'
+        exclude 'java/nio/file/attribute/'
+        exclude 'java/util/SplittableRandom*.class'
+        exclude 'java/util/Random.class'
+        exclude 'java/util/Random$*.class'
+        exclude 'java/util/WeakHashMap*.class'
+        exclude 'java/util/concurrent/Blocking*.class'
+        exclude 'java/util/concurrent/CompletionService.class'
+        exclude 'java/util/concurrent/CompletionStage.class'
+        exclude 'java/util/concurrent/ConcurrentLinked*.class'
+        exclude 'java/util/concurrent/ConcurrentNavigable*.class'
+        exclude 'java/util/concurrent/CopyOnWrite*.class'
+        exclude 'java/util/concurrent/*Executor*.class'
+        exclude 'java/util/concurrent/Future*.class'
+        exclude 'java/util/concurrent/Linked*.class'
+        exclude 'java/util/concurrent/RejectedExecution*.class'
+        exclude 'java/util/concurrent/Runnable*.class'
+        exclude 'java/util/concurrent/Semaphore*.class'
+        exclude 'java/util/concurrent/Synchronous*.class'
+        exclude 'java/util/concurrent/Thread*.class'
+        exclude 'java/util/concurrent/TransferQueue.class'
+        exclude 'java/util/concurrent/locks/'
+        exclude 'javax/activation/'
+    }
+
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+    includeEmptyDirs = false
+}
+
+defaultTasks 'build'
+assemble.dependsOn runtimeJar
+assemble.dependsOn apiJar
+clean.dependsOn cleanJdk
+
+artifacts {
+    archives runtimeJar
+    archives apiJar
+}
+
+artifactory {
+    // Load Artifactory credentials from either:
+    // - $HOME/.artifactory_credentials, or
+    // - the environment
+    Properties credentials = new Properties()
+    Path artifactoryCredentials = Paths.get(System.getProperty('user.home'), '.artifactory_credentials')
+    if (Files.isReadable(artifactoryCredentials)) {
+        artifactoryCredentials.withInputStream { input ->
+            credentials.load(input)
+        }
+    }
+
+    contextUrl = artifactory_contextUrl
+    publish {
+        repository {
+            repoKey = 'corda-dev'
+            username = credentials.getProperty('artifactory.username', System.getenv('CORDA_ARTIFACTORY_USERNAME'))
+            password = credentials.getProperty('artifactory.password', System.getenv('CORDA_ARTIFACTORY_PASSWORD'))
+            maven = true
+        }
+
+        defaults {
+            publications('mavenJava')
+        }
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId 'deterministic-rt'
+            artifact runtimeJar
+            artifact apiJar
+        }
+    }
+}
+
+task install(dependsOn: publishToMavenLocal)

--- a/deterministic-rt/gradle.properties
+++ b/deterministic-rt/gradle.properties
@@ -1,0 +1,6 @@
+org.gradle.caching=false
+
+deterministic_rt_version=1.0-SNAPSHOT
+
+artifactory_plugin_version=4.9.6
+proguard_version=6.1.1

--- a/deterministic-rt/settings.gradle
+++ b/deterministic-rt/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'com.jfrog.artifactory' version artifactory_plugin_version
+    }
+}
+
+rootProject.name = 'deterministic-rt'


### PR DESCRIPTION
commit c86483091efa19924363d7b571450f389e35db37
Author: Chris Rankin <chris.rankin@r3.com>
Date:   Mon Nov 18 14:28:02 2019 +0000

    CORDA-2963: Move deterministic-rt files into their own subdirectory.

commit 148f0358e1ac80273e2474843bf9e6fbf760f4cb
Author: Chris Rankin <chris.rankin@r3.com>
Date:   Mon Nov 18 13:54:51 2019 +0000

    CORDA-2963: Add calendars.properties to deterministic-rt.jar. (#5730)

commit 8be3e65e5170c5ce4fbe8da758b61cf2ccc4eaa8
Author: Chris Rankin <chris.rankin@r3.com>
Date:   Fri Oct 25 10:39:56 2019 +0100

    CORDA-2963: Update the Deterministic Java API artifacts. (#5637)

    * CORDA-2963: Restore FileChannel to deterministic-rt but still remove it from the API artifact.

    * CORDA-2963: Restore stub ObjectStream classes to deterministic-rt but still remove them from the API artifact.

    * CORDA-2963: Add currency.data to deterministic-rt.jar as a resource.

    * CORDA-2963: Add tzdb.dat to deterministic-rt.jar as a resource.

    * CORDA-3326: Restore supported java.util.concurrent.* classes to the API artifact.

commit 34981e69d60f54dede07c3c5c4382ef8118a5d1d
Author: Chris Rankin <chris.rankin@r3.com>
Date:   Tue Jun 26 11:53:16 2018 +0100

    ENT-1467: Make the deterministic JDK image compatible with IntelliJ. (#3416)

    * Expand the deterministic JDK image to make it friendlier to IntelliJ.
    * Fix Gradle always to use the latest deterministic rt.jar available.
    * Write JDK items directly from Gradle.

commit 0c55d2f3d8c9178fee5133819dcb8373da00a82d
Author: Chris Rankin <chris.rankin@r3.com>
Date:   Mon Jun 11 20:34:59 2018 +0100

    ENT-1463, ENT-1903: Create core-deterministic and serialization-deterministic artifacts. (#3262)

    * Create core-deterministic and serialization-deterministic artifacts:

    commit 6f77838fe53d7c9565283c20bbf20f27954b27f6
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 29 23:14:23 2018 +0100

        Tidy up Gradle files.

    commit 0aa958d31c6342e92ad4d6ab396db6e4a39d4fed
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 29 18:11:17 2018 +0100

        Fix EnclaveletTest with deterministic core and serialisation.

    commit 732fcf37ee2219dfad373200676241d2fd90aeb3
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun May 27 00:21:42 2018 +0100

        Extend JarFilter to delete typealias declarations.

    commit 25dbf30ed62c0c059df07782306b7f760f4cdf73
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 24 17:20:41 2018 +0100

        Test deserialising a contract and verifying it using core-deterministic.

    commit f7753bf2ab588e084cb8bfaa5fd04f1a18d3aaef
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 24 11:25:49 2018 +0100

        Do not remove constructors from Kotlin annotation metadata.

    commit 4ddf357b71b29775aa921aca33b4505a402a20e8
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 23 16:30:18 2018 +0100

        Add Gradle modules for deterministic rt.jar artifacts.

    commit e81f462eefad2369706fd1b8447d426a71a25a03
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 23 16:22:04 2018 +0100

        Isolate reference to WeakHashMap - for deletion!

    commit eea2458fbec06b28344547fdf9c191a9445fe1e7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 17 18:01:20 2018 +0100

        Extract Kotlin metadata classes from kotlin-compiler-embeddable.
        This fixes a classpath issue that was crashing Gradle.

    commit 87fdb938d83f3de6589730343c860fbbc406942e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 15 15:40:31 2018 +0100

        Remove instances of ConcurrentHashMap from AMQP serialization scheme.

    commit 9e7773ec32542af4df62269aea3d08e2bd3794f9
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon May 14 23:10:09 2018 +0100

        Fix the checkDeterminism targets to validate JAR.

    commit 6066ba89cb0077b17a7bdda79195763e86d100f9
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon May 14 09:16:14 2018 +0100

        Remove private Blob object.

    commit 73180723ad437b07ba4ccfd935620c0fa97039ea
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun May 13 23:48:48 2018 +0100

        Ignore unit tests if important system property is not set.

    commit abfa0a85aff72007342142a9c66fea3b48f62cc7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat May 12 22:18:28 2018 +0100

        Make deterministic tests involving keystores optional.

    commit 5866f8f08910cbfa90c006e88482acec467042a5
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri May 11 17:19:57 2018 +0100

        Prevent checked exceptions escaping from JarFilter tasks.

    commit e2a41913e00aff2bb9b59b43f0a721c5547a8683
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 10 17:18:30 2018 +0100

        Create node-api-deterministic artifact.

    commit 804feb4e69be4899f29c0cb1c5be95f58d2c47c9
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 10 16:54:46 2018 +0100

        Upgrade to ProGuard 6.0.3

    commit ec12b0ed213c1336202012ccf864a49bb8adf727
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 9 12:56:15 2018 +0100

        Extend JarFilter to identify extension properties correctly.

    commit f0e119e2e3d90db80efb38a316f48b34082c5f49
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat May 5 13:47:51 2018 +0100

        Construct a better test jar for tasks to unzip/rezip.

    commit a13380c0ee29dbdd93419f29c01a904c4a69db15
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri May 4 09:47:32 2018 +0100

        Update JarFilter to Kotlin 1.2.41.

    commit b774a1e359fb08077a57e8c3b4f1b314653deec0
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu May 3 16:27:43 2018 +0100

        Convert some JarFilter functions into val properties.

    commit b38f9a8f53a3e68e62580e0b8af625b37463cd41
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 2 23:05:24 2018 +0100

        Tidy up Gradle test projects.

    commit 421c2e6c93c0c7317e7977fd7bf134902920760e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 2 22:12:18 2018 +0100

        Published core-deterministic artifact is actually built by metafix task.

    commit 6d7b20a6826e4c04cd252a4ff4d30ceeb9193eb4
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 2 16:55:01 2018 +0100

        Always recompute compressed sizes for ZipEntry.

    commit 05587234c4f87aeab925b73f7b7fdc22a2d77159
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed May 2 15:14:12 2018 +0100

        Test whether MetaFix task can delete file timestamps from the jar.

    commit 9d6bd0d5cf9f05f088d98eaf7399db4cafc64c61
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 22:15:02 2018 +0100

        WIP - erase timestamps for all jar entries.

    commit 4cb4d6213916d752a654d4fa8d22db6fe6e7e9c6
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 17:39:56 2018 +0100

        Annotate more core elements as @Deterministic/@NonDeterministic.

    commit e847c6c1f03665bd0eff228ce242958512155860
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 17:17:24 2018 +0100

        Update JarFilter so that void methods are stubbed with empty bodies.

    commit f53d7b48676f2b3d2b2062bc12591f9966a8db83
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 16:07:48 2018 +0100

        Rename @DeterministicStub to @NonDeterministicStub.

    commit 0c2e7e76587805b72f0270cdbbc067a909abae82
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 15:57:37 2018 +0100

        Consistency fix for JarFilter log messages about methods.

    commit 43a5c342c508fcc690a02b94926cf4153b5eb297
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue May 1 13:25:15 2018 +0100

        Reorganise determinism unit test.

    commit 6079d319d20a6c0cb7386bfcf98b675a73bff040
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Apr 30 23:10:23 2018 +0100

        Allow file timestamps to be thrown away for reproducible builds.

    commit 7068f2fcd46d3f600710ccd9312b9d8dc46f1f38
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Apr 30 21:55:26 2018 +0100

        Declare PlatformSecureRandom as non-deterministic.

    commit 3a5b8eff11a7200f48310408442880967260d80e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Apr 30 17:48:20 2018 +0100

        Test deleting property initialisers from <clinit> block.

    commit a91f75cf8eb813305adcfd962d8931a1b9322915
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 29 23:34:26 2018 +0100

        Suppress lots of "UNUSED" warnings for test classes.

    commit fb09396f14cb6b2b80e80209091afe370cef15ab
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 29 23:10:13 2018 +0100

        Add crude test for fixing package metadata.

    commit 80a9c794bcbc6cbfb7010285c9e94faa9c17310a
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 29 21:45:28 2018 +0100

        Refactor GradleRunner code into a JUnit Rule.

    commit 5615dd6624991af49ae283beb3dfe1223d0f26f3
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 29 00:55:10 2018 +0100

        Add JaCoCo support to JarFilter plugin.

    commit df55b962aa77f170d4183865743a263d11f061b3
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat Apr 28 16:48:58 2018 +0100

        Allow the executor to iterate the Visitor more than twice.

    commit d906e3996b7724528e69fc4abe79c2b59b2f03cb
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat Apr 28 16:19:52 2018 +0100

        Add tests for deleting static properties.

    commit f87120efeeb9b6edd129ca71852d1c1bc3fe7e57
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 27 17:34:39 2018 +0100

        Ensure that SgxSupport.isInsideEnclave is always true for core-deterministic.

    commit 85ff9cb17492ae93f0e4f5bbaa2d935e4d776b13
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 27 14:26:14 2018 +0100

        Test deleting field references from constructor byte-code.

    commit ac45aa04c60dab71553ddf0ddfc97ecaed6c84af
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 26 22:49:39 2018 +0100

        Add tweak to ClassVisitor code.

    commit 70bc232592e8739546e3f0cdb90add29b5953cf8
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 26 18:37:55 2018 +0100

        Declare more Crypto functionality as Deterministic/NonDeterministic.

    commit 6ceb49af6b75e90ce8e6d739ca6b012627ed6128
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 26 15:39:41 2018 +0100

        Rewrite constructors not to reference deleted fields.

    commit ed1a0e76e68d49531026e130d3c4d4ca56b3e06d
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 26 09:48:38 2018 +0100

        Configure ASM to compute max stack and locals automatically.

    commit 0c1a789bf0824b8a18c57a04f4428c678864b76d
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 25 17:30:52 2018 +0100

        Add isConstructor property to MethodElement.

    commit acd640db52b2b1051c67067c30414d2035c9d064
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 25 14:59:33 2018 +0100

        Add test cases for deleting singleton objects.

    commit 1a1b79ee13f993dd9cfc9ab8f570e96a5f2e3530
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 25 12:18:49 2018 +0100

        Extend JarFilter to delete lazy properties.

    commit acea7942ad85107e0deec6bef1a0c9d88329b9c4
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 24 16:04:48 2018 +0100

        Remove functions for measuring elapsed time.

    commit 03cc5c53b5b220ceccf43b0a3a218e84055a2f17
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Apr 23 18:29:47 2018 +0100

        Modify MetaFixer task to remove deleted nested classes.

    commit 281c5c06b69fe4bbc28d41aa46c3cf4b6c625877
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Apr 23 15:02:54 2018 +0100

        Removing dangling references to deleted nested classes.

    commit 8bd44ab76dca21b1198db37a1e574538f99c2555
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 22 20:15:00 2018 +0100

        Refactor StubbingMethodAdapter to rewrite remaining annotations.

    commit 59f7392155fe79c9017af563c4705ef5f486dd6b
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 22 01:14:59 2018 +0100

        Small tidy-up of property tests.

    commit 7696708ddf3370b13ff5ea2727b2e03380792098
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 22 00:53:28 2018 +0100

        Test backing field when deleting a property.

    commit 083d7678ea73fde03be62d1b845654b9ec9c0c9a
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 22 00:40:45 2018 +0100

        Refactor isFunction() and isConstructor() for Kotlin reflection.

    commit cbb5bc30d9fb991d12a8c3775e715b49a2c13abd
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sun Apr 22 00:33:11 2018 +0100

        Ensure that stubbed out functions keep their annotations.

    commit 14947aa105cb7c336b6a7cffa875b6add8000c5d
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat Apr 21 16:11:33 2018 +0100

        Test JarFilter interactions between deleting and stubbing out.

    commit 2d2a944f56268a697d110923a73589bf71145011
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 20 16:59:40 2018 +0100

        Annotate more core classes as @Deterministic.

    commit a23382ff1930747fa55497fcd8c18e00bf980d4f
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 20 15:48:49 2018 +0100

        Extend JarFilter unit test coverage.

    commit af0d3b32c85e23fb7a6c6e9a0639cc0d22a7213f
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 20 14:49:56 2018 +0100

        Enhance JarFilter - also delete methods that use deleted methods/fields.

    commit e6cd87e73b5509656faa6879ab8057690c8450ad
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 19 18:40:30 2018 +0100

        Upgrade AssertJ to 3.9.1

    commit ab217563de2cb60a690221d1d497247d04486060
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 19 18:20:54 2018 +0100

        Add unit tests for the metadata-fixing task.

    commit ddff9a10e8aa6dae81b597ff757edee0125d663f
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Apr 19 09:01:25 2018 +0100

        Refactor Hamcrest matchers into a separate package.

    commit afa3f5a825f8127bec262ff0a7ece5af1e0c6dfb
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 18 23:15:05 2018 +0100

        Add unit tests for MethodElement and FieldElement.

    commit dd412756bc99ff46083558e6863498ae1493a4b7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 18 17:06:42 2018 +0100

        Declare exception and MerkleTree classes as deterministic.

    commit ce732d2cfb17a8f70a4bc71ccad4d75e68e240c7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 18 16:04:33 2018 +0100

        Never remove @JvmField properties from companion objects when fixing metadata.

    commit c2a5b35b351480c637dc023c07043243b7f16ee5
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Apr 18 10:37:28 2018 +0100

        Rename MetaFix* classes to MetaFixer*.

    commit 358916bef7eb9955f3fc7cea9ab08286ab153564
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 17 16:21:10 2018 +0100

        Extend JarFilter to remove getters/setters along with properties.

    commit 0c96a154b89244cdc93c53563aacd40b019182d4
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 17 13:11:29 2018 +0100

        Extend JarFilter tests for deleting properties.

    commit bb63fbacbd46e93eb2dbecca21161968d11fc59e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 17 12:28:37 2018 +0100

        Fix determination of CordaException.

    commit cb92d47643e1a9c41267e548fc79d077da941b28
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 17 12:25:06 2018 +0100

        Refactor JarFilter - support deleting @JvmField properties.

    commit 349b1a7fe9bec140e1f988e104ec44a8e65745c6
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Apr 13 17:32:07 2018 +0100

        Preliminary Gradle task to remove missing elements from @Metadata.

    commit f4564e6661458a317f2ebf0e8ce0fbdeae5e1c30
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Apr 3 20:46:41 2018 +0100

        Upgrade to ProGuard 6.0.2

    commit c937109398c242bb09d0157cec8debded6012a1b
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 29 12:04:52 2018 +0100

        Refactor internal Kotlin dependencies into MetadataTransformer.

    commit 899a315a2684986249c88f647784f88235205530
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 29 09:48:05 2018 +0100

        Upgrade to ASM 6.1.1.

    commit 592e1ced7d36f0838c634cb413af9d0b4b8b516b
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Sat Mar 24 13:37:17 2018 +0000

        Remove unwanted Kotlin artifacts from the JarFilter's classpath.

    commit 4591d54c247fc9937f202306e2a5ec872fb2dbea
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 23 10:04:49 2018 +0000

        Tidy up output from Kotlin reflection matchers.

    commit fb78d898ef1428210bbb030f43b9a2024f1fdeb1
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 23 09:42:38 2018 +0000

        Remove lateinit field from ClassTransformer.

    commit c08ecb2139550ea1bc6ab6cebb3ab180e037c40a
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 18:25:54 2018 +0000

        Remove non-deterministic DelegatingSecureRandom* classes from core-deterministic.

    commit 7c3e8e794ec868ff4385661ff68081f2bc5ba09c
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 18:24:48 2018 +0000

        Stop removing @kotlin.Metadata annotations from core-deterministic.

    commit 16ce8ceee91793efb8a100e29d1770f23cf02643
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 15:42:58 2018 +0000

        Add (C) headers for new files.

    commit 6146b0b47d9e9f46873506711cbef60477aea655
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 12:43:43 2018 +0000

        Log synthetic classes, but do not adjust @Metadata.

    commit 016b2be942533790413e28d50d6dc8b104a4de5c
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 12:08:36 2018 +0000

        Add @Metadata support for Kotlin multi-file classes.

    commit 9eeed582a083c34a0580f1049cad42d7dc8812a1
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 22 10:38:09 2018 +0000

        Add JarFilter unit tests for @kotlin.Metadata updates.

    commit eb71cb3d76a45fa15eedf478e6172e33a8127305
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Mar 21 15:29:01 2018 +0000

        Update JarFilter plugin to remove references to deleted constructors, functions and fields from @kotlin.Metadata.

    commit c28c099546dd24ab6f158b633e494948fabb6b5e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 15 18:27:06 2018 +0000

        Tidy up Enclavelet tests slightly.

    commit 895dfe659b9ffa6e39b407606876facc153e3128
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 15 18:25:14 2018 +0000

        Annotate more Attachment / Transaction classes as @Deterministic.

    commit f5ab283d09a803b9e2e0f465841cd072e9a7040f
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 15 14:21:51 2018 +0000

        Upgrade to ProGuard 6.0.1

    commit c7717cc0106f39fec822bce8fbbcf18a75a25c2d
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 15 11:11:34 2018 +0000

        Adjust LedgerTransaction to remove ClassLoader references when deterministic.

    commit 5b37fe9f3f716944f2eb3952870d2e9548dc144d
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Mar 14 16:28:41 2018 +0000

        Extra testing for deterministic SecureHash.

    commit 01be61676edddf28d4b16a75cff1dd5fe2079c03
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Mar 12 16:32:05 2018 +0000

        Keep synthetic methods for Kotlin classes.

    commit cb01f28089c94457c0498802741dcc742a52eaac
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Mar 12 14:35:17 2018 +0000

        Add libraries to core-deterministic's runtimeArtifacts configuration.

    commit c23ad307596c07a608d6ce3e600fe1b0aee94ef1
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Mar 12 11:20:35 2018 +0000

        Check that JarFilter's different annotations are all distinct.

    commit 4b84451f9d124cba75bb4a1984b9a9d9f60efd17
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 9 17:01:15 2018 +0000

        Update the JarFilter plugin to remove some annotations.
        This is for stripping @kotlin.Metadata from deterministic classes.

    commit 72c4740ffdd5fcb9a7828a1324f6632747fe3115
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 9 14:11:16 2018 +0000

        Configure ProGuard to preverify the deterministic JAR.

    commit 9fce4724ac3e1cb80f89d38f63a28b39585dfbf9
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 9 14:09:33 2018 +0000

        Update to corda-gradle-plugins 4.0.7-SNAPSHOT.

    commit fc46624ea2f1c862c9b2a2064a9007ffdc1b94d8
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 8 18:08:20 2018 +0000

        Allow core-deterministic artifact to be tested and published.

    commit 238814ad2d94dd74fd7cbae7dc3b4d1016697850
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Mar 8 14:54:27 2018 +0000

        Since Kotlin 1.2.x, Kotlin artifact dependencies match Kotlin plugin version by default.

    commit f81b3772b598995d0df0519512ae1c6b1d4d238b
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Mar 7 13:46:41 2018 +0000

        Update KDoc for @Deterministic annotation.

    commit 7a1b0fbe6540958bbc743981a3ba724f0f22ef80
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Mar 7 12:27:22 2018 +0000

        Add (C) headers for JarFilter and deterministic core.

    commit 0add901e55a23c898da7c6a3ec0c4273d7555441
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Mar 7 09:30:38 2018 +0000

        Refactor function name for compatibility with corda-gradle-plugins.

    commit f37a73dea8969a82ceda48072cb7d393c05a44c7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Mar 6 13:57:58 2018 +0000

        Include more contract states in core-deterministic.

    commit b2eeb08be90fa1a0739854d0c393a23b8c49aed0
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Mar 6 11:18:53 2018 +0000

        Remove synchronized section from deterministic ToggleField.

    commit 353257e6a04de1447c674f43989e2fc8aecc807a
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 15:24:46 2018 +0000

        Extend @NonDeterministic also to target JVM fields.

    commit 9dc940c4f9ae8e29e043cdf93634d072373eb030
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 15:21:03 2018 +0000

        Add tests for deleting field.

    commit 2bf43957ed656c419cbf1a0a0ba48b755b8e8ac9
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 14:16:33 2018 +0000

        Tidy up Kotlin lambdas.

    commit 45dc150cfc0b7090816036a4f4f3ce7ae5cde79b
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 10:27:57 2018 +0000

        Set 'gradle.user.home' for test-kit's GradleRunner. This allows
        it to share the project's module cache, which means that it doesn't
        need to download its own copy of Kotlin over the Internet.

    commit d79ffd0b44cc890dc8e0f513e5d5baaeaddb5d50
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 00:41:00 2018 +0000

        Remove settings.gradle from tests - it was not the solution.

    commit b30fdcd4c2b44370294ae78699b1424e817b13de
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Mar 2 00:28:42 2018 +0000

        Create plugin descriptor using java-gradle-plugin.

    commit a9e7cbe51e5d3f0d8efea0501ef4858fd3511cd0
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 16:55:53 2018 +0000

        Resolve simple compiler warning.

    commit d247524090539a0d708d383f25e9539a6e6ee809
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 16:03:19 2018 +0000

        Add local settings.gradle for all unit tests.

    commit 031411c71fda98511f9fba6c763cb6d3f74d95eb
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 13:58:06 2018 +0000

        Add test filtering interface functions.

    commit dcc6055ae01fb9e98bea73befe7a5cf473e27590
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 13:45:25 2018 +0000

        Add test for filtering abstract functions.

    commit 0c084f96aa4cbf7173f633dd1d4fa6e633cea6a7
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 11:26:27 2018 +0000

        Add tests for stubbing static functions out.

    commit 3412e3479f09f36e34a33bbd7564bd95b4bbd017
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 11:13:35 2018 +0000

        Add tests for deleting static functions.

    commit 5d8ce9ce1edbee0020595af99c20268de8c38c5f
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 10:50:03 2018 +0000

        Add test for stubbing out a var property.

    commit dea60c8252b0bc849845fdeecc28f67817ef77d8
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 10:41:13 2018 +0000

        Add test for stubbing a val property out.

    commit c69de1b904b496fe146e91eb7e6d138171528b1a
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 10:28:13 2018 +0000

        Add tests for stubbing constructors out.

    commit 1f791cf6013700689e38b129460eba1d20dc5efa
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Wed Feb 28 00:35:23 2018 +0000

        Add tests for deleting constructors.

    commit 55790a8abb3dba50b4a136760c9a21dc1bd214ca
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Feb 27 18:37:51 2018 +0000

        Add (and fix) test for stubbing a function out.

    commit 1f03202197a9e1fe9023848869e0273a05eef3dc
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Tue Feb 27 13:09:55 2018 +0000

        Refactor buildSrc into a multi-module project.

    commit 4c937580f40753408b6f29cfc72741b412e4ed3e
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Mon Feb 26 17:15:50 2018 +0000

        Initial unit testing framework for JarFilter plugin.

    commit 45afcaa082cb3f7223d42458a28af14c7c02d611
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Fri Feb 23 12:32:04 2018 +0000

        Allow some methods to be stubbed out instead of deleted.

    commit c5911ec643739369e138a5b451cafa7c067c4134
    Author: Chris Rankin <chris.rankin@r3.com>
    Date:   Thu Feb 22 10:31:18 2018 +0000

        ENT-1468: Initial version of the JarFilterTask.

    * Refactor deterministic test data to work on Windows.
    * Fix JarFilter unit tests on Windows.
    * Upgrade JarFilter to ASM 6.2
    * Allow core-deterministic, serialization-deterministic to be published to Artifactory.
    * Share repository configuration between all JarFilter unit tests.
    * Small fixes after review.
    * Ensure core-deterministic and serialization-deterministic are published with their dependencies.
    * Fix logic for number of JarFilter passes.
    * Add README for JarFilter plugin.
    * Move JarFilter plugin into the 'net.corda.plugins' namespace.
    * Modify JarFilter to update sealed subclasses in @kotlin.Metadata.
    * Add Gradle fixes from @Clintonio.
    * Annotate TransientClassWhitelist as deterministic.
    * Add literalinclude blocks to the deterministic-module docs.
    * Fix Kotlin Metadata properly when all nested classes are deleted.
    * Small tidy-up for Gradle files.
    * Add some KDoc for the JarFilter and deterministic classes.
    * Update JarFilter to handle properties with generic return types.
    * Remove some uses of Java Reflection from DJVM.
    * Rename determinism annotations to @KeepForDJVM, @DeleteForDJVM, @StubOutForDJVM.