### PR TITLE
CORDA-2963: Update to use first release candidate for deterministic-rt.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -26,6 +26,7 @@ repositories {
 }
 
 configurations {
+    jdkRt
     sandboxTesting
 
     all {
@@ -47,7 +48,7 @@ configurations {
         }
     }
 
-    [ jdkRt, testCompileClasspath, testRuntimeClasspath ].forEach { cfg ->
+    [ testCompileClasspath, testRuntimeClasspath ].forEach { cfg ->
         cfg.resolutionStrategy {
             // Always check the repository for a newer SNAPSHOT.
             cacheChangingModulesFor 0, 'seconds'
@@ -66,7 +67,7 @@ dependencies {
     testImplementation "net.corda:corda-serialization-djvm:$corda_version"
     testImplementation "net.corda.djvm:corda-djvm:$djvm_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
-    jdkRt "net.corda:deterministic-rt:latest.integration"
+    jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation "org.assertj:assertj-core:$assertj_version"

--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -2,7 +2,8 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
 kotlin.incremental=true
 
-djvm_version=1.0-SNAPSHOT
+djvm_version=1.0-RC03
+deterministic_rt_version=1.0-RC01
 corda_version=4.4-SNAPSHOT
 corda_tokens_version=1.0
 

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -14,7 +14,7 @@ description 'Corda deterministic JVM sandbox'
 
 repositories {
     maven {
-        url "$artifactory_contextUrl/corda-dev"
+        url "$artifactory_contextUrl/corda-dependencies"
     }
 }
 
@@ -30,12 +30,9 @@ if (current() > VERSION_1_8) {
 }
 
 configurations {
+    jdkRt
     sandboxTesting
     testImplementation.extendsFrom shadow
-    jdkRt.resolutionStrategy {
-        // Always check the repository for a newer SNAPSHOT.
-        cacheChangingModulesFor 0, 'seconds'
-    }
 }
 
 dependencies {
@@ -57,7 +54,7 @@ dependencies {
     // Test utilities
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
-    jdkRt "net.corda:deterministic-rt:latest.integration"
+    jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
 
     // The DJVM will need this classpath to run the unit tests.
     sandboxTesting files(sourceSets.getByName("test").output)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.caching=false
 kotlin.incremental=true
 
 corda_djvm_version=1.0-SNAPSHOT
+deterministic_rt_version=1.0-RC01
 
 corda_plugins_version=5.0.6
 asm_version=7.2


### PR DESCRIPTION
It's time to stop using a SNAPSHOT version of deterministic-rt.jar. The first release candidate of this artifact has now been published to the corda-dependencies repository in Artifactory.