### PR TITLE
CORDA-3814: Fetch application classes from HostClassLoader.

### DIFF
--- a/djvm/src/main/java/net/corda/djvm/rewiring/HostClassLoader.java
+++ b/djvm/src/main/java/net/corda/djvm/rewiring/HostClassLoader.java
@@ -1,0 +1,25 @@
+package net.corda.djvm.rewiring;
+
+/**
+ * A package-private {@link ClassLoader} for efficient access to
+ * the DJVM's own classes and everything else on the classpath.
+ */
+class HostClassLoader extends ClassLoader {
+    private final ClassLoader djvmClassLoader;
+
+    HostClassLoader() {
+        super(null);
+        djvmClassLoader = HostClassLoader.class.getClassLoader();
+    }
+
+    @Override
+    protected Class<?> loadClass(String className, boolean resolve) throws ClassNotFoundException {
+        /*
+         * Using Class.forName() because otherwise multiple sandbox
+         * threads would fight over the Application ClassLoader's
+         * class-loading lock. Instead, we consult the JVM's own
+         * "lockless" cache of classes that have been loaded already.
+         */
+        return Class.forName(className, false, djvmClassLoader);
+    }
+}


### PR DESCRIPTION
A `SandboxClassLoader` must ultimately have the DJVM's own application classloader as a parent so that it can load a sandbox's "foundation" classes. The standard classloader delegation mechanism would normally mean that multiple sandboxes would then complete for the `AppClassLoader`'s class-loading lock as they all tried to load the same non-sandbox classes at the same time.

Avoid this contention by creating `HostClassLoader` to handle requests for non-sandbox classes. This classloader leverages the JVM's native "lockless" cache of already loaded classes by invoking `Class.forName()` instead of `loadClass()`.