### PR TITLE
CORDA-3377: Update TestBase classes to make writing Java tests more natural.

### DIFF
--- a/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
+++ b/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
@@ -24,7 +24,6 @@ class JavaSandboxTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -41,7 +40,6 @@ class JavaSandboxTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -40,7 +40,6 @@ class AnnotatedJavaClassTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -55,7 +54,6 @@ class AnnotatedJavaClassTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -74,7 +72,6 @@ class AnnotatedJavaClassTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -94,7 +91,6 @@ class AnnotatedJavaClassTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -116,7 +112,6 @@ class AnnotatedJavaClassTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/Base64Test.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/Base64Test.java
@@ -33,7 +33,6 @@ class Base64Test extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -54,7 +53,6 @@ class Base64Test extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BasicInputOutputTest.java
@@ -29,7 +29,6 @@ class BasicInputOutputTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -48,7 +47,6 @@ class BasicInputOutputTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/BitSetTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/BitSetTest.java
@@ -41,7 +41,6 @@ class BitSetTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/CapturingLambdaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/CapturingLambdaTest.java
@@ -30,7 +30,6 @@ class CapturingLambdaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/DataInputStreamTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DataInputStreamTest.java
@@ -46,7 +46,6 @@ class DataInputStreamTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/DatatypeConverterTest.java
@@ -30,7 +30,6 @@ class DatatypeConverterTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -51,7 +50,6 @@ class DatatypeConverterTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/ImportTaskJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/ImportTaskJavaTest.java
@@ -33,7 +33,6 @@ class ImportTaskJavaTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -59,7 +58,6 @@ class ImportTaskJavaTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -83,7 +81,6 @@ class ImportTaskJavaTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -109,7 +106,6 @@ class ImportTaskJavaTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JarInputStreamTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JarInputStreamTest.java
@@ -80,7 +80,6 @@ class JarInputStreamTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaChronologyTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaChronologyTest.java
@@ -34,7 +34,6 @@ class JavaChronologyTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaPackageTest.java
@@ -27,7 +27,6 @@ class JavaPackageTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -49,7 +48,6 @@ class JavaPackageTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaTimeTest.java
@@ -39,7 +39,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -61,7 +60,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -83,7 +81,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -105,7 +102,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -127,7 +123,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -149,7 +144,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -171,7 +165,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -193,7 +186,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -215,7 +207,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -237,7 +228,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -259,7 +249,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -281,7 +270,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -303,7 +291,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -318,7 +305,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -333,7 +319,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -348,7 +333,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -365,7 +349,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -384,7 +367,6 @@ class JavaTimeTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaUUIDTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaUUIDTest.java
@@ -28,7 +28,6 @@ class JavaUUIDTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -33,7 +33,6 @@ class MaliciousClassLoaderTest extends TestBase {
             } catch(Exception e){
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -76,7 +75,6 @@ class MaliciousClassLoaderTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -122,7 +120,6 @@ class MaliciousClassLoaderTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -151,7 +148,6 @@ class MaliciousClassLoaderTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassTest.java
@@ -31,7 +31,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e){
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -58,7 +57,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -85,7 +83,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -108,7 +105,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -131,7 +127,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -159,7 +154,6 @@ class MaliciousClassTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxCloneableTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxCloneableTest.java
@@ -26,7 +26,6 @@ class SandboxCloneableTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -72,7 +71,6 @@ class SandboxCloneableTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxConcurrentHashMapTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxConcurrentHashMapTest.java
@@ -30,7 +30,6 @@ class SandboxConcurrentHashMapTest extends TestBase {
             } catch(Exception e){
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -82,7 +81,6 @@ class SandboxConcurrentHashMapTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxCurrencyTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxCurrencyTest.java
@@ -29,7 +29,6 @@ class SandboxCurrencyTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxEnumJavaTest.java
@@ -31,7 +31,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -53,7 +52,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -73,7 +71,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -94,7 +91,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -117,7 +113,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -138,7 +133,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -161,7 +155,6 @@ class SandboxEnumJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxExecutorJavaTest.java
@@ -35,7 +35,6 @@ class SandboxExecutorJavaTest extends TestBase {
             } catch (Throwable t) {
                 fail(t);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectHashCodeJavaTest.java
@@ -28,7 +28,6 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -42,7 +41,6 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -59,7 +57,6 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -73,7 +70,6 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -87,7 +83,6 @@ class SandboxObjectHashCodeJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxStrictMathTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxStrictMathTest.java
@@ -34,7 +34,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -63,7 +62,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -93,7 +91,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -119,7 +116,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -150,7 +146,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -178,7 +173,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -213,7 +207,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -242,7 +235,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -267,7 +259,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -295,7 +286,6 @@ class SandboxStrictMathTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxStringTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxStringTest.java
@@ -41,7 +41,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -63,7 +62,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -84,7 +82,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -115,7 +112,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
    }
 
@@ -141,7 +137,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -172,7 +167,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -194,7 +188,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -216,7 +209,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -240,7 +232,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -262,7 +253,6 @@ class SandboxStringTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxThrowableJavaTest.java
@@ -36,7 +36,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -58,7 +57,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -109,7 +107,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -135,7 +132,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -158,7 +154,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -182,7 +177,6 @@ class SandboxThrowableJavaTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SecurityManagerTest.java
@@ -29,7 +29,6 @@ class SecurityManagerTest extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/X500Tests.java
@@ -29,7 +29,6 @@ class X500Tests extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -52,7 +51,6 @@ class X500Tests extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 
@@ -73,7 +71,6 @@ class X500Tests extends TestBase {
             } catch(Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 

--- a/djvm/src/test/java/net/corda/djvm/rewiring/StitchedInterfaceTest.java
+++ b/djvm/src/test/java/net/corda/djvm/rewiring/StitchedInterfaceTest.java
@@ -37,7 +37,6 @@ class StitchedInterfaceTest extends TestBase {
             } catch (Exception e) {
                 fail(e);
             }
-            return null;
         });
     }
 }


### PR DESCRIPTION
We shouldn't need to terminate every `SandboxRuntimeContext` lambda with
```java
return null;
```
when writing tests in Java.