### PR TITLE
CORDA-3757: Add support for java.math.BigInteger and java.math.BigDecimal.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -115,6 +115,7 @@ shadowJar {
     exclude 'sandbox/java/lang/reflect/InvocationTargetException.class'
     exclude 'sandbox/java/lang/reflect/Member.class'
     exclude 'sandbox/java/lang/reflect/*Type*.class'
+    exclude 'sandbox/java/math/**'
     exclude 'sandbox/java/net/**'
     exclude 'sandbox/java/nio/Buffer.class'
     exclude 'sandbox/java/nio/ByteBuffer.class'

--- a/djvm/src/main/java/sandbox/java/math/BigDecimal.java
+++ b/djvm/src/main/java/sandbox/java/math/BigDecimal.java
@@ -1,0 +1,72 @@
+package sandbox.java.math;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Comparable;
+import sandbox.java.lang.Number;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.math.BigDecimal}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class BigDecimal extends Number implements Comparable<BigDecimal> {
+    private static final java.lang.String UNSUPPORTED = "Dummy class - not implemented";
+
+    public BigDecimal(BigInteger unscaledVal, int scale) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public int compareTo(@NotNull BigDecimal bigDecimal) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public double doubleValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public float floatValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public long longValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public int intValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public short shortValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public byte byteValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    public BigInteger unscaledValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    public int scale() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /**
+     * This method will actually be "stitched" into {@link BigDecimal} at runtime.
+     * It has been implemented here mainly for reference.
+     * @return An equivalent {@link java.math.BigDecimal} object.
+     */
+    @Override
+    @NotNull
+    protected final java.math.BigDecimal fromDJVM() {
+        return new java.math.BigDecimal(unscaledValue().fromDJVM(), scale());
+    }
+}

