### PR TITLE
CORDA-2963: Update deterministic-rt module to build from a tag.

### DIFF
--- a/deterministic-rt/Makefile
+++ b/deterministic-rt/Makefile
@@ -9,12 +9,13 @@ jdk8u/build/%/spec.gmk: jdk8u/common/autoconf/configure
 	cd jdk8u && $(SHELL) configure
 
 .PHONY: jdk-image clean all
-jdk-image: jdk8u/build/linux-x86_64-normal-server-release/spec.gmk
+jdk-image: jdk8u/build/*/spec.gmk
+	cd jdk8u && git checkout -f $(RT_TAG)
 	$(MAKE) -C jdk8u images docs
 
 all: libs/rt.jar libs/jce.jar libs/jsse.jar libs/currency.data libs/tzdb.dat libs/calendars.properties
 
-clean: jdk8u/build/%/spec.gmk
+clean: jdk8u/build/*/spec.gmk
 	$(MAKE) -C jdk8u clean
 
 libs:

--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -20,6 +20,7 @@ plugins {
 
 ext {
     artifactory_contextUrl = 'https://software.r3.com/artifactory'
+    deterministic_rt_tag = 'deterministic/1.0-RC01'
 }
 
 /*
@@ -37,7 +38,7 @@ task cleanJdk(type: Exec) {
 
 task makeJdk(type: Exec) {
     // See: https://github.com/corda/openjdk/tree/deterministic-jvm8
-    commandLine 'make'
+    commandLine 'make', "RT_TAG=$deterministic_rt_tag"
 }
 
 task runtimeJar(type: Jar, dependsOn: makeJdk) {


### PR DESCRIPTION
We need the deterministic-rt artifacts to be repeatable, so ensure that we build them from a known tag in our OpenJDK repository.