### PR TITLE
NOTICK: Publish SNAPSHOT builds to corda-dependencies-dev repository.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ artifactory {
 
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'corda-dev'
+            repoKey = 'corda-dependencies-dev'
             username = credentials.getProperty('artifactory.username', System.getenv('CORDA_ARTIFACTORY_USERNAME'))
             password = credentials.getProperty('artifactory.password', System.getenv('CORDA_ARTIFACTORY_PASSWORD'))
         }

--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -169,7 +169,7 @@ artifactory {
     contextUrl = artifactory_contextUrl
     publish {
         repository {
-            repoKey = 'corda-dev'
+            repoKey = 'corda-dependencies-dev'
             username = credentials.getProperty('artifactory.username', System.getenv('CORDA_ARTIFACTORY_USERNAME'))
             password = credentials.getProperty('artifactory.password', System.getenv('CORDA_ARTIFACTORY_PASSWORD'))
             maven = true

--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -18,10 +18,10 @@ repositories {
         url "$artifactory_contextUrl/corda-dev"
     }
     maven {
-        url "$artifactory_contextUrl/corda-lib"
+        url "$artifactory_contextUrl/corda-dependencies"
     }
     maven {
-        url "$artifactory_contextUrl/corda-dependencies"
+        url "$artifactory_contextUrl/corda-lib"
     }
     mavenCentral()
 }


### PR DESCRIPTION
The DJVM artifacts are now hosted in Artifactory's corda-dependencies and corda-dependencies-dev repositories.