### PR TITLE
CORDA-3377: Remove explicit enableTracing option from SandboxConfiguration.

### DIFF
--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -59,8 +59,7 @@ abstract class TestBase(type: SandboxType) {
             )
             parentConfiguration = SandboxConfiguration.createFor(
                 analysisConfiguration = rootConfiguration,
-                profile = UNLIMITED,
-                enableTracing = false
+                profile = null
             )
         }
 

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -181,11 +181,10 @@ abstract class ClassCommand : CommandBase() {
 
     private fun getConfiguration(whitelist: Whitelist): SandboxConfiguration {
         return SandboxConfiguration.of(
-                profile = profile,
+                profile = if (disableTracing) { null } else { profile },
                 rules = if (ignoreRules) { emptyList() } else { ALL_RULES },
                 emitters = ignoreEmitters.emptyListIfTrueOtherwiseNull(),
                 definitionProviders = if (ignoreDefinitionProviders) { emptyList() } else { ALL_DEFINITION_PROVIDERS },
-                enableTracing = !disableTracing,
                 analysisConfiguration = AnalysisConfiguration.createRoot(
                         userSource = UserPathSource(getClasspath()),
                         whitelist = whitelist,

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -34,7 +34,7 @@ class SandboxConfiguration private constructor(
     val rules: List<Rule>,
     val emitters: List<Emitter>,
     val definitionProviders: List<DefinitionProvider>,
-    val executionProfile: ExecutionProfile,
+    val executionProfile: ExecutionProfile?,
     val analysisConfiguration: AnalysisConfiguration,
     val byteCodeCache: ByteCodeCache,
     val externalCache: ExternalCache?
@@ -183,18 +183,17 @@ class SandboxConfiguration private constructor(
          * Create a sandbox configuration where one or more properties deviates from the default.
          */
         fun of(
-            profile: ExecutionProfile = ExecutionProfile.DEFAULT,
+            profile: ExecutionProfile? = ExecutionProfile.DEFAULT,
             rules: List<Rule> = ALL_RULES,
             emitters: List<Emitter>? = null,
             definitionProviders: List<DefinitionProvider> = ALL_DEFINITION_PROVIDERS,
-            enableTracing: Boolean = true,
             analysisConfiguration: AnalysisConfiguration,
             externalCache: ExternalCache? = null
         ) = SandboxConfiguration(
                 executionProfile = profile,
                 rules = rules,
                 emitters = (emitters ?: ALL_EMITTERS).filter {
-                    enableTracing || it.priority > EMIT_TRACING
+                    (profile != null) || it.priority > EMIT_TRACING
                 },
                 definitionProviders = definitionProviders,
                 analysisConfiguration = analysisConfiguration,
@@ -209,13 +208,11 @@ class SandboxConfiguration private constructor(
         @Suppress("unused")
         fun createFor(
             analysisConfiguration: AnalysisConfiguration,
-            profile: ExecutionProfile,
-            enableTracing: Boolean,
+            profile: ExecutionProfile?,
             externalCache: ExternalCache?
         ): SandboxConfiguration {
             return of(
                 profile = profile,
-                enableTracing = enableTracing,
                 analysisConfiguration = analysisConfiguration,
                 externalCache = externalCache
             )
@@ -227,12 +224,10 @@ class SandboxConfiguration private constructor(
          */
         fun createFor(
             analysisConfiguration: AnalysisConfiguration,
-            profile: ExecutionProfile,
-            enableTracing: Boolean
+            profile: ExecutionProfile?
         ): SandboxConfiguration {
             return of(
                 profile = profile,
-                enableTracing = enableTracing,
                 analysisConfiguration = analysisConfiguration
             )
         }

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -1,6 +1,7 @@
 package net.corda.djvm
 
 import net.corda.djvm.costing.RuntimeCostSummary
+import net.corda.djvm.execution.ExecutionProfile
 import net.corda.djvm.rewiring.SandboxClassLoader
 import java.util.function.Consumer
 
@@ -19,7 +20,7 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
     /**
      * A summary of the currently accumulated runtime costs (for, e.g., memory allocations, invocations, etc.).
      */
-    val runtimeCosts = RuntimeCostSummary(configuration.executionProfile)
+    val runtimeCosts = RuntimeCostSummary(configuration.executionProfile ?: ExecutionProfile.UNLIMITED)
 
     private val hashCodes: MutableMap<Int, Int> = mutableMapOf()
     private var objectCounter: Int = 0


### PR DESCRIPTION
The `enableTracing` parameter is superfluous and can be replaced by a null `ExecutionProfile`.