### PR TITLE
CORDA-3738: Tidy up class name resolution.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -91,15 +91,11 @@ class AnalysisConfiguration private constructor(
      */
     val stitchedClasses: Map<String, List<Member>> get() = STITCHED_CLASSES
 
-    fun isTemplateClass(className: String): Boolean = className in TEMPLATE_CLASSES
-
     fun isJvmException(className: String): Boolean = className in JVM_EXCEPTIONS
     fun isJvmAnnotation(className: String): Boolean = className in JVM_ANNOTATIONS
     fun hasDJVMSynthetic(className: String): Boolean = !isJvmException(className) && !isJvmAnnotation(className)
 
     fun isJvmAnnotationDesc(descriptor: String): Boolean = descriptor in JVM_ANNOTATION_DESC
-
-    fun isSandboxClass(className: String): Boolean = className.startsWith(SANDBOX_PREFIX)
 
     fun toSandboxClassName(header: ClassHeader): String {
         val sandboxName = classResolver.resolve(header.internalName)

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassRemapper.kt
@@ -79,7 +79,7 @@ class SandboxClassRemapper(
         : MethodVisitor(api, remapper) {
 
         private fun mapperFor(element: Element): MethodVisitor {
-            return if (configuration.isTemplateClass(element.className) || isUnmapped(element)) {
+            return if (configuration.classResolver.isTemplateClass(element.className) || isUnmapped(element)) {
                 methodNonMapper
             } else {
                 mv

--- a/djvm/src/main/kotlin/net/corda/djvm/validation/RuleContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/validation/RuleContext.kt
@@ -16,7 +16,9 @@ import net.corda.djvm.references.*
 class RuleContext(
     private val analysisContext: AnalysisRuntimeContext
 ) : ConstraintProvider(analysisContext) {
-    fun formatFor(member: MemberInformation): String = analysisContext.configuration.formatFor(member)
+    private val configuration = analysisContext.configuration
+
+    fun formatFor(member: MemberInformation): String = configuration.formatFor(member)
 
     /**
      * The class currently being analysed.
@@ -40,24 +42,24 @@ class RuleContext(
      * The configured whitelist.
      */
     val whitelist: Whitelist
-        get() = analysisContext.configuration.whitelist
+        get() = configuration.whitelist
 
     /**
      * Utilities for dealing with classes.
      */
     val classModule: ClassModule
-        get() = analysisContext.configuration.classModule
+        get() = configuration.classModule
 
     /**
      * Utilities for dealing with members.
      */
     val memberModule: MemberModule
-        get() = analysisContext.configuration.memberModule
+        get() = configuration.memberModule
 
     /**
      * Check whether the class has been explicitly defined in the sandbox namespace.
      */
-    fun isSandboxClass(className: String): Boolean = analysisContext.configuration.isSandboxClass(className)
+    fun isSandboxClass(className: String): Boolean = configuration.classResolver.isSandboxClass(className)
 
     /**
      * Set up and execute a rule validation block.


### PR DESCRIPTION
The logic for mapping class names into and out of the sandbox belongs in `ClassResolver`. Remove the logic which had "leaked" into `AnalysisConfiguration` to make `ClassResolver` the Source of Truth.