### PR TITLE
Add JVM compiler directives for testing on JDK11 JVM.

### DIFF
--- a/compiler-control.txt
+++ b/compiler-control.txt
@@ -1,0 +1,11 @@
+[
+    {
+        match: "sandbox.*::*",
+
+        // Disable the optimising compiler for sandbox
+        // classes because they will all be discarded.
+        c2: {
+             Exclude:true
+        }
+    }
+]

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -179,9 +179,15 @@ tasks.withType(Test) {
     systemProperty 'test.gradle.home', gradle.gradleHomeDir.toURI()
     systemProperty 'test.project.uri', projectDir.toURI()
 
-    // Disable JIT compilation of sandbox.* classes because they are discarded after use.
-    // https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
-    jvmArgs '-XX:CompileCommand=quiet', '-XX:CompileCommand=exclude,sandbox/*.*'
+    if (current().isJava9Compatible()) {
+        // https://openjdk.java.net/jeps/165
+        jvmArgs '-XX:+UnlockDiagnosticVMOptions',
+                "-XX:CompilerDirectivesFile=${rootProject.projectDir}/compiler-control.txt"
+    } else {
+        // Disable JIT compilation of sandbox.* classes because they are discarded after use.
+        // https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
+        jvmArgs '-XX:CompileCommand=quiet', '-XX:CompileCommand=exclude,sandbox/*.*'
+    }
 }
 
 artifacts {


### PR DESCRIPTION
Disable the JVM's C2 compiler for all `sandbox.*` classes when building on Java 11.