### PR TITLE
INFRA-396 - Migrate DJVM build from TeamCity to Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     }
 
     environment {
-        ARTIFACTORY_BUILD_NAME = "DJVM / Publish / Publish to Artifactory".replaceAll("/", "::")
+        ARTIFACTORY_BUILD_NAME = "DJVM / Publish / ${isSnapshot ? "Snapshot /":""} Publish to Artifactory".replaceAll("/", "::")
     }
 
     stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -82,6 +82,7 @@ pipeline {
 
     post {
         always {
+            archiveArtifacts artifacts: '**/*.log', fingerprint: false
             junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -20,7 +20,7 @@ boolean isMaster = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {
     agent {
-        label 'k8s'
+        label 'standard'
     }
 
     options {
@@ -30,9 +30,6 @@ pipeline {
     }
 
     environment {
-        DOCKER_TAG_TO_USE = "${env.GIT_COMMIT.subSequence(0, 8)}"
-        EXECUTOR_NUMBER = "${env.EXECUTOR_NUMBER}"
-        BUILD_ID = "${env.BUILD_ID}-${env.JOB_NAME}"
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         ARTIFACTORY_BUILD_NAME = "DJVM / Publish / Publish to Artifactory".replaceAll("/", "::")
     }
@@ -47,7 +44,7 @@ pipeline {
 
         stage('Build DJVM Example') {
             steps {
-                sh "./gradlew --daemon --no-build-cache clean build"
+                sh "cd djvm-example && ./gradlew --daemon --no-build-cache clean build"
             }
         }
 
@@ -85,7 +82,7 @@ pipeline {
 
     post {
         always {
-            junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true
+            junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {
             deleteDir() /* clean up our workspace */

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
 
     post {
         always {
-            archiveArtifacts artifacts: '**/*.log', fingerprint: false
+            archiveArtifacts artifacts: '**/build/reports/tests/**/*', fingerprint: false
             junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,7 +16,8 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-boolean isReleaseTag = (env.TAG_NAME =~ /^release\/.+$/)
+boolean isPR = (env.BRANCH_NAME.startsWith('PR'))
+boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/ || env.BRANCH_NAME =~ /^release\/.+$/)
 
 pipeline {
     agent {
@@ -51,7 +52,7 @@ pipeline {
 
         stage('Publish to Artifactory') {
             when {
-                expression { isReleaseTag }
+                expression { !isPR }
             }
 
             steps {
@@ -63,7 +64,7 @@ pipeline {
                 rtGradleDeployer(
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
-                        repo: 'corda-dependencies-dev'
+                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -17,7 +17,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
  * Sense environment
  */
 //boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
-boolean isRelease = (env.TAG_NAME =~ '/^ci-test.*$/')
+boolean isRelease = (env.TAG_NAME =~ /^ci-test.*$/)
 boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
 //                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
-                        repo: isRelease ? 'testing-ci-uploads-release' : 'testing-ci-uploads-dev'
+                        repo: isRelease ? 'testing-ci-uploads-dev' : 'testing-ci-uploads-release'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         label 'standard'
     }
 
-    params {
+    parameters {
         booleanParam defaultValue: ( isRelease || isSnapshot ), description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
     }
 
@@ -68,7 +68,8 @@ pipeline {
                 rtGradleDeployer(
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
-                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
+//                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
+                        repo: isRelease ? 'testing-ci-uploads-release' : 'testing-ci-uploads-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 /**
- * Jenkins pipeline to build Corda Enterprise Network Services
+ * Jenkins pipeline to build Corda DJVM
  */
 
 /**
@@ -16,17 +16,12 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-// boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
-// boolean isRelease = (env.TAG_NAME =~ /^release_.*/)
+ boolean isMaster = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {
     agent {
         label 'k8s'
     }
-
-//     parameters {
-//         booleanParam defaultValue: (isReleaseBranch || isRelease), description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
-//     }
 
     options {
         timestamps()
@@ -58,13 +53,9 @@ pipeline {
         }
 
         stage('Publish to Artifactory') {
-//            when {
-//                expression { params.DO_PUBLISH }
-//                beforeAgent true
-//            }
-
-            // only publish on commits to master
-            // do not publish on pr
+            when {
+                expression { master }
+            }
 
             steps {
                 rtServer(
@@ -75,8 +66,7 @@ pipeline {
                 rtGradleDeployer(
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
-                        repo: 'r3-tools-dev'
-//                        repo: isRelease ? 'r3-corda-releases' : 'r3-corda-dev'
+                        repo: 'corda-dependencies-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,9 +16,8 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-//boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
-boolean isRelease = (env.TAG_NAME =~ /^ci-test-release.*$/)
-boolean isSnapshot = (env.TAG_NAME =~ /^ci-test-snapshot.*$/)
+boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
+boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {
     agent {
@@ -69,8 +68,7 @@ pipeline {
                 rtGradleDeployer(
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
-//                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
-                        repo: isRelease ? 'testing-ci-uploads-release' : 'testing-ci-uploads-dev'
+                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,7 +16,8 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
+//boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
+boolean isRelease = (env.TAG_NAME =~ '/^ci-test.*$/')
 boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,7 +16,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-boolean isMaster = (env.BRANCH_NAME =~ /^master$/)
+boolean isReleaseTag = (env.TAG_NAME =~ /^release\/.+$/)
 
 pipeline {
     agent {
@@ -30,7 +30,6 @@ pipeline {
     }
 
     environment {
-        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         ARTIFACTORY_BUILD_NAME = "DJVM / Publish / Publish to Artifactory".replaceAll("/", "::")
     }
 
@@ -44,13 +43,15 @@ pipeline {
 
         stage('Build DJVM Example') {
             steps {
-                sh "cd djvm-example && ./gradlew --daemon --no-build-cache clean build && cd .."
+                dir("djvm-example") {
+                    sh "./gradlew --daemon --no-build-cache clean build"
+                }
             }
         }
 
         stage('Publish to Artifactory') {
             when {
-                expression { master }
+                expression { isReleaseTag }
             }
 
             steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
             junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {
+            sh "./gradlew --stop"
             deleteDir() /* clean up our workspace */
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,7 +16,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
- boolean isMaster = (env.BRANCH_NAME =~ /^master$/)
+boolean isMaster = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {
     agent {
@@ -26,7 +26,6 @@ pipeline {
     options {
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '7', artifactDaysToKeepStr: '7'))
-        disableConcurrentBuilds()
         timeout(time: 3, unit: 'HOURS')
     }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -16,12 +16,16 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 /**
  * Sense environment
  */
-boolean isPR = (env.BRANCH_NAME.startsWith('PR'))
-boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/ || env.BRANCH_NAME =~ /^release\/.+$/)
+boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
+boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {
     agent {
         label 'standard'
+    }
+
+    params {
+        booleanParam defaultValue: ( isRelease || isSnapshot ), description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
     }
 
     options {
@@ -52,7 +56,7 @@ pipeline {
 
         stage('Publish to Artifactory') {
             when {
-                expression { !isPR }
+                expression { params.DO_PUBLISH }
             }
 
             steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: '**/build/reports/tests/**/*', fingerprint: false
+            junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {
             deleteDir() /* clean up our workspace */

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -84,7 +84,6 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: '**/build/reports/tests/**/*', fingerprint: false
-            junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true, keepLongStdio: true
         }
         cleanup {
             deleteDir() /* clean up our workspace */

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -17,7 +17,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
  * Sense environment
  */
 //boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
-boolean isRelease = (env.TAG_NAME =~ /^ci-test.*$/)
+boolean isRelease = (env.TAG_NAME =~ /^ci-test-release.*$/)
 boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
 
 pipeline {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
 //                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
-                        repo: isRelease ? 'testing-ci-uploads-dev' : 'testing-ci-uploads-release'
+                        repo: isRelease ? 'testing-ci-uploads-releases' : 'testing-ci-uploads-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -18,7 +18,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
  */
 //boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
 boolean isRelease = (env.TAG_NAME =~ /^ci-test-release.*$/)
-boolean isSnapshot = (env.BRANCH_NAME =~ /^ci-test-snapshot.*$/)
+boolean isSnapshot = (env.TAG_NAME =~ /^ci-test-snapshot.*$/)
 
 pipeline {
     agent {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                         id: 'deployer',
                         serverId: 'R3-Artifactory',
 //                        repo: isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'
-                        repo: isRelease ? 'testing-ci-uploads-releases' : 'testing-ci-uploads-dev'
+                        repo: isRelease ? 'testing-ci-uploads-release' : 'testing-ci-uploads-dev'
                 )
                 rtGradleRun(
                         usesPlugin: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -18,7 +18,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
  */
 //boolean isRelease = (env.TAG_NAME =~ /^release\/.+$/)
 boolean isRelease = (env.TAG_NAME =~ /^ci-test-release.*$/)
-boolean isSnapshot = (env.BRANCH_NAME =~ /^master$/)
+boolean isSnapshot = (env.BRANCH_NAME =~ /^ci-test-snapshot.*$/)
 
 pipeline {
     agent {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
         stage('Build DJVM Example') {
             steps {
-                sh "cd djvm-example && ./gradlew --daemon --no-build-cache clean build"
+                sh "cd djvm-example && ./gradlew --daemon --no-build-cache clean build && cd .."
             }
         }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,105 @@
+#!groovy
+/**
+ * Jenkins pipeline to build Corda Enterprise Network Services
+ */
+
+/**
+ * Kill already started job.
+ * Assume new commit takes precendence and results from previous
+ * unfinished builds are not required.
+ * This feature doesn't play well with disableConcurrentBuilds() option
+ */
+@Library('existing-build-control')
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+/**
+ * Sense environment
+ */
+// boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
+// boolean isRelease = (env.TAG_NAME =~ /^release_.*/)
+
+pipeline {
+    agent {
+        label 'k8s'
+    }
+
+//     parameters {
+//         booleanParam defaultValue: (isReleaseBranch || isRelease), description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
+//     }
+
+    options {
+        timestamps()
+        buildDiscarder(logRotator(daysToKeepStr: '7', artifactDaysToKeepStr: '7'))
+        disableConcurrentBuilds()
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    environment {
+        DOCKER_TAG_TO_USE = "${env.GIT_COMMIT.subSequence(0, 8)}"
+        EXECUTOR_NUMBER = "${env.EXECUTOR_NUMBER}"
+        BUILD_ID = "${env.BUILD_ID}-${env.JOB_NAME}"
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        ARTIFACTORY_BUILD_NAME = "DJVM / Publish / Publish to Artifactory".replaceAll("/", "::")
+    }
+
+    stages {
+
+        stage('Build DJVM') {
+            steps {
+                sh "./gradlew --daemon --no-build-cache clean build"
+            }
+        }
+
+        stage('Build DJVM Example') {
+            steps {
+                sh "./gradlew --daemon --no-build-cache clean build"
+            }
+        }
+
+        stage('Publish to Artifactory') {
+//            when {
+//                expression { params.DO_PUBLISH }
+//                beforeAgent true
+//            }
+
+            // only publish on commits to master
+            // do not publish on pr
+
+            steps {
+                rtServer(
+                        id: 'R3-Artifactory',
+                        url: 'https://software.r3.com/artifactory',
+                        credentialsId: 'artifactory-credentials'
+                )
+                rtGradleDeployer(
+                        id: 'deployer',
+                        serverId: 'R3-Artifactory',
+                        repo: 'r3-tools-dev'
+//                        repo: isRelease ? 'r3-corda-releases' : 'r3-corda-dev'
+                )
+                rtGradleRun(
+                        usesPlugin: true,
+                        useWrapper: true,
+                        switches: '-s --info',
+                        tasks: 'artifactoryPublish',
+                        deployerId: 'deployer',
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+                )
+                rtPublishBuildInfo(
+                        serverId: 'R3-Artifactory',
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+                )
+            }
+        }
+    }
+
+    post {
+        always {
+            junit testResults: '**/build/test-results/**/*.xml', allowEmptyResults: true
+        }
+        cleanup {
+            deleteDir() /* clean up our workspace */
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
 kotlin.incremental=true
 
-corda_djvm_version=1.2-SNAPSHOT
+corda_djvm_version=1.2
 deterministic_rt_version=1.0-RC02
 
 corda_version=4.5-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
 kotlin.incremental=true
 
-corda_djvm_version=1.2
+corda_djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
 
 corda_version=4.5-SNAPSHOT


### PR DESCRIPTION
### Changes
This PR adds the Jenkinsfile necessary to migrate the TeamCity DJVM build to Jenkins. There are currently two TeamCity jobs configured for master and PR builds.

https://ci-master.corda.r3cev.com/project/CordaEnterprise_Sgx_Djvm?

Non-PR builds trigger publication to Artifactory.

Making a tag starting with `release/` publishes to `corda-dependencies` in Artifactory. Non-releases i.e. SNAPSHOTs will be published to `corda-dependencies-dev`.

https://ci01.dev.r3.com/job/DJVM/
