### PR TITLE
CORDA-3684: Fix NPE when unsandboxing an array that contains null.

### DIFF
--- a/djvm/src/main/java/sandbox/java/lang/Object.java
+++ b/djvm/src/main/java/sandbox/java/lang/Object.java
@@ -44,7 +44,7 @@ public class Object {
     private static java.lang.Object unwrap(java.lang.Object arg) {
         if (arg instanceof Object) {
             return ((Object) arg).fromDJVM();
-        } else if (java.lang.Object[].class.isAssignableFrom(arg.getClass())) {
+        } else if (arg != null && java.lang.Object[].class.isAssignableFrom(arg.getClass())) {
             return fromDJVM((java.lang.Object[]) arg);
         } else {
             return arg;

--- a/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/DJVMTest.kt
@@ -96,19 +96,34 @@ class DJVMTest : TestBase(KOTLIN) {
     @Test
     fun testSandboxingArrays() = sandbox {
         with(DJVM(classLoader)) {
-            val result = sandbox(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
-            assertThat(result).isEqualTo(
-                arrayOf(intOf(1), longOf(10), stringOf("Hello World"), charOf('?'), booleanOf(false), doubleOf(1234.56)))
+            val result = sandbox(arrayOf(1, 10L, "Hello World", '?', false, 1234.56, null))
+            assertThat(result).isEqualTo(arrayOf(
+                intOf(1),
+                longOf(10),
+                stringOf("Hello World"),
+                charOf('?'),
+                booleanOf(false),
+                doubleOf(1234.56),
+                null
+            ))
         }
     }
 
     @Test
     fun testUnsandboxingObjectArray() = sandbox {
         val result = with(DJVM(classLoader)) {
-            unsandbox(arrayOf(intOf(1), longOf(10L), stringOf("Hello World"), charOf('?'), booleanOf(false), doubleOf(1234.56)))
+            unsandbox(arrayOf(
+                intOf(1),
+                longOf(10L),
+                stringOf("Hello World"),
+                charOf('?'),
+                booleanOf(false),
+                doubleOf(1234.56),
+                null
+            ))
         }
         assertThat(result)
-            .isEqualTo(arrayOf(1, 10L, "Hello World", '?', false, 1234.56))
+            .isEqualTo(arrayOf(1, 10L, "Hello World", '?', false, 1234.56, null))
     }
 
     @Test


### PR DESCRIPTION
Extend array test cases to include `null` values.