### PR TITLE
CORDA-3748: Add error stubs for System.currentTimeMillis() and System.nanoTime().

### DIFF
--- a/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
+++ b/djvm-example/src/test/java/com/example/testing/JavaSandboxTest.java
@@ -1,6 +1,7 @@
 package com.example.testing;
 
 import net.corda.djvm.TypedTaskFactory;
+import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
 
 import static com.example.testing.SandboxType.JAVA;
@@ -32,11 +33,11 @@ class JavaSandboxTest extends TestBase {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                Throwable ex = assertThrows(NoSuchMethodError.class, () -> WithJava.run(taskFactory, BadJavaTask.class, BIG_NUMBER));
+                Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(taskFactory, BadJavaTask.class, BIG_NUMBER));
                 assertThat(ex)
-                    .isExactlyInstanceOf(NoSuchMethodError.class)
-                    .hasMessageContaining("sandbox.java.lang.System.currentTimeMillis()")
-                    .hasMessageFindingMatch("(long sandbox\\.|\\.currentTimeMillis\\(\\)J)+");
+                    .isExactlyInstanceOf(RuleViolationError.class)
+                    .hasMessage("Disallowed reference to API; java.lang.System.currentTimeMillis()")
+                    .hasNoCause();
             } catch(Exception e) {
                 fail(e);
             }

--- a/djvm/src/main/java/sandbox/java/lang/System.java
+++ b/djvm/src/main/java/sandbox/java/lang/System.java
@@ -21,14 +21,24 @@ public final class System extends Object {
         java.lang.System.arraycopy(src, srcPos, dest, destPos, length);
     }
 
+    public static long currentTimeMillis() {
+        throw DJVM.failApi("java.lang.System.currentTimeMillis()");
+    }
+
+    public static long nanoTime() {
+        throw DJVM.failApi("java.lang.System.nanoTime()");
+    }
+
     public static String getProperty(String name, String defaultValue) {
         return defaultValue;
     }
 
+    @Nullable
     public static String getProperty(String name) {
         return null;
     }
 
+    @Nullable
     public static String setProperty(String name, String value) {
         return null;
     }

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotationProxyJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotationProxyJavaTest.java
@@ -339,9 +339,7 @@ class AnnotationProxyJavaTest extends TestBase {
                 Throwable ex = assertThrows(RuleViolationError.class, () -> WithJava.run(taskFactory, EvilAnnotationTask.class, null));
                 assertThat(ex)
                     .isExactlyInstanceOf(RuleViolationError.class)
-                    .hasMessageStartingWith("java.lang.NoSuchMethodError -> ")
-                    .hasMessageContaining("sandbox.java.lang.System.currentTimeMillis()")
-                    .hasMessageMatching(".*( 'long sandbox\\..*\\(\\)'$|\\.currentTimeMillis\\(\\)J$)")
+                    .hasMessage("Disallowed reference to API; java.lang.System.currentTimeMillis()")
                     .hasNoCause();
             } catch (Exception e) {
                 fail(e);

--- a/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/MaliciousClassLoaderTest.java
@@ -25,10 +25,11 @@ class MaliciousClassLoaderTest extends TestBase {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                Throwable ex = assertThrows(NoSuchMethodError.class, () -> WithJava.run(taskFactory, ActOfEvil.class, PureEvil.class.getName()));
+                RuleViolationError ex = assertThrows(RuleViolationError.class,
+                    () -> WithJava.run(taskFactory, ActOfEvil.class, PureEvil.class.getName())
+                );
                 assertThat(ex)
-                    .hasMessageContaining("sandbox.java.lang.System.currentTimeMillis()")
-                    .hasMessageFindingMatch("(long sandbox\\.|\\.currentTimeMillis\\(\\)J)+")
+                    .hasMessage("Disallowed reference to API; java.lang.System.currentTimeMillis()")
                     .hasNoCause();
             } catch(Exception e){
                 fail(e);

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -138,10 +138,9 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     @Test
     fun `can detect illegal references in Kotlin meta-classes`() = sandbox {
         val taskFactory = classLoader.createTypedTaskFactory()
-        assertThatExceptionOfType(NoSuchMethodError::class.java)
+        assertThatExceptionOfType(RuleViolationError::class.java)
             .isThrownBy { taskFactory.create(TestKotlinMetaClasses::class.java).apply(0) }
-            .withMessageContaining("sandbox.java.lang.System.nanoTime()")
-            .withMessageMatching(".*(long sandbox\\.|\\.nanoTime\\(\\)J)+.*")
+            .withMessage("Disallowed reference to API; java.lang.System.nanoTime()")
     }
 
     class TestKotlinMetaClasses : Function<Int, Long> {
@@ -154,10 +153,9 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     @Test
     fun `cannot execute runnable that references non-deterministic code`() = sandbox {
         val taskFactory = classLoader.createTypedTaskFactory()
-        assertThatExceptionOfType(NoSuchMethodError::class.java)
+        assertThatExceptionOfType(RuleViolationError::class.java)
             .isThrownBy { taskFactory.create(TestNonDeterministicCode::class.java).apply(0) }
-            .withMessageContaining("sandbox.java.lang.System.currentTimeMillis()")
-            .withMessageMatching(".*(long sandbox\\.|\\.currentTimeMillis\\(\\)J)+.*")
+            .withMessage("Disallowed reference to API; java.lang.System.currentTimeMillis()")
     }
 
     class TestNonDeterministicCode : Function<Int, Long> {


### PR DESCRIPTION
Add stubs for `java.lang.System.currentTimeMillis()` and `java.lang.System.nanoTime()` to the DJVM's template code so that these two functions result in `RuleViolationError` exceptions rather than `NoSuchMethodException`.