### PR TITLE
CORDA-2963: Ensure that deterministic-rt.jar artifact build is repeatable.

### DIFF
--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -52,6 +52,7 @@ task runtimeJar(type: Jar, dependsOn: makeJdk) {
     from 'libs/currency.data'
     from 'libs/tzdb.dat'
 
+    preserveFileTimestamps = false
     reproducibleFileOrder = true
     includeEmptyDirs = false
 }


### PR DESCRIPTION
Remove file timestamps from within the jar so that the artifact can be recreated exactly.