### PR TITLE
Initialise the DJVM with more standard system properties.

### DIFF
--- a/djvm/src/main/java/sandbox/sun/security/action/GetPropertyAction.java
+++ b/djvm/src/main/java/sandbox/sun/security/action/GetPropertyAction.java
@@ -2,6 +2,7 @@ package sandbox.sun.security.action;
 
 import sandbox.java.lang.DJVM;
 import sandbox.java.lang.String;
+import sandbox.java.lang.System;
 import sandbox.java.security.PrivilegedAction;
 import sandbox.java.util.LinkedHashMap;
 import sandbox.java.util.Map;
@@ -13,23 +14,28 @@ public class GetPropertyAction extends sandbox.java.lang.Object implements Privi
     static {
         systemValues = new LinkedHashMap<>();
         systemValues.put(DJVM.intern("file.encoding"), DJVM.intern("UTF-8"));
+        systemValues.put(DJVM.intern("user.language"), DJVM.intern("en"));
         systemValues.put(DJVM.intern("user.timezone"), DJVM.intern("UTC"));
-        systemValues.put(DJVM.intern("line.separator"), DJVM.intern("\n"));
+        systemValues.put(DJVM.intern("line.separator"), System.lineSeparator);
+        systemValues.put(DJVM.intern("path.separator"), DJVM.intern(":"));
     }
 
+    private final String name;
     private final String defaultValue;
 
     @SuppressWarnings("WeakerAccess")
     public GetPropertyAction(String name, String defaultValue) {
+        this.name = name;
         this.defaultValue = defaultValue;
     }
 
     public GetPropertyAction(String name) {
-        this(name, systemValues.get(name));
+        this(name, null);
     }
 
     @Override
     public String run() {
-        return defaultValue;
+        String value = systemValues.get(name);
+        return (value != null) ? value : defaultValue;
     }
 }


### PR DESCRIPTION
Provide values for the following system properties:
- `user.language`
- `path.separator`

This just makes the settings explicit; there is no change in behaviour.