### PR TITLE
Extend DJVM example project to include Scala support.

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'org.jetbrains.kotlin.jvm'
+    id 'scala'
 }
 
 ext {
@@ -59,6 +60,7 @@ configurations {
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
+    implementation "org.scala-lang:scala-library:$scala_version"
     implementation "com.r3.corda.lib.tokens:tokens-contracts:$corda_tokens_version"
     implementation "com.r3.corda.lib.tokens:tokens-money:$corda_tokens_version"
     implementation "net.corda:corda-core:$corda_version"
@@ -95,6 +97,16 @@ tasks.withType(KotlinCompile) {
         javaParameters = true    // Required for reflection / deserialization
         freeCompilerArgs = ['-Xjvm-default=enable']
         allWarningsAsErrors = true
+    }
+}
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.with {
+        encoding = 'UTF-8'
+        additionalParameters = [
+            '-opt:l:method',
+            '-opt:l:inline', '-opt-inline-from:**'
+        ]
     }
 }
 

--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -8,6 +8,7 @@ corda_version=4.4-SNAPSHOT
 corda_tokens_version=1.0
 
 kotlin_version=1.3.60
+scala_version=2.13.1
 assertj_version=3.13.2
 junit_jupiter_version=5.5.2
 log4j_version=2.12.1

--- a/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
+++ b/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
@@ -1,0 +1,13 @@
+package com.example.testing
+
+import java.security.MessageDigest
+import java.util.function.Function
+
+final class BadScalaTask extends Function[Array[Byte], String] {
+    override def apply(input: Array[Byte]): String = {
+        MessageDigest.getInstance("SHA-256")
+            .digest(input)
+            .map("%02x" format _)
+            .mkString
+    }
+}

--- a/djvm-example/src/main/scala/com/example/testing/ScalaTask.scala
+++ b/djvm-example/src/main/scala/com/example/testing/ScalaTask.scala
@@ -1,0 +1,12 @@
+package com.example.testing
+
+import java.util.function.Function
+
+final class ScalaTask extends Function[Int, String] {
+    private val say = (s: Int) => "Sandbox says: '" + s.toHexString.toUpperCase + "'"
+
+    override def apply(input: Int): String = {
+        lazy val s = say(input)
+        s
+    }
+}

--- a/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
+++ b/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
@@ -7,9 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import static com.example.testing.SandboxType.JAVA;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JavaSandboxTest extends TestBase {
+    private static final long BIG_NUMBER = 1234L;
+
     JavaSandboxTest() {
         super(JAVA);
     }
@@ -28,7 +31,7 @@ class JavaSandboxTest extends TestBase {
     void testBadTask() {
         sandbox(ctx -> {
             SandboxExecutor<Long, Long> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
-            Throwable ex = assertThrows(NoSuchMethodError.class, () -> WithJava.run(executor, BadJavaTask.class, 1234L));
+            Throwable ex = assertThrows(NoSuchMethodError.class, () -> WithJava.run(executor, BadJavaTask.class, BIG_NUMBER));
             assertThat(ex)
                 .isExactlyInstanceOf(NoSuchMethodError.class)
                 .hasMessageContaining("sandbox.java.lang.System.currentTimeMillis()")

--- a/djvm-example/src/test/kotlin/com/example/testing/KotlinSandboxTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/KotlinSandboxTest.kt
@@ -20,7 +20,9 @@ class KotlinSandboxTest : TestBase(KOTLIN) {
     @Test
     fun testBadTask() = sandbox {
         val executor = DeterministicSandboxExecutor<String, Long>(configuration)
-        val exception = assertThrows<SandboxException> { executor.run<BadKotlinTask>("field") }
+        val exception = assertThrows<SandboxException> {
+            executor.run<BadKotlinTask>("field")
+        }
         assertThat(exception)
             .hasCauseExactlyInstanceOf(RuleViolationError::class.java)
             .hasMessageContaining("Disallowed reference to API; java.lang.Class.getField(String)")

--- a/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
@@ -1,0 +1,34 @@
+package com.example.testing
+
+import com.example.testing.SandboxType.KOTLIN
+import net.corda.djvm.execution.DeterministicSandboxExecutor
+import net.corda.djvm.execution.SandboxException
+import net.corda.djvm.rules.RuleViolationError
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Scala's runtime library doesn't play nicely inside the DJVM's sandbox.
+ * The [java.lang.invoke] classes are currently off-limits!
+ */
+class ScalaSandboxTest : TestBase(KOTLIN) {
+    @Test
+    fun testGoodTask() = sandbox {
+        val executor = DeterministicSandboxExecutor<Int, String>(configuration)
+        val output = executor.run<ScalaTask>(0xbadf00d).result
+        assertEquals("Sandbox says: 'BADF00D'", output)
+    }
+
+    @Test
+    fun testBadTask() = sandbox {
+        val executor = DeterministicSandboxExecutor<ByteArray, String>(configuration)
+        val ex = assertThrows<SandboxException> {
+            executor.run<BadScalaTask>("Secret Message!".toByteArray())
+        }
+        assertThat(ex)
+            .hasCauseExactlyInstanceOf(RuleViolationError::class.java)
+            .hasMessageContaining("Disallowed reference to reflection API; java.lang.invoke.MethodHandleImpl\$1.run()")
+    }
+}

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -18,7 +18,7 @@ repositories {
     }
 }
 
-if (current() > VERSION_1_8) {
+if (current().java9Compatible) {
     sourceSets {
         // Exclude test classes which cannot be compiled for Java > 8.
         test {

--- a/djvm/src/test/java/net/corda/djvm/execution/CapturingLambdaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/CapturingLambdaTest.java
@@ -1,0 +1,40 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.WithJava;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapturingLambdaTest extends TestBase {
+    private static final long BIG_NUMBER = 1234L;
+    private static final int MULTIPLIER = 100;
+
+    CapturingLambdaTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testCapturingLambda() {
+        sandbox(ctx -> {
+            SandboxExecutor<Long, Long> executor = new DeterministicSandboxExecutor<>(ctx.getConfiguration());
+            ExecutionSummaryWithResult success = WithJava.run(executor, CapturingLambda.class, BIG_NUMBER);
+            assertEquals(BIG_NUMBER * MULTIPLIER, success.getResult());
+            return null;
+        });
+    }
+
+    public static class CapturingLambda implements Function<Long, Long> {
+        private final BigDecimal value = new BigDecimal(MULTIPLIER);
+
+        @Override
+        public Long apply(Long input) {
+            Function<BigDecimal, BigDecimal> lambda = value::multiply;
+            return lambda.apply(new BigDecimal(input)).longValue();
+        }
+    }
+}


### PR DESCRIPTION
Add some test cases to explore how Scala behaves inside the sandbox - even if the answer is "Badly!".