### PR TITLE
CORDA-3649: Improve marshalling of some exceptions out of the sandbox.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/ExceptionInInitializerError.java
+++ b/djvm/src/main/java/sandbox/java/lang/ExceptionInInitializerError.java
@@ -4,5 +4,25 @@ package sandbox.java.lang;
  * This is a dummy class that implements just enough of {@link java.lang.ExceptionInInitializerError}
  * to allow us to compile {@link sandbox.java.lang.DJVM}.
  */
+@SuppressWarnings("unused")
 public class ExceptionInInitializerError extends Throwable {
+    private final Throwable exception;
+
+    public ExceptionInInitializerError(Throwable t) {
+        super((Throwable) null);
+        exception = t;
+    }
+
+    public ExceptionInInitializerError(String message) {
+        super(message);
+        exception = null;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public Throwable getCause() {
+        return exception;
+    }
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/JVMExceptionTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/JVMExceptionTest.kt
@@ -1,0 +1,96 @@
+package net.corda.djvm
+
+import net.corda.djvm.SandboxType.KOTLIN
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.reflect.InvocationTargetException
+import java.util.function.Function
+
+/**
+ * Check that exception types thrown by the JVM itself
+ * are marshalled correctly out of the sandbox.
+ */
+class JVMExceptionTest : TestBase(KOTLIN) {
+    companion object {
+        const val MESSAGE = "Hello World!"
+        const val OTHER = "Boo!"
+    }
+
+    @Test
+    fun testInvocationTargetException() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val throwMeTask = taskFactory.create(ThrowMeTask::class.java)
+        val ex = assertThrows<InvocationTargetException> {
+            throwMeTask.apply(InvocationTargetException(MyCustomException(OTHER), MESSAGE))
+        }
+        assertThat(ex)
+            .hasCauseExactlyInstanceOf(Exception::class.java)
+            .hasMessage(MESSAGE)
+        assertThat(ex.cause)
+            .hasMessage("sandbox.net.corda.djvm.MyCustomException -> Boo!")
+            .hasNoCause()
+    }
+
+    @Test
+    fun testExceptionInInitializerErrorWithThrowable() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val throwMeTask = taskFactory.create(ThrowMeTask::class.java)
+        val ex = assertThrows<ExceptionInInitializerError> {
+            throwMeTask.apply(ExceptionInInitializerError(MyCustomException(MESSAGE)))
+        }
+        assertThat(ex)
+            .hasCauseExactlyInstanceOf(Exception::class.java)
+            .hasMessage(null)
+        assertThat(ex.cause)
+            .hasMessage("sandbox.net.corda.djvm.MyCustomException -> Hello World!")
+            .hasNoCause()
+    }
+
+    @Test
+    fun testExceptionInInitializerErrorWithMessage() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val throwMeTask = taskFactory.create(ThrowMeTask::class.java)
+        val ex = assertThrows<ExceptionInInitializerError> {
+            throwMeTask.apply(ExceptionInInitializerError(MESSAGE))
+        }
+        assertThat(ex)
+            .hasMessage(MESSAGE)
+            .hasNoCause()
+    }
+
+    @Test
+    fun testNoSuchMethodException() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val throwMeTask = taskFactory.create(ThrowMeTask::class.java)
+        val ex = assertThrows<NoSuchMethodException> {
+            throwMeTask.apply(NoSuchMethodException(MESSAGE))
+        }
+        assertThat(ex)
+            .hasMessage(MESSAGE)
+            .hasNoCause()
+    }
+
+    @Test
+    fun testClassNotFoundException() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val throwMeTask = taskFactory.create(ThrowMeTask::class.java)
+        val ex = assertThrows<ClassNotFoundException> {
+            throwMeTask.apply(ClassNotFoundException(MESSAGE, MyCustomException(OTHER)))
+        }
+        assertThat(ex)
+            .hasCauseExactlyInstanceOf(Exception::class.java)
+            .hasMessage(MESSAGE)
+        assertThat(ex.cause)
+            .hasMessage("sandbox.net.corda.djvm.MyCustomException -> Boo!")
+            .hasNoCause()
+    }
+
+    class ThrowMeTask : Function<Throwable, String> {
+        override fun apply(t: Throwable): String {
+            throw t
+        }
+    }
+}
+
+class MyCustomException(message: String) : Exception(message)


### PR DESCRIPTION
Ensure that `InvocationTargetException`, `ExceptionInInitializerError` and `ClassNotFoundException` can be marshalled out of the sandbox when explicitly thrown. They are usually thrown by the JVM itself, but there's nothing to stop users doing it too.