### PR TITLE
CORDA-3377: Extend test coverage for synthetic exception classes.

### DIFF
--- a/djvm/src/test/kotlin/net/corda/djvm/ExceptionWithoutSyntheticCounterpartTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/ExceptionWithoutSyntheticCounterpartTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource
  * This list is representative rather than exhaustive.
  */
 class ExceptionWithoutSyntheticCounterpartTest : TestBase(KOTLIN) {
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] => {0}")
     @ValueSource(strings = [
         "sandbox.java.lang.Throwable",
         "sandbox.java.lang.Exception",
@@ -30,6 +30,9 @@ class ExceptionWithoutSyntheticCounterpartTest : TestBase(KOTLIN) {
         val syntheticName = "$exceptionName\$1DJVM"
         val ex = assertThrows<ClassNotFoundException> { classLoader.loadClass(syntheticName) }
         assertThat(ex).hasMessageContaining(syntheticName)
+        assertDoesNotThrow { classLoader.loadClass(exceptionName) }
+
+        // Check we can reload this class, to prove it has already been loaded correctly!
         assertDoesNotThrow { classLoader.loadClass(exceptionName) }
     }
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/SyntheticExceptionCachingTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/SyntheticExceptionCachingTest.kt
@@ -1,0 +1,50 @@
+package net.corda.djvm
+
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.rewiring.ByteCode
+import net.corda.djvm.rewiring.ByteCodeKey
+import net.corda.djvm.rewiring.SandboxClassLoader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.ConcurrentHashMap
+
+class SyntheticExceptionCachingTest : TestBase(KOTLIN) {
+    @ParameterizedTest(name = "[{index}] = {0}")
+    @ValueSource(strings = [
+        "sandbox.java.security.NoSuchAlgorithmException",
+        "sandbox.net.corda.djvm.execution.MyExampleException"
+    ])
+    fun testSyntheticExceptionIsRecreatedWithExternalCache(exceptionName: String) {
+        val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
+        val syntheticClassName = "$exceptionName\$1DJVM"
+
+        sandbox(externalCache) {
+            assertThat(classLoader.parent).isInstanceOf(SandboxClassLoader::class.java)
+            classLoader.loadClass(syntheticClassName)
+        }
+
+        // Check that the bytecode has also been cached correctly.
+        // The synthetic exception class is cheap to create and so is not cached.
+        val classNames = externalCache.keys.mapTo(LinkedHashSet(), ByteCodeKey::className)
+        assertThat(classNames)
+            .doesNotContain(syntheticClassName)
+            .contains(exceptionName)
+
+        sandbox(externalCache) {
+            assertThat(classLoader.parent).isInstanceOf(SandboxClassLoader::class.java)
+
+            // Empty this configuration's internal cache, which
+            // will force us to consult the external cache.
+            flushInternalCache()
+
+            assertDoesNotThrow { classLoader.loadClass(syntheticClassName) }
+            assertDoesNotThrow { classLoader.loadClass(exceptionName) }
+
+            // Check we can reload these classes, to prove they were loaded correctly!
+            assertDoesNotThrow { classLoader.loadClass(syntheticClassName) }
+            assertDoesNotThrow { classLoader.loadClass(exceptionName) }
+        }
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -20,7 +20,7 @@ import net.corda.djvm.messages.Severity.WARNING
 import net.corda.djvm.references.ClassHierarchy
 import net.corda.djvm.rewiring.ExternalCache
 import net.corda.djvm.rewiring.LoadedClass
-import net.corda.djvm.rewiring.flush
+import net.corda.djvm.rewiring.flushAll
 import net.corda.djvm.rules.Rule
 import net.corda.djvm.source.BootstrapClassLoader
 import net.corda.djvm.source.ClassSource
@@ -125,8 +125,8 @@ abstract class TestBase(type: SandboxType) {
         userSource.close()
     }
 
-    fun flushParentCache() {
-        parentConfiguration.byteCodeCache.flush()
+    fun flushInternalCache() {
+        parentConfiguration.byteCodeCache.flushAll()
     }
 
     /**

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ExternalByteCodeCacheTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ExternalByteCodeCacheTest.kt
@@ -18,7 +18,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
     fun testSubsequentSandboxesWithCaching() {
         // Ensure that the shared parent configuration's internal
         // cache does not already contain the Function class.
-        flushParentCache()
+        flushInternalCache()
 
         val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
         sandbox(externalCache) {
@@ -83,7 +83,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
     fun testInternalCacheTakesPrecedenceOverExternalCache() {
         // Ensure that the shared parent configuration's internal
         // cache does not already contain the Function class.
-        flushParentCache()
+        flushInternalCache()
 
         val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
         sandbox(externalCache) {

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheAccess.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheAccess.kt
@@ -5,3 +5,11 @@ package net.corda.djvm.rewiring
  * Expose this function for testing only.
  */
 fun ByteCodeCache.flush() = clear()
+
+fun ByteCodeCache.flushAll() {
+    var cache = this
+    do {
+        cache.flush()
+        cache = cache.parent ?: break
+    } while (true)
+}


### PR DESCRIPTION
Extend test coverage to ensure that `Throwable` wrapper classes are cached correctly.

We don't add synthetic `Throwable` wrapper classes to the external cache because they are small and cheap to create. Make this behaviour clear in the unit tests too.
