### PR TITLE
Small fixes before releasing 1.0

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisContext.kt
@@ -44,7 +44,7 @@ class AnalysisContext private constructor(
             return AnalysisContext(
                     MessageCollection(configuration.minimumSeverityLevel, configuration.prefixFilters),
                     ClassHierarchy(configuration.classModule, configuration.memberModule),
-                    ReferenceMap(configuration.classModule)
+                    ReferenceMap()
             )
         }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/references/ReferenceMap.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/ReferenceMap.kt
@@ -6,9 +6,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 /**
  * Map from member references to all discovered call-sites / field accesses for each reference.
  */
-class ReferenceMap(
-        private val classModule: ClassModule
-) : Iterable<EntityReference> {
+class ReferenceMap : Iterable<EntityReference> {
 
     private val queueOfReferences = ConcurrentLinkedQueue<EntityReference>()
 

--- a/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/source/SourceClassLoader.kt
@@ -337,7 +337,9 @@ private fun resolvePaths(paths: List<Path>): Array<URL> {
         when {
             !Files.exists(it) -> throw FileNotFoundException("File not found; $it")
             Files.isDirectory(it) -> {
-                listOf(it.toURL()) + Files.list(it).filter(::isJarFile).map { jar -> jar.toURL() }.toList()
+                listOf(it.toURL()) + Files.list(it).use { files ->
+                    files.filter(::isJarFile).map(Path::toURL).toList()
+                }
             }
             Files.isReadable(it) && isJarFile(it) -> listOf(it.toURL())
             else -> throw IllegalArgumentException("Expected JAR or class file, but found $it")
@@ -353,9 +355,9 @@ private fun expandPath(path: Path): Path {
     return path
 }
 
-private fun isJarFile(path: Path) = path.toString().endsWith(".jar", true)
+private fun isJarFile(path: Path): Boolean = path.toString().endsWith(".jar", true)
 
-private fun Path.toURL(): URL = this.toUri().toURL()
+private fun Path.toURL(): URL = toUri().toURL()
 
 private val homeDirectory: Path
     get() = Paths.get(System.getProperty("user.home"))

--- a/djvm/src/test/kotlin/net/corda/djvm/ExceptionWithoutSyntheticCounterpartTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/ExceptionWithoutSyntheticCounterpartTest.kt
@@ -1,0 +1,35 @@
+package net.corda.djvm
+
+import net.corda.djvm.SandboxType.KOTLIN
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Check that the DJVM does not create synthetic throwable
+ * counterparts for these exceptions, because we're going
+ * to use the JVM's own [Throwable] classes here.
+ *
+ * This list is representative rather than exhaustive.
+ */
+class ExceptionWithoutSyntheticCounterpartTest : TestBase(KOTLIN) {
+    @ParameterizedTest
+    @ValueSource(strings = [
+        "sandbox.java.lang.Throwable",
+        "sandbox.java.lang.Exception",
+        "sandbox.java.lang.RuntimeException",
+        "sandbox.java.lang.Error",
+        "sandbox.java.lang.LinkageError",
+        "sandbox.java.lang.ThreadDeath",
+        "sandbox.java.lang.VirtualMachineError",
+        "sandbox.java.lang.DJVMThrowableWrapper"
+    ])
+    fun testNoSyntheticExceptionForJVM(exceptionName: String) = sandbox {
+        val syntheticName = "$exceptionName\$1DJVM"
+        val ex = assertThrows<ClassNotFoundException> { classLoader.loadClass(syntheticName) }
+        assertThat(ex).hasMessageContaining(syntheticName)
+        assertDoesNotThrow { classLoader.loadClass(exceptionName) }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/SyntheticExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/SyntheticExceptionTest.kt
@@ -1,0 +1,28 @@
+package net.corda.djvm
+
+import net.corda.djvm.SandboxType.KOTLIN
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Check that synthetic throwable classes are created in the
+ * same [ClassLoader] as their [sandbox.java.lang.Throwable]
+ * counterparts.
+ */
+class SyntheticExceptionTest : TestBase(KOTLIN) {
+    @Test
+    fun testSyntheticJavaExceptionIsCreatedInCorrectClassLoader() = sandbox {
+        val syntheticClass = classLoader.loadClass("sandbox.java.security.NoSuchAlgorithmException\$1DJVM")
+        val exceptionClass = classLoader.loadClass("sandbox.java.security.NoSuchAlgorithmException")
+        assertThat(syntheticClass.classLoader).isSameAs(exceptionClass.classLoader)
+        assertThat(syntheticClass.classLoader).isNotSameAs(classLoader)
+    }
+
+    @Test
+    fun testSyntheticUserExceptionIsCreatedInCorrectClassLoader() = sandbox {
+        val syntheticClass = classLoader.loadClass("sandbox.net.corda.djvm.execution.MyExampleException\$1DJVM")
+        val exceptionClass = classLoader.loadClass("sandbox.net.corda.djvm.execution.MyExampleException")
+        assertThat(syntheticClass.classLoader).isSameAs(exceptionClass.classLoader)
+        assertThat(syntheticClass.classLoader).isSameAs(classLoader)
+    }
+}


### PR DESCRIPTION
- Fix a directory descriptor leak in SourceClassLoader.
- Simplify how SandboxClassLoader resolves new classes.
- Remove an unused constructor parameter from ReferenceMap.
- Add some more test cases for loading Throwable classes.