### PR TITLE
CORDA-2963: Add GPLv2+CE licence to deterministic-rt POM artifact.

### DIFF
--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -182,6 +182,24 @@ publishing {
             artifactId 'deterministic-rt'
             artifact runtimeJar
             artifact apiJar
+
+            pom {
+                licenses {
+                    license {
+                        name = 'GPLv2+CE'
+                        url = 'https://openjdk.java.net/legal/gplv2+ce.html'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'R3'
+                        name = 'R3'
+                        email = 'dev@corda.net'
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Ensure that we publish the deterministic-rt artifacts under the correct GPLv2+CE licence.