### PR TITLE
Lock down the DJVM internal classes.

### DIFF
--- a/djvm/src/main/java/sandbox/java/io/DJVMInputStream.java
+++ b/djvm/src/main/java/sandbox/java/io/DJVMInputStream.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * Create an instance of {@link InputStream} by wrapping {@link java.io.InputStream}.
  */
-class DJVMInputStream extends InputStream {
+final class DJVMInputStream extends InputStream {
     private final java.io.InputStream input;
 
     DJVMInputStream(java.io.InputStream input) {

--- a/djvm/src/main/java/sandbox/java/util/concurrent/atomic/DJVM.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/atomic/DJVM.java
@@ -7,8 +7,7 @@ import sandbox.java.util.concurrent.atomic.AtomicReferenceFieldUpdater.AtomicRef
 
 @SuppressWarnings("unused")
 public final class DJVM {
-    private DJVM() {
-    }
+    private DJVM() {}
 
     @NotNull
     public static <T,V> AtomicReferenceFieldUpdater<T,V> toDJVM(java.util.concurrent.atomic.AtomicReferenceFieldUpdater<T,V> ref) {

--- a/djvm/src/main/java/sandbox/java/util/concurrent/locks/DJVMConditionObject.java
+++ b/djvm/src/main/java/sandbox/java/util/concurrent/locks/DJVMConditionObject.java
@@ -3,9 +3,8 @@ package sandbox.java.util.concurrent.locks;
 import sandbox.java.util.Date;
 import sandbox.java.util.concurrent.TimeUnit;
 
-class DJVMConditionObject extends sandbox.java.lang.Object implements Condition {
-    DJVMConditionObject() {
-    }
+final class DJVMConditionObject extends sandbox.java.lang.Object implements Condition {
+    DJVMConditionObject() {}
 
     @Override
     public void await() {

--- a/djvm/src/main/java/sandbox/javax/security/auth/x500/DJVM.java
+++ b/djvm/src/main/java/sandbox/javax/security/auth/x500/DJVM.java
@@ -4,8 +4,7 @@ import sandbox.sun.security.x509.X500Name;
 
 @SuppressWarnings("unused")
 public final class DJVM {
-    private DJVM() {
-    }
+    private DJVM() {}
 
     public static X500Principal create(X500Name name) {
         return new X500Principal(name);


### PR DESCRIPTION
Ensure that the private DJVM helper classes are `final`.