### PR TITLE
CORDA-3377: Annotate interfaces as @FunctionalInterface.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/DJVMException.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMException.java
@@ -4,6 +4,7 @@ package sandbox.java.lang;
  * All synthetic {@link java.lang.Throwable} classes wrapping non-JVM exceptions
  * will implement this interface.
  */
+@FunctionalInterface
 public interface DJVMException {
     /**
      * Returns the {@link sandbox.java.lang.Throwable} instance inside the wrapper.

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/Rule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/Rule.kt
@@ -8,6 +8,7 @@ import net.corda.djvm.validation.RuleContext
 /**
  * Representation of a rule.
  */
+@FunctionalInterface
 interface Rule {
 
     /**

--- a/djvm/src/test/java/net/corda/djvm/Action.java
+++ b/djvm/src/test/java/net/corda/djvm/Action.java
@@ -1,5 +1,6 @@
 package net.corda.djvm;
 
+@FunctionalInterface
 public interface Action<T, R> {
     T action(R input);
 }

--- a/djvm/src/test/kotlin/foo/bar/sandbox/Callable.kt
+++ b/djvm/src/test/kotlin/foo/bar/sandbox/Callable.kt
@@ -3,6 +3,7 @@ package foo.bar.sandbox
 /**
  * Interface used for implementing test classes.
  */
+@FunctionalInterface
 interface Callable {
 
     /**

--- a/djvm/src/test/kotlin/sandbox/greymalkin/StringReturner.kt
+++ b/djvm/src/test/kotlin/sandbox/greymalkin/StringReturner.kt
@@ -1,6 +1,7 @@
 package sandbox.greymalkin
 
 // Simple hack for now, generalise to lambdas later...
+@FunctionalInterface
 interface StringReturner {
 
     fun addEntry(): String


### PR DESCRIPTION
Add the `@FunctionalInterface` annotation to appropriate interfaces, mainly for documentation purposes.