### PR TITLE
CORDA-3377: Marshall exceptions into the sandbox from imported Functions.

### DIFF
--- a/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesProvider.java
+++ b/djvm/src/main/java/sandbox/java/time/zone/ZoneRulesProvider.java
@@ -2,7 +2,6 @@ package sandbox.java.time.zone;
 
 import sandbox.java.io.DataInputStream;
 import sandbox.java.lang.DJVM;
-import sandbox.java.lang.String;
 import sandbox.java.lang.Throwable;
 import sandbox.java.security.AccessController;
 import sandbox.java.security.PrivilegedAction;
@@ -28,7 +27,7 @@ public abstract class ZoneRulesProvider extends sandbox.java.lang.Object {
                     loaded.clear();
                 } catch (Exception ex) {
                     Throwable t = DJVM.doCatch(ex);
-                    throw (RuntimeException) DJVM.fromDJVM(new ZoneRulesException(String.toDJVM("Unable to load TZDB time-zone rules"), t));
+                    throw (RuntimeException) DJVM.fromDJVM(new ZoneRulesException(DJVM.intern("Unable to load TZDB time-zone rules"), t));
                 }
                 return null;
             }

--- a/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/EmitterModule.kt
@@ -295,7 +295,7 @@ class EmitterModule(
 
     /**
      * This determines which [sandbox.java.lang.Throwable] type we must up-cast
-     * the return value of [sandbox.java.lang.DJVM.catch] to.
+     * the return value of [sandbox.java.lang.doCatch] to.
      */
     fun commonThrowableClassOf(classNames: Iterable<String>): String {
         val classIterator = classNames.iterator()

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -266,10 +266,10 @@ class SandboxClassLoader private constructor(
         InvocationTargetException::class,
         NoSuchMethodException::class
     )
-    fun <T> createForImport(task: Function<in T?, out Any?>): Function<in T?, out Any?> {
+    fun <T> createForImport(task: Function<in T, out Any?>): Function<in T, out Any?> {
         val taskClass = loadClass("sandbox.ImportTask")
         @Suppress("unchecked_cast")
-        return taskClass.getDeclaredConstructor(Function::class.java).newInstance(task) as Function<in T?, out Any?>
+        return taskClass.getDeclaredConstructor(Function::class.java).newInstance(task) as Function<in T, out Any?>
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowCatchingBlacklistedExceptions.kt
@@ -46,7 +46,7 @@ object DisallowCatchingBlacklistedExceptions : Emitter {
             exceptionHandlers.add(instruction.handler)
         } else if (instruction is CodeLabel && instruction.label in exceptionHandlers) {
             duplicate()
-            invokeInstrumenter("checkCatch", "(Ljava/lang/Throwable;)V")
+            invokeStatic(DJVM_NAME, "checkCatch", "(Ljava/lang/Throwable;)V")
         }
     }
 

--- a/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
+++ b/djvm/src/main/kotlin/sandbox/RuntimeCostAccounter.kt
@@ -30,15 +30,6 @@ private val allocationCosts = mapOf(
 )
 
 /**
- * Re-throw exception if it is of type [ThreadDeath] or [VirtualMachineError].
- */
-fun checkCatch(exception: Throwable) {
-    when (exception) {
-        is ThreadDeath, is VirtualMachineError -> throw exception
-    }
-}
-
-/**
  * Record a jump operation.
  */
 fun recordJump() = runtimeCosts.jumpCost.increment()

--- a/djvm/src/main/kotlin/sandbox/TaskTypes.kt
+++ b/djvm/src/main/kotlin/sandbox/TaskTypes.kt
@@ -1,8 +1,11 @@
 @file:JvmName("TaskTypes")
 package sandbox
 
+import sandbox.java.lang.checkCatch
 import sandbox.java.lang.escapeSandbox
 import sandbox.java.lang.sandbox
+import sandbox.java.lang.toRuleViolationError
+import sandbox.java.lang.toRuntimeException
 import sandbox.java.lang.unsandbox
 import java.util.Collections.unmodifiableSet
 
@@ -19,8 +22,7 @@ private val taskClasses = unmodifiableSet(setOf(
     "Task",
     "RawTask",
     "BasicInput",
-    "BasicOutput",
-    "ImportTask"
+    "BasicOutput"
 ))
 
 private fun isTaskClass(className: String): Boolean {
@@ -88,10 +90,17 @@ class BasicOutput : SandboxFunction<Any?, Any?>, Function<Any?, Any?> {
 @Suppress("unused")
 class ImportTask(private val function: Function<Any?, Any?>) : SandboxFunction<Any?, Any?>, Function<Any?, Any?> {
     /**
-     * This allows [function] to be executed both
-     * inside and outside the sandbox.
+     * This allows [function] to be executed inside the sandbox.
+     * !!! USE WITH EXTREME CARE !!!
      */
     override fun apply(input: Any?): Any? {
-        return function.apply(input)
+        return try {
+            function.apply(input)
+        } catch (e: Exception) {
+            throw e.toRuntimeException()
+        } catch (t: Throwable) {
+            checkCatch(t)
+            throw t.toRuleViolationError()
+        }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
@@ -1,7 +1,6 @@
 package net.corda.djvm.execution;
 
 import net.corda.djvm.TestBase;
-import net.corda.djvm.rewiring.SandboxClassLoader;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
@@ -51,31 +50,5 @@ class BasicInputOutputTest extends TestBase {
             }
             return null;
         });
-    }
-
-    @Test
-    void testImportTask() {
-        sandbox(ctx -> {
-            try {
-                SandboxClassLoader classLoader = ctx.getClassLoader();
-                Function<? super String, ?> importTask = classLoader.createForImport(
-                    new DoMagic().andThen(classLoader.createBasicInput())
-                );
-                Object result = importTask.apply(MESSAGE);
-
-                assertEquals(new DoMagic().apply(MESSAGE), result.toString());
-                assertEquals("sandbox.java.lang.String", result.getClass().getName());
-            } catch (Exception e) {
-                fail(e);
-            }
-            return null;
-        });
-    }
-
-    public static class DoMagic implements Function<String, String> {
-        @Override
-        public String apply(String input) {
-            return String.format(">>> %s <<<", input);
-        }
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/ImportTaskJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/ImportTaskJavaTest.java
@@ -1,0 +1,122 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.rewiring.SandboxClassLoader;
+import net.corda.djvm.rules.RuleViolationError;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImportTaskJavaTest extends TestBase {
+    private static final String MESSAGE = "Hello Outside World!";
+
+    ImportTaskJavaTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testImportTask() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super String, ?> importTask = classLoader.createForImport(
+                    new DoMagic().andThen(classLoader.createBasicInput())
+                );
+                Object result = importTask.apply(MESSAGE);
+
+                assertEquals(new DoMagic().apply(MESSAGE), result.toString());
+                assertEquals("sandbox.java.lang.String", result.getClass().getName());
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class DoMagic implements Function<String, String> {
+        @Override
+        public String apply(String input) {
+            return String.format(">>> %s <<<", input);
+        }
+    }
+
+    @Test
+    void testImportFailingTask() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super String, ?> importTask = classLoader.createForImport(
+                    new Failing().andThen(classLoader.createBasicInput())
+                );
+                Throwable ex = assertThrows(RuntimeException.class, () -> importTask.apply(MESSAGE));
+                assertThat(ex)
+                    .isExactlyInstanceOf(RuntimeException.class)
+                    .hasMessage("java.lang.IllegalArgumentException -> " + MESSAGE);
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class Failing implements Function<String, String> {
+        @Override
+        public String apply(String input) {
+            throw new IllegalArgumentException(input);
+        }
+    }
+
+    @Test
+    void testImportTaskWithStackOverflow() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super String, ?> importTask = classLoader.createForImport(
+                    new StackOverflow().andThen(classLoader.createBasicInput())
+                );
+                Throwable ex = assertThrows(StackOverflowError.class, () -> importTask.apply(MESSAGE));
+                assertThat(ex).isExactlyInstanceOf(StackOverflowError.class);
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class StackOverflow implements Function<String, String> {
+        @Override
+        public String apply(String input) {
+            return new StackOverflow().apply(input);
+        }
+    }
+
+    @Test
+    void testImportTaskWithError() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super String, ?> importTask = classLoader.createForImport(
+                    new HasError().andThen(classLoader.createBasicInput())
+                );
+                Throwable ex = assertThrows(RuleViolationError.class, () -> importTask.apply(MESSAGE));
+                assertThat(ex)
+                    .isExactlyInstanceOf(RuleViolationError.class)
+                    .hasMessage("java.lang.ExceptionInInitializerError -> I am broken!");
+            } catch (Exception e) {
+                fail(e);
+            }
+            return null;
+        });
+    }
+
+    public static class HasError implements Function<String, String> {
+        @Override
+        public String apply(String input) {
+            throw new ExceptionInInitializerError("I am broken!");
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ImportTaskTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ImportTaskTest.kt
@@ -1,0 +1,74 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.fail
+import java.io.InputStream
+import java.io.NotSerializableException
+import java.util.function.Function
+
+class ImportTaskTest : TestBase(KOTLIN) {
+    companion object {
+        const val MESSAGE = "Goodbye, Cruel World!"
+    }
+
+    /**
+     * Test we can import a [java.io.InputStream] to be
+     * consumed inside the sandbox as [sandbox.java.io.InputStream].
+     */
+    @Test
+    fun `import stream from outside sandbox`() = sandbox {
+        val taskFactory = classLoader.createRawTaskFactory()
+        val readStream = classLoader.createSandboxFunction().apply(ReadInputStream::class.java)
+        val createStream = classLoader.createForImport(
+            CreateInputStream().andThen(classLoader.createBasicInput())
+        )
+        val pipelineTask = taskFactory.apply(createStream)
+            .andThen(taskFactory.apply(readStream))
+        val result = pipelineTask.apply(MESSAGE) ?: fail("Result is missing!")
+        assertEquals("sandbox.java.lang.String", result::class.java.name)
+        assertEquals(MESSAGE, result.toString())
+
+        // And check that we're handling nulls correctly too.
+        assertNull(pipelineTask.apply(null), "Pipeline does not handle null correctly.")
+    }
+
+    class CreateInputStream : Function<String?, InputStream?> {
+        override fun apply(input: String?): InputStream? {
+            return input?.byteInputStream()
+        }
+    }
+
+    class ReadInputStream : Function<InputStream?, String?> {
+        override fun apply(input: InputStream?): String? {
+            return input?.use {
+                String(it.readBytes())
+            }
+        }
+    }
+
+    @Test
+    fun `failing import from outside sandbox`() = sandbox {
+        val importTask = classLoader.createForImport(
+            ShowFailingInputStream().andThen(classLoader.createBasicInput())
+        )
+        val sandboxTask = classLoader.createRawTaskFactory().apply(importTask)
+        val ex = assertThrows<RuntimeException> { sandboxTask.apply(MESSAGE.byteInputStream()) }
+        assertThat(ex)
+            .isExactlyInstanceOf(RuntimeException::class.java)
+            .hasMessage("java.io.NotSerializableException -> Corrupt stream!")
+            .hasStackTraceContaining(ShowFailingInputStream::class.java.name)
+            .hasStackTraceContaining("sandbox.ImportTask")
+    }
+
+    class ShowFailingInputStream : Function<InputStream, String> {
+        override fun apply(input: InputStream): String {
+            throw NotSerializableException("Corrupt stream!")
+        }
+    }
+}


### PR DESCRIPTION
Fix some wrinkles with the `SandboxClassLoader.createForImport()` API:
- Make it more forgiving of Kotlin's non-nullable generic types.
- Handle exceptions thrown by an imported tasks to guarantee that sandboxed code can catch them.

Also improve test coverage for imported tasks, and fix missing `intern` for a constant String value.