### PR TITLE
CORDA-3377: Preserve the `@FunctionalInterface` annotation because it is safe.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -184,6 +184,7 @@ class AnalysisConfiguration private constructor(
          * annotation and the transformed one.
          */
         private val STITCHED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
+            "Lsandbox/java/lang/FunctionalInterface;",
             "Lsandbox/kotlin/Metadata;"
         ))
 
@@ -192,6 +193,7 @@ class AnalysisConfiguration private constructor(
          * "safe" to preserve inside the sandbox.
          */
         private val ALLOWED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
+            "Ljava/lang/FunctionalInterface;",
             KOTLIN_METADATA
         ))
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
@@ -83,9 +83,9 @@ class SandboxClassRemapper(
     }
 
     /**
-     * Do not attempt to remap references to methods and fields on templated classes.
-     * For example, the methods on [sandbox.RuntimeCostAccounter] really DO use
-     * [java.lang.String] rather than [sandbox.java.lang.String].
+     * Do not attempt to remap references to methods and fields on template classes.
+     * For example, [sandbox.recordAllocation] and [sandbox.recordArrayAllocation]
+     * really DO use [java.lang.String] rather than [sandbox.java.lang.String].
      */
     private inner class MethodRemapperWithTemplating(private val nonMethodMapper: MethodVisitor, remapper: MethodVisitor)
         : MethodVisitor(API_VERSION, remapper) {

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -123,6 +123,25 @@ class AnnotatedJavaClassTest extends TestBase {
         }
     }
 
+    @Test
+    void testFunctionalInterfaceIsPreserved() {
+        sandbox(ctx -> {
+            try {
+                Class<?> sandboxFunction = ctx.getClassLoader().toSandboxClass(Function.class);
+                Annotation[] sandboxAnnotations = sandboxFunction.getAnnotations();
+                List<String> names = Arrays.stream(sandboxAnnotations)
+                    .map(ann -> ann.annotationType().getName())
+                    .collect(toList());
+                assertThat(names).containsExactlyInAnyOrder(
+                    "sandbox.java.lang.FunctionalInterface",
+                    "java.lang.FunctionalInterface"
+                );
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
     @SuppressWarnings("WeakerAccess")
     @JavaAnnotation("Hello Java!")
     static class UserJavaData {}


### PR DESCRIPTION
The `java.lang.FnctionalInterface` annotation has no methods and is therefore "safe". It also has "runtime" visibility and so should be discoverable. Therefore preserve this annotation inside the sandbox. Preserve the original annotation too in order to maintain the contract with the Java language. 