### PR TITLE
CORDA-3870: Upgrade libraries for 1.2

### DIFF
--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -4,12 +4,12 @@ kotlin.incremental=true
 
 djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
-corda_version=4.5-SNAPSHOT
+corda_version=4.6-SNAPSHOT
 corda_tokens_version=1.1
 
 kotlin_version=1.3.72
-scala_version=2.13.1
-assertj_version=3.15.0
-junit_jupiter_version=5.6.0
-log4j_version=2.13.1
+scala_version=2.13.3
+assertj_version=3.16.1
+junit_jupiter_version=5.6.2
+log4j_version=2.13.3
 slf4j_version=1.7.26

--- a/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
+++ b/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
@@ -1,13 +1,7 @@
 package com.example.testing
 
-import java.security.MessageDigest
 import java.util.function.Function
 
-final class BadScalaTask extends Function[Array[Byte], String] {
-    override def apply(input: Array[Byte]): String = {
-        MessageDigest.getInstance("SHA-256")
-            .digest(input)
-            .map("%02x" format _)
-            .mkString
-    }
+final class BadScalaTask extends Function[String, Long] {
+    override def apply(input: String): Long = getClass().getField(input).getLong(this)
 }

--- a/djvm-example/src/main/scala/com/example/testing/ScalaDigestTask.scala
+++ b/djvm-example/src/main/scala/com/example/testing/ScalaDigestTask.scala
@@ -1,0 +1,13 @@
+package com.example.testing
+
+import java.security.MessageDigest
+import java.util.function.Function
+
+final class ScalaDigestTask extends Function[Array[Byte], String] {
+    override def apply(input: Array[Byte]): String = {
+        MessageDigest.getInstance("SHA-256")
+            .digest(input)
+            .map("%02x" format _)
+            .mkString
+    }
+}

--- a/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
@@ -20,12 +20,19 @@ class ScalaSandboxTest : TestBase(KOTLIN) {
     }
 
     @Test
+    fun testDigestTask() = sandbox {
+        val taskFactory = classLoader.createTypedTaskFactory()
+        val digest = taskFactory.create(ScalaDigestTask::class.java).apply("Secret Message!".toByteArray())
+        assertEquals("1bf7aa187ccdf0082f99593371a2f4cd0a4f9dc9a30e867d5ad48b9971a95f53", digest)
+    }
+
+    @Test
     fun testBadTask() = sandbox {
         val taskFactory = classLoader.createTypedTaskFactory()
         val ex = assertThrows<RuleViolationError> {
-            taskFactory.create(BadScalaTask::class.java).apply("Secret Message!".toByteArray())
+            taskFactory.create(BadScalaTask::class.java).apply("name")
         }
         assertThat(ex)
-            .hasMessageContaining("Disallowed reference to API; java.lang.invoke.MethodHandleImpl\$1.run()")
+            .hasMessageContaining("Disallowed reference to API; java.lang.Class.getField(String)")
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -604,7 +604,7 @@ open class ClassAndMemberVisitor(
         /**
          * The API version of ASM.
          */
-        const val API_VERSION: Int = Opcodes.ASM7
+        const val API_VERSION: Int = Opcodes.ASM8
 
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ kotlin.incremental=true
 corda_djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
 
-corda_version=4.5-SNAPSHOT
+corda_version=4.6-SNAPSHOT
 corda_plugins_version=5.0.8
 
-asm_version=7.3.1
-assertj_version=3.15.0
-class_graph_version=4.8.65
+asm_version=8.0.1
+assertj_version=3.16.1
+class_graph_version=4.8.78
 bouncycastle_version=1.65
 jcabi_manifests_version=1.1
 jopt_simple_version=5.0.2
-junit_jupiter_version=5.6.0
+junit_jupiter_version=5.6.2
 kotlin_version=1.2.71
-log4j_version=2.13.1
+log4j_version=2.13.3
 picocli_version=3.9.6
 slf4j_version=1.7.26


### PR DESCRIPTION
Upgrade the following libraries for the DJVM:
- ASM 7.3.1 → 8.0.1
- Log4J2 2.13.1 → 2.13.3
- AssertJ 3.15.0 → 3.16.1
- ClassGraph 4.8.65 → 4.8.78

Example project:
- Corda 4.5-SNAPSHOT → 4.6-SNAPSHOT
- Kotlin 1.3.70 → 1.3.72
- Scala 2.13.1 → 2.13.3
- JUnit Jupiter 5.6.0 → 5.6.2