### PR TITLE
Standardise compiler directives for Java 11.

### DIFF
--- a/compiler-control.json
+++ b/compiler-control.json
@@ -1,11 +1,11 @@
 [
     {
-        match: "sandbox.*::*",
+        match: "sandbox/*.*",
 
         // Disable the optimising compiler for sandbox
         // classes because they will all be discarded.
         c2: {
-             Exclude:true
+             Exclude: true
         }
     }
 ]

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -183,7 +183,7 @@ tasks.withType(Test) {
     if (current().isJava9Compatible()) {
         // https://openjdk.java.net/jeps/165
         jvmArgs '-XX:+UnlockDiagnosticVMOptions',
-                "-XX:CompilerDirectivesFile=${rootProject.projectDir}/compiler-control.txt"
+                "-XX:CompilerDirectivesFile=${rootProject.projectDir}/compiler-control.json"
     } else {
         // Disable JIT compilation of sandbox.* classes because they are discarded after use.
         // https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html


### PR DESCRIPTION
Make the compiler directives file more consistent with [compiler control documentation](https://docs.oracle.com/en/java/javase/11/vm/compiler-control1.html).