### PR TITLE
CORDA-3642: Reduce memory footprint of external byte-code cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ package net.corda.djvm.source;
 public interface Source extends AutoCloseable {
     URL findResource(String name);
     Enumeration<URL> findResources(String name);
-}
-
-public interface UserSource extends Source {
     URL[] getURLs();
 }
+
+public interface UserSource extends Source {}
 ```
 
 This will most likely be a descendant of `URLClassLoader` such as the DJVM's `UserPathSource` class:

--- a/djvm/src/main/kotlin/net/corda/djvm/utilities/Logging.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/utilities/Logging.kt
@@ -7,5 +7,6 @@ import org.slf4j.LoggerFactory
 /**
  * Get logger for provided class [T].
  */
-inline fun <reified T : Any> loggerFor(): Logger =
-        LoggerFactory.getLogger(T::class.java)
+internal inline fun <reified T : Any> loggerFor(): Logger {
+    return LoggerFactory.getLogger(T::class.java)
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ExternalByteCodeCacheTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ExternalByteCodeCacheTest.kt
@@ -6,10 +6,15 @@ import net.corda.djvm.rewiring.ByteCode
 import net.corda.djvm.rewiring.ByteCodeKey
 import net.corda.djvm.rewiring.SandboxClassLoader
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import sandbox.SandboxFunction
+import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Function
 
@@ -30,7 +35,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         sandbox(externalCache) {
             assertTrue((classLoader.parent as SandboxClassLoader).externalCaching)
             assertTrue(classLoader.externalCaching)
-            classLoader.loadForSandbox(ExternalTask::class.java.name)
+            classLoader.toSandboxClass(ExternalTask::class.java.name)
         }
 
         val keyNames = externalCache.keys.mapTo(ArrayList(), ByteCodeKey::className)
@@ -52,7 +57,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         sandbox(externalCache) {
             (classLoader.parent as SandboxClassLoader).externalCaching = false
             classLoader.externalCaching = false
-            classLoader.loadForSandbox(ExternalTask::class.java.name)
+            classLoader.toSandboxClass(ExternalTask::class.java)
         }
         assertThat(externalCache).isEmpty()
     }
@@ -62,7 +67,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
         sandbox(externalCache) {
             (classLoader.parent as SandboxClassLoader).externalCaching = false
-            classLoader.loadForSandbox(ExternalTask::class.java.name)
+            classLoader.toSandboxClass(ExternalTask::class.java)
         }
         assertThat(externalCache).hasSize(1)
 
@@ -71,9 +76,9 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         externalCache[key] = ByteCode(byteArrayOf(), false)
 
         // We cannot create a class without any byte-code!
-        val ex = assertThrows<ClassFormatError>() {
+        val ex = assertThrows<ClassFormatError> {
             sandbox(externalCache) {
-                classLoader.loadForSandbox(ExternalTask::class.java.name)
+                classLoader.toSandboxClass(ExternalTask::class.java)
             }
         }
         assertThat(ex).hasMessage("Truncated class file")
@@ -87,7 +92,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
 
         val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
         sandbox(externalCache) {
-            classLoader.loadForSandbox(Function::class.java.name)
+            classLoader.toSandboxClass(Function::class.java)
         }
         assertThat(externalCache).hasSize(1)
 
@@ -96,7 +101,7 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         externalCache[key] = ByteCode(byteArrayOf(), false)
 
         sandbox(externalCache) {
-            classLoader.loadForSandbox(ExternalTask::class.java.name)
+            classLoader.toSandboxClass(ExternalTask::class.java)
         }
         assertThat(externalCache).hasSize(2)
     }
@@ -105,5 +110,62 @@ class ExternalByteCodeCacheTest : TestBase(KOTLIN) {
         override fun apply(input: String): String {
             return input
         }
+    }
+
+    @Test
+    fun testExternalCacheKeysHaveValidLocations() {
+        // Empty the shared parent configuration's internal cache.
+        flushInternalCache()
+
+        val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
+        sandbox(externalCache) {
+            classLoader.toSandboxClass(ExternalTask::class.java)
+            classLoader.toSandboxClass(ExampleEnum::class.java)
+            classLoader.toSandboxClass(MyExampleException::class.java)
+        }
+
+        val cacheKeys = externalCache.keys
+        assertAll(cacheKeys.map { key -> {
+            val url = assertDoesNotThrow { URL(key.source) }
+            assertEquals("file", url.protocol)
+            assertTrue(url.path.endsWith('/') || url.path.endsWith(".jar"),
+                "Invalid path: '${url.path}'")
+        }})
+    }
+
+    @Test
+    fun testExternalCacheIsCorrectlyFormed() {
+        val externalCache = ConcurrentHashMap<ByteCodeKey, ByteCode>()
+
+        flushInternalCache()
+        sandbox(externalCache) {
+            classLoader.toSandboxClass(Function::class.java)
+        }
+
+        flushInternalCache()
+        sandbox(externalCache) {
+            classLoader.toSandboxClass(ExternalTask::class.java)
+        }
+
+        flushInternalCache()
+        sandbox(externalCache) {
+            classLoader.toSandboxClass(ExampleEnum::class.java)
+        }
+
+        flushInternalCache()
+        sandbox(externalCache) {
+            classLoader.toSandboxClass(MyExampleException::class.java)
+        }
+
+        assertThat(externalCache)
+            .hasSizeGreaterThanOrEqualTo(4)
+
+        val sourceLocations = mutableMapOf<String, String>()
+        assertAll(externalCache.map { entry -> {
+            val location = entry.key.source.let { source ->
+                sourceLocations.putIfAbsent(source, source) ?: source
+            }
+            assertSame(entry.key.source, location)
+        }})
     }
 }


### PR DESCRIPTION
Use `String.intern()` on `URL.toString()` values when creating `ByteCodeKey` objects. This will ensure that the keys will use exactly one instance of `String` per unique URL value.