### PR TITLE
CORDA-3760: Replace whitelisting with override classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ package net.corda.djvm.analysis
 
 fun AnalysisConfiguration.createRoot(
     userSource: UserSource,
-    whitelist: Whitelist,
     visibleAnnotations: Set<Class<out Annotation>> = emptySet(),
     minimumSeverityLevel: Severity = Severity.WARNING,
     bootstrapSource: ApiSource? = null,
+    overrideClasses: Set<String> = emptySet(),
     analyzeAnnotations: Boolean = false,
     prefixFilters: List<String> = emptyList(),
     classModule: ClassModule = ClassModule(),
@@ -90,14 +90,18 @@ fun AnalysisConfiguration.createRoot(
 
 where:
 - `userSource` is an instance of `UserSource` that contains the user's classes to be sandboxed.
-- `whitelist` contains the class names which the DJVM should _not_ map into the sandbox. Regular
-expressions are supported, although you probably still want to use `Whitelist.MINIMAL` anyway.
 - `visibleAnnotations` Not only will occurrences of these annotations be mapped into the `sandbox.*`,
 package space, but the original annotations will be preserved too.
 - `minimumSeverityLevel` is the minimum message severity level to be recorded in `MessageCollection` by
 `sandbox.*` classes.
 - `bootstrapSource` is an instance of `ApiSource` containing an implementation of Java 8 APIs. A `null`
 value forcs the DJVM to use the underlying JVM's API classes instead.
+- `overrideClasses` is a set of names of classes which will be included in the sandbox "as is". These
+classes must already exist on the classpath. Any class which already belongs to the `sandbox.*` package
+space will be copied and relinked into the `SandboxClassLoader`, whereas classes outside the `sandbox.*`
+packages will be used directly from the classpath. **It is your responsibility to ensure that these classes
+are compatible with the rest of the classes inside the sandbox.** This is a very powerful, and consequently
+_VERY DANGEROUS_ option. _HANDLE WITH CARE!_
 - `analyzeAnnotations` determines whether the DJVM should include class references from annotations during
 the analysts phase.
 - `prefixFilter` is another logging option. If set, only messages from classes matching one of these

--- a/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/TestBase.kt
@@ -8,7 +8,6 @@ import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration
-import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.messages.Severity.WARNING
 import net.corda.djvm.rewiring.ExternalCache
@@ -48,7 +47,6 @@ abstract class TestBase(type: SandboxType) {
             bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
             val rootConfiguration = AnalysisConfiguration.createRoot(
                 userSource = UserPathSource(emptyList()),
-                whitelist = MINIMAL,
                 visibleAnnotations = setOf(
                     CordaSerializable::class.java,
                     ConstructorForDeserialization::class.java,

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -5,7 +5,6 @@ import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.SandboxConfiguration.Companion.ALL_DEFINITION_PROVIDERS
 import net.corda.djvm.SandboxConfiguration.Companion.ALL_RULES
 import net.corda.djvm.analysis.AnalysisConfiguration
-import net.corda.djvm.analysis.Whitelist
 import net.corda.djvm.execution.*
 import net.corda.djvm.references.ClassModule
 import net.corda.djvm.source.ClassSource
@@ -67,7 +66,7 @@ abstract class ClassCommand : CommandBase() {
     override fun validateArguments() = filters.isNotEmpty()
 
     override fun handleCommand(): Boolean {
-        val configuration = getConfiguration(Whitelist.MINIMAL)
+        val configuration = getConfiguration()
         classLoader = configuration.analysisConfiguration.supportingClassLoader
         createExecutor(configuration)
 
@@ -179,7 +178,7 @@ abstract class ClassCommand : CommandBase() {
           + filters.filter { it.endsWith(".jar", true) }.map { Paths.get(it) }
     )
 
-    private fun getConfiguration(whitelist: Whitelist): SandboxConfiguration {
+    private fun getConfiguration(): SandboxConfiguration {
         return SandboxConfiguration.of(
                 profile = if (disableTracing) { null } else { profile },
                 rules = if (ignoreRules) { emptyList() } else { ALL_RULES },
@@ -187,7 +186,6 @@ abstract class ClassCommand : CommandBase() {
                 definitionProviders = if (ignoreDefinitionProviders) { emptyList() } else { ALL_DEFINITION_PROVIDERS },
                 analysisConfiguration = AnalysisConfiguration.createRoot(
                         userSource = UserPathSource(getClasspath()),
-                        whitelist = whitelist,
                         minimumSeverityLevel = level,
                         analyzeAnnotations = analyzeAnnotations,
                         prefixFilters = prefixFilters.toList()

--- a/djvm/secure/src/test/kotlin/com/example/testing/TestBase.kt
+++ b/djvm/secure/src/test/kotlin/com/example/testing/TestBase.kt
@@ -6,7 +6,6 @@ import net.corda.core.serialization.DeprecatedConstructorForDeserialization
 import net.corda.djvm.SandboxConfiguration
 import net.corda.djvm.SandboxRuntimeContext
 import net.corda.djvm.analysis.AnalysisConfiguration
-import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.messages.Severity
 import net.corda.djvm.messages.Severity.WARNING
 import net.corda.djvm.rewiring.ExternalCache
@@ -47,7 +46,6 @@ abstract class TestBase {
             bootstrapSource = BootstrapClassLoader(DETERMINISTIC_RT)
             val rootConfiguration = AnalysisConfiguration.createRoot(
                 userSource = UserPathSource(emptyList()),
-                whitelist = MINIMAL,
                 visibleAnnotations = setOf(
                     CordaSerializable::class.java,
                     ConstructorForDeserialization::class.java,

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/Whitelist.kt
@@ -1,6 +1,5 @@
 package net.corda.djvm.analysis
 
-import java.io.FileNotFoundException
 import java.io.InputStream
 import java.io.PushbackInputStream
 import java.nio.file.Files
@@ -96,8 +95,6 @@ open class Whitelist private constructor(
         get() = textEntries + entries.map(Regex::pattern)
 
     companion object {
-        private val everythingRegex = setOf(".*".toRegex())
-
         private val minimumSet = setOf(
             "^java/lang/AutoCloseable(\\..*)?\$".toRegex(),
             "^java/lang/Class(\\..*)?\$".toRegex(),
@@ -115,35 +112,10 @@ open class Whitelist private constructor(
         )
 
         /**
-         * Empty whitelist.
-         */
-        @JvmField
-        val EMPTY: Whitelist = Whitelist(null, emptySet(), emptySet())
-
-        /**
          * The minimum set of classes that needs to be whitelisted from standard Java libraries.
          */
-        @JvmField
-        val MINIMAL: Whitelist = Whitelist(Whitelist(null, minimumSet, emptySet()), minimumSet, emptySet())
-
-        /**
-         * Whitelist everything.
-         */
-        @JvmField
-        val EVERYTHING: Whitelist = Whitelist(
-            Whitelist(null, everythingRegex, emptySet()),
-            everythingRegex,
-            emptySet()
-        )
-
-        /**
-         * Load a whitelist from a resource stream.
-         */
-        fun fromResource(resourceName: String): Whitelist {
-            val inputStream = Whitelist::class.java.getResourceAsStream("/$resourceName")
-                    ?: throw FileNotFoundException("Cannot find resource \"$resourceName\"")
-            return fromStream(inputStream)
-        }
+        @JvmStatic
+        fun createWhitelist() = Whitelist(Whitelist(null, minimumSet, emptySet()), minimumSet, emptySet())
 
         /**
          * Load a whitelist from a file.

--- a/djvm/src/test/java/net/corda/djvm/Utilities.java
+++ b/djvm/src/test/java/net/corda/djvm/Utilities.java
@@ -7,8 +7,8 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * Whitelist this {@link Utilities} class inside the sandbox to allow
- * tests to invoke these functions.
+ * Add this {@link Utilities} class inside the sandbox as
+ * an override to allow tests to invoke these functions.
  */
 public final class Utilities {
     public static final String CANNOT_CATCH = "Can't catch this!";

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/ClassResolverTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/ClassResolverTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 
 class ClassResolverTest {
 
-    private val resolver = ClassResolver(emptySet(), Whitelist.MINIMAL, SANDBOX_PREFIX)
+    private val resolver = ClassResolver(emptySet(), Whitelist.createWhitelist(), SANDBOX_PREFIX)
 
     @Test
     fun `can resolve class name`() {

--- a/djvm/src/test/kotlin/net/corda/djvm/analysis/WhitelistTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/analysis/WhitelistTest.kt
@@ -9,7 +9,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `can determine when a class is whitelisted when namespace is covered`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/lang/Object")).isTrue()
         assertThat(whitelist.matches("java/lang/Object.<init>:()V")).isTrue()
         assertThat(whitelist.matches("java/lang/reflect/Array")).isTrue()
@@ -19,7 +19,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `can determine when a class is not whitelisted when namespace is covered`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/util/Random")).isFalse()
         assertThat(whitelist.matches("java/util/Random.<init>:()V")).isFalse()
         assertThat(whitelist.matches("java/util/Random.nextInt:()I")).isFalse()
@@ -29,7 +29,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `can determine when a class is whitelisted when namespace is not covered`() {
-        val whitelist = Whitelist.MINIMAL + setOf(
+        val whitelist = Whitelist.createWhitelist()+ setOf(
                 "^org/assertj/.*\$".toRegex(),
                 "^org/junit/.*\$".toRegex()
         )
@@ -40,14 +40,14 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `can determine when a namespace is not covered`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/lang/Object")).isTrue()
         assertThat(whitelist.matches("org/junit/Test")).isFalse()
     }
 
     @Test
     fun `test closeables are whitelisted`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/lang/AutoCloseable")).isTrue()
         assertThat(whitelist.matches("java/lang/AutoCloseable.close:()V")).isTrue()
 
@@ -57,7 +57,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `test atomic field updater factories are whitelisted`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicIntegerFieldUpdater.newUpdater:(Ljava/lang/Class;Ljava/lang/String;)Ljava/util/concurrent/atomic/AtomicIntegerFieldUpdater;")).isTrue()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicLongFieldUpdater.newUpdater:(Ljava/lang/Class;Ljava/lang/String;)Ljava/util/concurrent/atomic/AtomicLongFieldUpdater;")).isTrue()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicReferenceFieldUpdater.newUpdater:(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/String;)Ljava/util/concurrent/atomic/AtomicReferenceFieldUpdater;")).isTrue()
@@ -65,7 +65,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `test atomic field updaters are not whitelisted`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicIntegerFieldUpdater")).isFalse()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicLongFieldUpdater")).isFalse()
         assertThat(whitelist.matches("java/util/concurrent/atomic/AtomicReferenceFieldUpdater")).isFalse()
@@ -73,7 +73,7 @@ class WhitelistTest : TestBase(KOTLIN) {
 
     @Test
     fun `test access controller`() {
-        val whitelist = Whitelist.MINIMAL
+        val whitelist = Whitelist.createWhitelist()
         assertThat(whitelist.matches("java/security/AccessController")).isFalse()
         assertThat(whitelist.matches("java/security/AccessController.doPrivileged:(Ljava/security/PrivilegedAction;)Ljava/lang/Object;")).isTrue()
         assertThat(whitelist.matches("java/security/AccessController.doPrivileged:(Ljava/security/PrivilegedExceptionAction;)Ljava/lang/Object;")).isTrue()

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/SandboxExecutorTest.kt
@@ -7,7 +7,6 @@ import net.corda.djvm.SandboxType.KOTLIN
 import net.corda.djvm.TestBase
 import net.corda.djvm.Utilities.throwRuleViolationError
 import net.corda.djvm.Utilities.throwThresholdViolationError
-import net.corda.djvm.analysis.Whitelist.Companion.MINIMAL
 import net.corda.djvm.costing.ThresholdViolationError
 import net.corda.djvm.rules.RuleViolationError
 import org.assertj.core.api.Assertions.assertThat
@@ -27,7 +26,7 @@ class SandboxExecutorTest : TestBase(KOTLIN) {
     }
 
     @Test
-    fun `can load and execute runnable`() = customSandbox(MINIMAL) {
+    fun `can load and execute runnable`() = sandbox {
         val taskFactory = classLoader.createTypedTaskFactory()
         val result = taskFactory.create(TestSandboxedRunnable::class.java).apply(1)
         assertThat(result).isEqualTo("sandbox")

--- a/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/rewiring/ByteCodeCacheTest.kt
@@ -1,7 +1,6 @@
 package net.corda.djvm.rewiring
 
 import net.corda.djvm.analysis.AnalysisConfiguration
-import net.corda.djvm.analysis.Whitelist
 import net.corda.djvm.source.UserPathSource
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -31,7 +30,6 @@ class ByteCodeCacheTest {
 
     private fun createAnalysisConfiguration() = AnalysisConfiguration.createRoot(
         userSource = UserPathSource(emptyList()),
-        whitelist = Whitelist.EMPTY,
         visibleAnnotations = emptySet()
     )
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/source/SourceClassLoaderTest.kt
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 
 class SourceClassLoaderTest {
 
-    private val classResolver = ClassResolver(emptySet(), Whitelist.MINIMAL, "")
+    private val classResolver = ClassResolver(emptySet(), Whitelist.createWhitelist(), "")
     private val apiSource = BootstrapClassLoader(Paths.get(
         System.getProperty("deterministic-rt.path") ?: fail("deterministic-rt.path property not set")
     ))


### PR DESCRIPTION
The DJVM's whitelist option is obsolete because the sandbox will almost certainly break if users tinker with the whitelist's contents. Conversely, there are situations when we may want to inject hand-written classes into the sandbox without their byte-code being rewritten.

Remove `whitelist` from the "root" `AnalysisConfiguration` options, and replace it with `overrideClasses`.