### PR TITLE
CORDA-3377: Preserve basic Java and Kotlin annotations inside the sandbox.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -184,7 +184,8 @@ class AnalysisConfiguration private constructor(
          * annotation and the transformed one.
          */
         private val STITCHED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
-            "Lsandbox/java/lang/FunctionalInterface;",
+            "Lsandbox/kotlin/annotation/MustBeDocumented;",
+            "Lsandbox/kotlin/annotation/Repeatable;",
             "Lsandbox/kotlin/Metadata;"
         ))
 
@@ -194,6 +195,11 @@ class AnalysisConfiguration private constructor(
          */
         private val ALLOWED_ANNOTATIONS: Set<String> = unmodifiable(setOf(
             "Ljava/lang/FunctionalInterface;",
+            "Ljava/lang/annotation/Documented;",
+            "Ljava/lang/annotation/Inherited;",
+            "Ljava/lang/annotation/Repeatable;",
+            "Lkotlin/annotation/MustBeDocumented;",
+            "Lkotlin/annotation/Repeatable;",
             KOTLIN_METADATA
         ))
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
@@ -103,6 +103,7 @@ open class Whitelist private constructor(
             "^java/lang/Class(\\..*)?\$".toRegex(),
             "^java/lang/ClassLoader(\\..*)?\$".toRegex(),
             "^java/lang/Cloneable\$".toRegex(),
+            "^java/lang/FunctionalInterface\$".toRegex(),
             "^java/lang/Object(\\..*)?\$".toRegex(),
             "^java/lang/StrictMath\\.(?!random:).*\$".toRegex(),
             "^java/lang/Void\$".toRegex(),

--- a/djvm/src/test/java/net/corda/djvm/JavaAnnotation.java
+++ b/djvm/src/test/java/net/corda/djvm/JavaAnnotation.java
@@ -1,5 +1,7 @@
 package net.corda.djvm;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -8,6 +10,8 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 @Retention(RUNTIME)
 @Target(TYPE)
+@Documented
+@Inherited
 public @interface JavaAnnotation {
     String value() default "<default-value>";
 }

--- a/djvm/src/test/java/net/corda/djvm/JavaLabel.java
+++ b/djvm/src/test/java/net/corda/djvm/JavaLabel.java
@@ -1,0 +1,14 @@
+package net.corda.djvm;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+@Repeatable(JavaLabels.class)
+public @interface JavaLabel {
+    String name();
+}

--- a/djvm/src/test/java/net/corda/djvm/JavaLabels.java
+++ b/djvm/src/test/java/net/corda/djvm/JavaLabels.java
@@ -1,0 +1,15 @@
+package net.corda.djvm;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+public @interface JavaLabels {
+    JavaLabel[] value();
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/KotlinLabel.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/KotlinLabel.kt
@@ -1,13 +1,10 @@
 package net.corda.djvm
 
-import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 
 @Retention(RUNTIME)
 @Target(CLASS)
 @MustBeDocumented
-@Inherited
-annotation class KotlinAnnotation(
-    val value: String = "<default-value>"
-)
+@Repeatable
+annotation class KotlinLabel(val name: String)

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/WhitelistTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/WhitelistTest.kt
@@ -74,6 +74,7 @@ class WhitelistTest : TestBase(KOTLIN) {
     @Test
     fun `test Java annotations`() {
         val whitelist = Whitelist.MINIMAL
+        assertThat(whitelist.matches("java/lang/FunctionalInterface")).isTrue()
         assertThat(whitelist.matches("java/lang/annotation/Annotation")).isTrue()
         assertThat(whitelist.matches("java/lang/annotation/Documented")).isTrue()
         assertThat(whitelist.matches("java/lang/annotation/ElementType")).isFalse()


### PR DESCRIPTION
Kotlin reflection and Corda need to be able to examine the annotations on sandbox classes, which means that the unsandboxed values of _some_ annotations need to be preserved. We have also
whitelisted Java's `@Repeatable` annotation, which means that we _do_ need to be able to "stitch back" the unsandboxed values of annotations that have annotation-typed parameters.

The plan here is:
- Whitelist safe (i.e. ones without `Enum` fields) fundamental Java 8 annotations, and preserve them on sandboxed classes.
- Preserve safe fundamental Kotlin annotations by stitching the unsandboxed values underneath the sandboxed ones. Note that we _never_ whitelist Kotlin classes - see `SandboxClassRemapper.visitAnnotation()`, which updates the data in the`@kotlin.Metadata` annotations by just transforming its string table and _not_ recreating the protobuf that refers to it.

Note that we cannot read annotations from within the sandbox yet. Doing this is _**extremely**_ non-trivial!