### PR TITLE
CORDA-3377: Use DJVM's own ClassLoader as the base ClassLoader of every sandbox.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -47,7 +47,7 @@ class SandboxClassLoader private constructor(
     private val externalCache: ExternalCache?,
     throwableClass: Class<*>?,
     parent: ClassLoader?
-) : ClassLoader(parent ?: getSystemClassLoader()), AutoCloseable {
+) : ClassLoader(parent ?: SandboxClassLoader::class.java.classLoader), AutoCloseable {
 
     /**
      * Set of classes that should be left untouched due to whitelisting.


### PR DESCRIPTION
The DJVM code is very likely inside the system classloader, but use the DJVM's own classloader explicitly as the sandbox's parent classloader.