### PR TITLE
CORDA-3536: Add support for exposing Predicate<?> tasks.

### DIFF
--- a/djvm/src/main/java/sandbox/java/util/function/Predicate.java
+++ b/djvm/src/main/java/sandbox/java/util/function/Predicate.java
@@ -1,0 +1,10 @@
+package sandbox.java.util.function;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.util.function.Predicate}
+ * to allow us to compile {@link sandbox.PredicateTask}.
+ */
+@FunctionalInterface
+public interface Predicate<T> {
+    boolean test(T obj);
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -252,6 +252,7 @@ class AnalysisConfiguration private constructor(
             "sandbox/BasicInput",
             "sandbox/BasicOutput",
             "sandbox/ImportTask",
+            "sandbox/PredicateTask",
             "sandbox/RawTask",
             "sandbox/Task",
             "sandbox/TaskTypes",

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/Predicates.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/Predicates.kt
@@ -1,0 +1,56 @@
+@file:JvmName("Predicates")
+package net.corda.djvm.rewiring
+
+import net.corda.djvm.execution.SandboxRuntimeException
+import java.lang.reflect.Constructor
+import java.lang.reflect.InvocationTargetException
+import java.util.function.Function
+import java.util.function.Predicate
+
+/**
+ * Returns an instance of [Function] that can wrap an
+ * instance of [sandbox.java.util.function.Predicate].
+ * The predicate's input is not marshalled.
+ */
+@Throws(
+    ClassNotFoundException::class,
+    NoSuchMethodException::class
+)
+fun SandboxClassLoader.createRawPredicateFactory(): Function<in Any, out Predicate<in Any?>> {
+    val taskClass = loadClass("sandbox.PredicateTask")
+    @Suppress("unchecked_cast")
+    val constructor = taskClass.getDeclaredConstructor(loadClass("sandbox.java.util.function.Predicate"))
+            as Constructor<out Predicate<in Any?>>
+    return Function { userPredicate ->
+        try {
+            constructor.newInstance(userPredicate)
+        } catch (ex: Throwable) {
+            val target = (ex as? InvocationTargetException)?.targetException ?: ex
+            throw when (target) {
+                is RuntimeException, is Error -> target
+                else -> SandboxRuntimeException(target.message, target)
+            }
+        }
+    }
+}
+
+/**
+ * Factory to create a [Function] that will execute a sandboxed
+ * instance of a task, where this task implements [Predicate].
+ * This is just a convenience function which assumes that the
+ * task has a no-argument constructor, but is still likely to be
+ * what you want.
+ */
+fun SandboxClassLoader.createSandboxPredicate(): Function<Class<out Predicate<*>>, out Any> {
+    return Function { predicateClass ->
+        try {
+            toSandboxClass(predicateClass).getDeclaredConstructor().newInstance()
+        } catch (ex: Throwable) {
+            val target = (ex as? InvocationTargetException)?.targetException ?: ex
+            throw when (target) {
+                is RuntimeException, is Error -> target
+                else -> SandboxRuntimeException(target.message, target)
+            }
+        }
+    }
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/EmptyEnum.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/EmptyEnum.java
@@ -1,0 +1,5 @@
+package net.corda.djvm.execution;
+
+public enum EmptyEnum {
+    // Nothing to see here!
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaSandboxPredicateTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaSandboxPredicateTest.java
@@ -1,0 +1,51 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.rewiring.Predicates;
+import net.corda.djvm.rewiring.SandboxClassLoader;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JavaSandboxPredicateTest extends TestBase {
+    JavaSandboxPredicateTest() {
+        super(JAVA);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ExampleEnum.class)
+    void testPredicate(ExampleEnum example) {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<Class<? extends Predicate<?>>, ?> sandboxPredicate = Predicates.createSandboxPredicate(classLoader);
+                Function<Class<? extends Predicate<?>>, ? extends Predicate<? super Object>> predicateFactory
+                    = Predicates.createRawPredicateFactory(classLoader).compose(sandboxPredicate);
+                Predicate<? super Object> isSandboxEnum = predicateFactory.apply(CheckEnum.class);
+                Object sandboxEnum = classLoader.createBasicInput().apply(example);
+
+                assertNotNull(sandboxEnum, "sandboxed enum should not be null");
+                assertTrue(isSandboxEnum.test(sandboxEnum.getClass()), sandboxEnum + " should be sandbox.Enum");
+                assertFalse(isSandboxEnum.test(example.getClass()), example + " should not be sandbox.Enum");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    public static class CheckEnum implements Predicate<Class<?>> {
+        @Override
+        public boolean test(@NotNull Class<?> clazz) {
+            return clazz.isEnum();
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -623,6 +623,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
         "java.util.concurrent.atomic.DJVM",
         "java.util.concurrent.locks.DJVMConditionObject",
         "javax.security.auth.x500.DJVM",
+        "PredicateTask",
         "RawTask",
         "RuntimeCostAccounter",
         "TaskTypes",

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxPredicateTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxPredicateTest.kt
@@ -1,0 +1,44 @@
+package net.corda.djvm.execution
+
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import net.corda.djvm.rewiring.createRawPredicateFactory
+import net.corda.djvm.rewiring.createSandboxPredicate
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.function.Predicate
+
+class SandboxPredicateTest : TestBase(KOTLIN) {
+    @ParameterizedTest
+    @EnumSource(ExampleEnum::class)
+    fun testPredicate(example: ExampleEnum) = sandbox {
+        val sandboxPredicate = classLoader.createSandboxPredicate()
+        val predicateFactory = classLoader.createRawPredicateFactory().compose(sandboxPredicate)
+        val isSandboxEnum = predicateFactory.apply(CheckEnum::class.java)
+        val sandboxEnum = classLoader.createBasicInput().apply(example)
+                ?: fail("sandboxed enum should not be null")
+
+        assertTrue(isSandboxEnum.test(sandboxEnum::class.java))
+        assertFalse(isSandboxEnum.test(example::class.java))
+    }
+
+    @Test
+    fun testEmptyEnum() = sandbox {
+        val sandboxPredicate = classLoader.createSandboxPredicate()
+        val predicateFactory = classLoader.createRawPredicateFactory().compose(sandboxPredicate)
+        val isSandboxEnum = predicateFactory.apply(CheckEnum::class.java)
+        val sandboxEnumClass = classLoader.toSandboxClass(EmptyEnum::class.java)
+        assertTrue(isSandboxEnum.test(sandboxEnumClass))
+        assertFalse(isSandboxEnum.test(EmptyEnum::class.java))
+    }
+
+    class CheckEnum : Predicate<Class<*>> {
+        override fun test(clazz: Class<*>): Boolean {
+            return clazz.isEnum
+        }
+    }
+}


### PR DESCRIPTION
While `java.util.function.Function<T,R>` is fine for passing objects into and out of the sandbox, it is not ideal for handling primitive Java types such as `boolean`, `int` or `long` which require no marshalling at all.

Create a new task for executing `Predicate<T>` functions without using reflection.