--- a/djvm/src/main/java/sandbox/java/math/BigInteger.java
+++ b/djvm/src/main/java/sandbox/java/math/BigInteger.java
@@ -1,0 +1,72 @@
+package sandbox.java.math;
+
+import org.jetbrains.annotations.NotNull;
+import sandbox.java.lang.Comparable;
+import sandbox.java.lang.Number;
+
+/**
+ * This is a dummy class that implements just enough of {@link java.math.BigInteger}
+ * to allow us to compile {@link sandbox.java.lang.DJVM}.
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class BigInteger extends Number implements Comparable<BigInteger> {
+    private static final java.lang.String UNSUPPORTED = "Dummy class - not implemented";
+
+    public BigInteger(int signum, byte[] magnitude) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public int compareTo(@NotNull BigInteger bigInteger) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public double doubleValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public float floatValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public long longValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public int intValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public short shortValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public byte byteValue() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    public int signum() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    public byte[] toByteArray() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /**
+     * This method will actually be "stitched" into {@link BigInteger} at runtime.
+     * It has been implemented here mainly for reference.
+     * @return An equivalent {@link java.math.BigInteger} object.
+     */
+    @Override
+    @NotNull
+    protected final java.math.BigInteger fromDJVM() {
+        return new java.math.BigInteger(signum(), toByteArray());
+    }
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -440,6 +440,7 @@ class AnalysisConfiguration private constructor(
             generateJavaUuidMethods() +
             generateJavaPackageMethods() +
             generateJavaBitsMethods() +
+            generateJavaMathMethods() +
 
             object : FromDJVMBuilder(
                 className = sandboxed(Enum::class.java),

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaMathConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/JavaMathConfiguration.kt
@@ -1,0 +1,51 @@
+@file:JvmName("JavaMathConfiguration")
+package net.corda.djvm.analysis
+
+import net.corda.djvm.analysis.AnalysisConfiguration.Companion.sandboxed
+import net.corda.djvm.code.CONSTRUCTOR_NAME
+import net.corda.djvm.code.EmitterModule
+import net.corda.djvm.code.FROM_DJVM
+import net.corda.djvm.references.Member
+
+/**
+ * Generate [Member] objects that will be stitched into [sandbox.java.math.BigInteger]
+ * and [sandbox.java.math.BigDecimal].
+ */
+fun generateJavaMathMethods(): List<Member> = object : FromDJVMBuilder(
+    className = sandboxed(java.math.BigInteger::class.java),
+    bridgeDescriptor = "()Ljava/math/BigInteger;"
+) {
+    /**
+     * Implements BigInteger.fromDJVM():
+     *     return new java.math.BigInteger(signum(), toByteArray())
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        new("java/math/BigInteger")
+        duplicate()
+        pushObject(0)
+        invokeVirtual(className, "signum", "()I")
+        pushObject(0)
+        invokeVirtual(className, "toByteArray", "()[B")
+        invokeSpecial("java/math/BigInteger", CONSTRUCTOR_NAME, "(I[B)V")
+        returnObject()
+    }
+}.build() + object : FromDJVMBuilder(
+    className = sandboxed(java.math.BigDecimal::class.java),
+    bridgeDescriptor = "()Ljava/math/BigDecimal;"
+) {
+    /**
+     * Implements BigDecimal.fromDJVM():
+     *     return new java.math.BigDecimal(unscaledValue().fromDJVM(), scale())
+     */
+    override fun writeBody(emitter: EmitterModule) = with(emitter) {
+        new("java/math/BigDecimal")
+        duplicate()
+        pushObject(0)
+        invokeVirtual(className, "unscaledValue", "()Lsandbox/java/math/BigInteger;")
+        invokeVirtual("sandbox/java/math/BigInteger", FROM_DJVM, "()Ljava/math/BigInteger;")
+        pushObject(0)
+        invokeVirtual(className, "scale", "()I")
+        invokeSpecial("java/math/BigDecimal", CONSTRUCTOR_NAME, "(Ljava/math/BigInteger;I)V")
+        returnObject()
+    }
+}.build()

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -66,6 +66,8 @@ fun Any.sandbox(): Any {
         is kotlin.Boolean -> Boolean.toDJVM(this)
         is kotlin.Enum<*> -> toDJVMEnum()
         is kotlin.Throwable -> toDJVMThrowable()
+        is java.math.BigInteger -> toDJVMBigInteger()
+        is java.math.BigDecimal -> sandbox.java.math.BigDecimal(unscaledValue().toDJVMBigInteger(), scale())
         is java.util.Date -> Date(time)
         is java.io.InputStream -> InputStream.toDJVM(this)
         is java.util.UUID -> UUID(mostSignificantBits, leastSignificantBits)
@@ -246,6 +248,10 @@ private fun kotlin.Throwable.copyExtraTo(t: kotlin.Throwable) {
 }
 
 private fun Array<*>.fromDJVMArray(): Array<*> = Object.fromDJVM(this)
+
+private fun java.math.BigInteger.toDJVMBigInteger(): sandbox.java.math.BigInteger {
+    return sandbox.java.math.BigInteger(signum(), toByteArray())
+}
 
 private fun java.time.LocalDate.toDJVM(): sandbox.java.time.LocalDate {
     return sandbox.java.time.LocalDate.of(year, monthValue, dayOfMonth)

--- a/djvm/src/test/java/net/corda/djvm/execution/JavaMathTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/JavaMathTest.java
@@ -1,0 +1,62 @@
+package net.corda.djvm.execution;
+
+import net.corda.djvm.TestBase;
+import net.corda.djvm.rewiring.SandboxClassLoader;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import static net.corda.djvm.SandboxType.JAVA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JavaMathTest extends TestBase {
+    JavaMathTest() {
+        super(JAVA);
+    }
+
+    @Test
+    void testBigIntegerMarshalledFaithfully() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super Object, ?> basicInput = classLoader.createBasicInput();
+                Function<? super Object, ?> basicOutput = classLoader.createBasicOutput();
+
+                BigInteger originalValue = new BigInteger("12345678901234567890");
+                Object sandboxValue = basicInput.apply(originalValue);
+                assertEquals("sandbox.java.math.BigInteger", sandboxValue.getClass().getName());
+
+                BigInteger returnedValue = (BigInteger) basicOutput.apply(sandboxValue);
+                assertEquals(originalValue, returnedValue);
+                assertNotSame(originalValue, returnedValue);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void testBigDecimalMarshalledFaithfully() {
+        sandbox(ctx -> {
+            try {
+                SandboxClassLoader classLoader = ctx.getClassLoader();
+                Function<? super Object, ?> basicInput = classLoader.createBasicInput();
+                Function<? super Object, ?> basicOutput = classLoader.createBasicOutput();
+
+                BigDecimal originalValue = new BigDecimal("1234567890555.123456789");
+                Object sandboxValue = basicInput.apply(originalValue);
+                assertEquals("sandbox.java.math.BigDecimal", sandboxValue.getClass().getName());
+
+                BigDecimal returnedValue = (BigDecimal) basicOutput.apply(sandboxValue);
+                assertEquals(originalValue, returnedValue);
+                assertNotSame(originalValue, returnedValue);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Add `BigInteger` and `BigDecimal` to the list of types that the DJVM can marshall into and out of the sandbox.