### PR TITLE
CORDA-3911: Optimise DefinitionProvider passes by using immutable objects.

### DIFF
--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -213,7 +213,7 @@ publish {
     dependenciesFrom(configurations.shadow) {
         defaultScope = 'compile'
     }
-    name 'corda-djvm'
+    name = 'corda-djvm'
 }
 
 idea {

--- a/djvm/cli/build.gradle
+++ b/djvm/cli/build.gradle
@@ -66,5 +66,5 @@ publish {
     dependenciesFrom configurations.shadow
     publishSources = false
     publishJavadoc = false
-    name shadowZip.flatMap { it.archiveBaseName }
+    name = shadowZip.flatMap { it.archiveBaseName }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -223,7 +223,7 @@ open class ClassAndMemberVisitor(
                 interfaces: Array<String>?
         ) {
             val superClassName = superName ?: ""
-            val interfaceNames = interfaces?.toMutableList() ?: mutableListOf()
+            val interfaceNames = interfaces?.toList() ?: emptyList()
             ClassRepresentation(version, access, name, superClassName, interfaceNames, genericsDetails = signature ?: "").also {
                 currentClass = it
                 currentMember = null

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -300,7 +300,7 @@ open class ClassAndMemberVisitor(
                 memberName = name,
                 descriptor = desc,
                 genericsDetails = signature ?: "",
-                exceptions = exceptions?.toMutableSet() ?: mutableSetOf()
+                exceptions = exceptions?.toSet() ?: emptySet()
             )
             currentMember = member
             sourceLocation = sourceLocation.copy(

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/SewingKit.kt
@@ -10,6 +10,8 @@ import org.objectweb.asm.Opcodes.ACC_BRIDGE
 import org.objectweb.asm.Opcodes.ACC_FINAL
 import org.objectweb.asm.Opcodes.ACC_PROTECTED
 import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
+import java.util.Collections.unmodifiableList
+import java.util.Collections.unmodifiableSet
 
 @CordaInternal
 open class MethodBuilder(
@@ -37,8 +39,8 @@ open class MethodBuilder(
         memberName = memberName,
         descriptor = descriptor,
         genericsDetails = signature,
-        exceptions = exceptions.toMutableSet(),
-        body = bodies
+        exceptions = unmodifiableSet(exceptions),
+        body = unmodifiableList(bodies)
     )
 }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/code/ClassDefinitionProvider.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/ClassDefinitionProvider.kt
@@ -1,7 +1,7 @@
 package net.corda.djvm.code
 
 import net.corda.djvm.analysis.AnalysisRuntimeContext
-import net.corda.djvm.references.ClassRepresentation
+import net.corda.djvm.references.ImmutableClass
 
 /**
  * A class definition provider is a hook for [ClassMutator], from where one can modify the name and meta-data of
@@ -17,6 +17,6 @@ interface ClassDefinitionProvider : DefinitionProvider {
      *
      * @return The updated class definition, or [clazz] if no changes are desired.
      */
-    fun define(context: AnalysisRuntimeContext, clazz: ClassRepresentation): ClassRepresentation
+    fun define(context: AnalysisRuntimeContext, clazz: ImmutableClass): ImmutableClass
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
@@ -4,6 +4,8 @@ import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.ClassAndMemberVisitor
 import net.corda.djvm.code.instructions.MethodEntry
 import net.corda.djvm.references.ClassRepresentation
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.references.Member
 import net.corda.djvm.references.MethodBody
 import net.corda.djvm.utilities.loggerFor
@@ -68,18 +70,18 @@ class ClassMutator(
      * of the class itself.
      */
     override fun visitClass(clazz: ClassRepresentation): ClassRepresentation {
-        var resultingClass = clazz
+        var resultingClass: ImmutableClass = clazz
         processEntriesOfType<ClassDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingClass = it.define(currentAnalysisContext(), resultingClass)
         })
-        if (clazz != resultingClass) {
+        if (clazz !== resultingClass) {
             logger.trace("Type has been mutated {}", clazz)
             setModified()
         }
         if (clazz.access and ACC_ANNOTATION != 0) {
             setAnnotation()
         }
-        return super.visitClass(resultingClass)
+        return super.visitClass(resultingClass as ClassRepresentation)
     }
 
     /**
@@ -110,15 +112,15 @@ class ClassMutator(
      * of a class member.
      */
     override fun visitMethod(clazz: ClassRepresentation, method: Member): Member {
-        var resultingMethod = method
+        var resultingMethod: ImmutableMember = method
         processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingMethod = it.define(currentAnalysisContext(), resultingMethod)
         })
-        if (method != resultingMethod) {
+        if (method !== resultingMethod) {
             logger.trace("Method has been mutated {}", method)
             setModified()
         }
-        return super.visitMethod(clazz, resultingMethod)
+        return super.visitMethod(clazz, resultingMethod as Member)
     }
 
     /**
@@ -126,16 +128,16 @@ class ClassMutator(
      * of a class member.
      */
     override fun visitField(clazz: ClassRepresentation, field: Member): Member {
-        var resultingField = field
+        var resultingField: ImmutableMember = field
         processEntriesOfType<MemberDefinitionProvider>(definitionProviders, analysisContext.messages, Consumer {
             resultingField = it.define(currentAnalysisContext(), resultingField)
         })
-        if (field != resultingField) {
+        if (field !== resultingField) {
             logger.trace("Field has been mutated {}", field)
             initializers += resultingField.body
             setModified()
         }
-        return super.visitField(clazz, resultingField)
+        return super.visitField(clazz, resultingField as Member)
     }
 
     /**

--- a/djvm/src/main/kotlin/net/corda/djvm/code/MemberDefinitionProvider.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/MemberDefinitionProvider.kt
@@ -1,7 +1,7 @@
 package net.corda.djvm.code
 
 import net.corda.djvm.analysis.AnalysisRuntimeContext
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 
 /**
  * A member definition provider is a hook for [ClassMutator], from where one can modify the name and meta-data of
@@ -17,6 +17,6 @@ interface MemberDefinitionProvider : DefinitionProvider {
      *
      * @return The updated member definition, or [member] if no changes are desired.
      */
-    fun define(context: AnalysisRuntimeContext, member: Member): Member
+    fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/references/ClassInformation.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/ClassInformation.kt
@@ -1,0 +1,6 @@
+package net.corda.djvm.references
+
+interface ClassInformation {
+    val isInterface: Boolean
+    val hasObjectAsSuperclass: Boolean
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/references/ClassRepresentation.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/ClassRepresentation.kt
@@ -1,6 +1,5 @@
 package net.corda.djvm.references
 
-import net.corda.djvm.CordaInternal
 import net.corda.djvm.code.OBJECT_NAME
 import java.lang.reflect.Modifier
 
@@ -34,10 +33,31 @@ data class ClassRepresentation(
     override val hasObjectAsSuperclass: Boolean
         get() = superClass.isEmpty() || superClass == OBJECT_NAME
 
-    override fun toMutable(): ClassCopier = ClassCopier(this)
+    override fun toMutable(): Copier = Copier()
+
+    inner class Copier {
+        fun copy(
+            apiVersion: Int = this@ClassRepresentation.apiVersion,
+            access: Int = this@ClassRepresentation.access,
+            name: String = this@ClassRepresentation.name,
+            superClass: String = this@ClassRepresentation.superClass,
+            interfaces: List<String> = this@ClassRepresentation.interfaces,
+            sourceFile: String = this@ClassRepresentation.sourceFile,
+            genericsDetails: String = this@ClassRepresentation.genericsDetails
+        ): ImmutableClass = ClassRepresentation(
+            apiVersion = apiVersion,
+            access = access,
+            name = name,
+            superClass = superClass,
+            interfaces = interfaces,
+            sourceFile = sourceFile,
+            genericsDetails = genericsDetails,
+            members = this@ClassRepresentation.members,
+            annotations = this@ClassRepresentation.annotations
+        )
+    }
 }
 
-@CordaInternal
 interface ImmutableClass : ClassInformation {
     val apiVersion: Int
     val access: Int
@@ -47,26 +67,5 @@ interface ImmutableClass : ClassInformation {
     var sourceFile: String
     val genericsDetails: String
 
-    fun toMutable(): ClassCopier
-}
-
-@CordaInternal
-class ClassCopier internal constructor(private val clazz: ClassRepresentation) {
-    fun copy(
-        apiVersion: Int = clazz.apiVersion,
-        access: Int = clazz.access,
-        name: String = clazz.name,
-        superClass: String = clazz.superClass,
-        interfaces: List<String> = clazz.interfaces,
-        sourceFile: String = clazz.sourceFile,
-        genericsDetails: String = clazz.genericsDetails
-    ): ClassRepresentation = clazz.copy(
-        apiVersion = apiVersion,
-        access = access,
-        name = name,
-        superClass = superClass,
-        interfaces = interfaces,
-        sourceFile = sourceFile,
-        genericsDetails = genericsDetails
-    )
+    fun toMutable(): ClassRepresentation.Copier
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/references/ClassRepresentation.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/ClassRepresentation.kt
@@ -21,7 +21,7 @@ data class ClassRepresentation(
         override val access: Int,
         val name: String,
         val superClass: String = "",
-        val interfaces: List<String> = listOf(),
+        val interfaces: List<String> = emptyList(),
         var sourceFile: String = "",
         val genericsDetails: String = "",
         val members: MutableMap<String, Member> = mutableMapOf(),

--- a/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
@@ -32,7 +32,7 @@ data class Member(
     override val descriptor: String,
     val genericsDetails: String,
     val annotations: MutableSet<String> = mutableSetOf(),
-    val exceptions: MutableSet<String> = mutableSetOf(),
+    val exceptions: Set<String> = emptySet(),
     val value: Any? = null,
     val body: List<MethodBody> = emptyList(),
     val runtimeContext: MutableMap<Emitter, Any> = mutableMapOf()

--- a/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
@@ -30,10 +30,49 @@ data class Member(
     override val className: String,
     override val memberName: String,
     override val descriptor: String,
-    val genericsDetails: String,
+    override val genericsDetails: String,
     val annotations: MutableSet<String> = mutableSetOf(),
-    val exceptions: Set<String> = emptySet(),
-    val value: Any? = null,
-    val body: List<MethodBody> = emptyList(),
+    override val exceptions: Set<String> = emptySet(),
+    override val value: Any? = null,
+    override val body: List<MethodBody> = emptyList(),
     val runtimeContext: MutableMap<Emitter, Any> = mutableMapOf()
-) : MemberInformation, EntityWithAccessFlag
+) : ImmutableMember, EntityWithAccessFlag {
+    override fun toMutable() = MemberCopier(this)
+}
+
+@CordaInternal
+interface ImmutableMember : MemberInformation {
+    val access: Int
+    override val className: String
+    override val memberName: String
+    override val descriptor: String
+    val genericsDetails: String
+    val exceptions: Set<String>
+    val value: Any?
+    val body: List<MethodBody>
+
+    fun toMutable(): MemberCopier
+}
+
+@CordaInternal
+class MemberCopier internal constructor(private val member: Member) {
+    fun copy(
+        access: Int = member.access,
+        className: String = member.className,
+        memberName: String = member.memberName,
+        descriptor: String = member.descriptor,
+        genericsDetails: String = member.genericsDetails,
+        exceptions: Set<String> = member.exceptions,
+        value: Any? = member.value,
+        body: List<MethodBody> = member.body
+    ): Member = member.copy(
+        access = access,
+        className = className,
+        memberName = memberName,
+        descriptor = descriptor,
+        genericsDetails = genericsDetails,
+        exceptions = exceptions,
+        value = value,
+        body = body
+    )
+}

--- a/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/references/Member.kt
@@ -37,7 +37,32 @@ data class Member(
     override val body: List<MethodBody> = emptyList(),
     val runtimeContext: MutableMap<Emitter, Any> = mutableMapOf()
 ) : ImmutableMember, EntityWithAccessFlag {
-    override fun toMutable() = MemberCopier(this)
+    override fun toMutable(): Copier = Copier()
+
+    @CordaInternal
+    inner class Copier {
+        fun copy(
+            access: Int = this@Member.access,
+            className: String = this@Member.className,
+            memberName: String = this@Member.memberName,
+            descriptor: String = this@Member.descriptor,
+            genericsDetails: String = this@Member.genericsDetails,
+            exceptions: Set<String> = this@Member.exceptions,
+            value: Any? = this@Member.value,
+            body: List<MethodBody> = this@Member.body
+        ): ImmutableMember = Member(
+            access = access,
+            className = className,
+            memberName = memberName,
+            descriptor = descriptor,
+            genericsDetails = genericsDetails,
+            annotations = this@Member.annotations,
+            exceptions = exceptions,
+            value = value,
+            body = body,
+            runtimeContext = this@Member.runtimeContext
+        )
+    }
 }
 
 @CordaInternal
@@ -51,28 +76,5 @@ interface ImmutableMember : MemberInformation {
     val value: Any?
     val body: List<MethodBody>
 
-    fun toMutable(): MemberCopier
-}
-
-@CordaInternal
-class MemberCopier internal constructor(private val member: Member) {
-    fun copy(
-        access: Int = member.access,
-        className: String = member.className,
-        memberName: String = member.memberName,
-        descriptor: String = member.descriptor,
-        genericsDetails: String = member.genericsDetails,
-        exceptions: Set<String> = member.exceptions,
-        value: Any? = member.value,
-        body: List<MethodBody> = member.body
-    ): Member = member.copy(
-        access = access,
-        className = className,
-        memberName = memberName,
-        descriptor = descriptor,
-        genericsDetails = genericsDetails,
-        exceptions = exceptions,
-        value = value,
-        body = body
-    )
+    fun toMutable(): Member.Copier
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/ClassRule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/ClassRule.kt
@@ -1,8 +1,8 @@
 package net.corda.djvm.rules
 
 import net.corda.djvm.code.Instruction
-import net.corda.djvm.references.ClassRepresentation
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.validation.RuleContext
 
 /**
@@ -16,9 +16,9 @@ abstract class ClassRule : Rule {
      * @param context The context in which the rule is to be validated.
      * @param clazz The class to apply and validate this rule against.
      */
-    abstract fun validate(context: RuleContext, clazz: ClassRepresentation)
+    abstract fun validate(context: RuleContext, clazz: ImmutableClass)
 
-    final override fun validate(context: RuleContext, clazz: ClassRepresentation?, member: Member?, instruction: Instruction?) {
+    final override fun validate(context: RuleContext, clazz: ImmutableClass?, member: ImmutableMember?, instruction: Instruction?) {
         // Only run validation step if applied to the class itself.
         if (clazz != null && member == null && instruction == null) {
             validate(context, clazz)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/InstructionRule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/InstructionRule.kt
@@ -1,8 +1,8 @@
 package net.corda.djvm.rules
 
 import net.corda.djvm.code.Instruction
-import net.corda.djvm.references.ClassRepresentation
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.validation.RuleContext
 
 /**
@@ -18,7 +18,7 @@ abstract class InstructionRule : Rule {
      */
     abstract fun validate(context: RuleContext, instruction: Instruction)
 
-    final override fun validate(context: RuleContext, clazz: ClassRepresentation?, member: Member?, instruction: Instruction?) {
+    final override fun validate(context: RuleContext, clazz: ImmutableClass?, member: ImmutableMember?, instruction: Instruction?) {
         // Only run validation step if applied to the class member itself.
         if (clazz != null && member != null && instruction != null) {
             validate(context, instruction)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/MemberRule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/MemberRule.kt
@@ -1,8 +1,8 @@
 package net.corda.djvm.rules
 
 import net.corda.djvm.code.Instruction
-import net.corda.djvm.references.ClassRepresentation
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.validation.RuleContext
 
 /**
@@ -16,9 +16,9 @@ abstract class MemberRule : Rule {
      * @param context The context in which the rule is to be validated.
      * @param member The class member to apply and validate this rule against.
      */
-    abstract fun validate(context: RuleContext, member: Member)
+    abstract fun validate(context: RuleContext, member: ImmutableMember)
 
-    final override fun validate(context: RuleContext, clazz: ClassRepresentation?, member: Member?, instruction: Instruction?) {
+    final override fun validate(context: RuleContext, clazz: ImmutableClass?, member: ImmutableMember?, instruction: Instruction?) {
         // Only run validation step if applied to the class member itself.
         if (clazz != null && member != null && instruction == null) {
             validate(context, member)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/Rule.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/Rule.kt
@@ -1,8 +1,8 @@
 package net.corda.djvm.rules
 
 import net.corda.djvm.code.Instruction
-import net.corda.djvm.references.ClassRepresentation
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.validation.RuleContext
 
 /**
@@ -19,6 +19,6 @@ interface Rule {
      * @param member The class member to apply and validate this rule against, if any.
      * @param instruction The instruction to apply and validate this rule against, if any.
      */
-    fun validate(context: RuleContext, clazz: ClassRepresentation?, member: Member?, instruction: Instruction?)
+    fun validate(context: RuleContext, clazz: ImmutableClass?, member: ImmutableMember?, instruction: Instruction?)
 
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysInheritFromSandboxedObject.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysInheritFromSandboxedObject.kt
@@ -4,7 +4,7 @@ import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.*
 import net.corda.djvm.code.instructions.MemberAccessInstruction
 import net.corda.djvm.code.instructions.TypeInstruction
-import net.corda.djvm.references.ClassRepresentation
+import net.corda.djvm.references.ImmutableClass
 import org.objectweb.asm.Opcodes
 
 /**
@@ -14,9 +14,9 @@ import org.objectweb.asm.Opcodes
 object AlwaysInheritFromSandboxedObject : ClassDefinitionProvider, Emitter {
     private val SIGNATURE = "^(<.*>)?Ljava/lang/Object;(.*)$".toRegex()
 
-    override fun define(context: AnalysisRuntimeContext, clazz: ClassRepresentation) = when {
+    override fun define(context: AnalysisRuntimeContext, clazz: ImmutableClass): ImmutableClass = when {
         isDirectSubClassOfObject(context.clazz) ->
-            clazz.copy(
+            clazz.toMutable().copy(
                 superClass = SANDBOX_OBJECT_NAME,
                 genericsDetails = mapToSandboxObject(clazz.genericsDetails)
             )
@@ -52,7 +52,7 @@ object AlwaysInheritFromSandboxedObject : ClassDefinitionProvider, Emitter {
         }
     }
 
-    private fun isDirectSubClassOfObject(clazz: ClassRepresentation): Boolean {
+    private fun isDirectSubClassOfObject(clazz: ImmutableClass): Boolean {
         // Check if the super class is java.lang.Object.
         return !clazz.isInterface && clazz.hasObjectAsSuperclass
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
@@ -20,7 +20,7 @@ object AlwaysUseNonSynchronizedMethods : MemberRule(), MemberDefinitionProvider 
         }
     }
 
-    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember) = when {
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
         member.isMethod && isConcrete(context.clazz) -> member.toMutable().copy(access = member.access and ACC_SYNCHRONIZED.inv())
         else -> member
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseNonSynchronizedMethods.kt
@@ -3,7 +3,7 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.MemberDefinitionProvider
 import net.corda.djvm.references.EntityWithAccessFlag
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.rules.MemberRule
 import net.corda.djvm.validation.RuleContext
 import org.objectweb.asm.Opcodes.ACC_SYNCHRONIZED
@@ -14,14 +14,14 @@ import java.lang.reflect.Modifier
  */
 object AlwaysUseNonSynchronizedMethods : MemberRule(), MemberDefinitionProvider {
 
-    override fun validate(context: RuleContext, member: Member) = context.validate {
+    override fun validate(context: RuleContext, member: ImmutableMember) = context.validate {
         if (member.isMethod && isConcrete(context.clazz)) {
             trace("Synchronization specifier will be ignored") given ((member.access and ACC_SYNCHRONIZED) == 0)
         }
     }
 
-    override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        member.isMethod && isConcrete(context.clazz) -> member.copy(access = member.access and ACC_SYNCHRONIZED.inv())
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember) = when {
+        member.isMethod && isConcrete(context.clazz) -> member.toMutable().copy(access = member.access and ACC_SYNCHRONIZED.inv())
         else -> member
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
@@ -3,7 +3,7 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.MemberDefinitionProvider
 import net.corda.djvm.references.EntityWithAccessFlag
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.rules.MemberRule
 import net.corda.djvm.validation.RuleContext
 import org.objectweb.asm.Opcodes.ACC_STRICT
@@ -16,14 +16,14 @@ import java.lang.reflect.Modifier
  */
 object AlwaysUseStrictFloatingPointArithmetic : MemberRule(), MemberDefinitionProvider {
 
-    override fun validate(context: RuleContext, member: Member) = context.validate {
+    override fun validate(context: RuleContext, member: ImmutableMember) = context.validate {
         if (member.isMethod && isConcrete(context.clazz)) {
             trace("Strict floating-point arithmetic will be applied") given ((member.access and ACC_STRICT) == 0)
         }
     }
 
-    override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        member.isMethod && isConcrete(context.clazz) -> member.copy(access = member.access or ACC_STRICT)
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember) = when {
+        member.isMethod && isConcrete(context.clazz) -> member.toMutable().copy(access = member.access or ACC_STRICT)
         else -> member
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/AlwaysUseStrictFloatingPointArithmetic.kt
@@ -22,7 +22,7 @@ object AlwaysUseStrictFloatingPointArithmetic : MemberRule(), MemberDefinitionPr
         }
     }
 
-    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember) = when {
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
         member.isMethod && isConcrete(context.clazz) -> member.toMutable().copy(access = member.access or ACC_STRICT)
         else -> member
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowOverriddenSandboxPackage.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowOverriddenSandboxPackage.kt
@@ -1,6 +1,6 @@
 package net.corda.djvm.rules.implementation
 
-import net.corda.djvm.references.ClassRepresentation
+import net.corda.djvm.references.ImmutableClass
 import net.corda.djvm.rules.ClassRule
 import net.corda.djvm.validation.RuleContext
 
@@ -9,7 +9,7 @@ import net.corda.djvm.validation.RuleContext
  */
 object DisallowOverriddenSandboxPackage : ClassRule() {
 
-    override fun validate(context: RuleContext, clazz: ClassRepresentation) = context.validate {
+    override fun validate(context: RuleContext, clazz: ImmutableClass) = context.validate {
         fail("Cannot load class explicitly defined in the 'sandbox' root package; ${clazz.name}") given
                 isSandboxClass(clazz.name)
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowSandboxMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowSandboxMethods.kt
@@ -1,7 +1,7 @@
 package net.corda.djvm.rules.implementation
 
 import net.corda.djvm.code.FROM_DJVM
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import net.corda.djvm.rules.MemberRule
 import net.corda.djvm.validation.RuleContext
 
@@ -10,7 +10,7 @@ import net.corda.djvm.validation.RuleContext
  * [sandbox.java.lang.Object] which are specific to the DJVM.
  */
 object DisallowSandboxMethods : MemberRule() {
-    override fun validate(context: RuleContext, member: Member) = context.validate {
+    override fun validate(context: RuleContext, member: ImmutableMember) = context.validate {
         fail("Class is not allowed to implement toDJVMString()") given (
             member.memberName == "toDJVMString" && member.descriptor == "()Ljava/lang/String;"
         )

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowUnsupportedApiVersions.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/DisallowUnsupportedApiVersions.kt
@@ -1,6 +1,6 @@
 package net.corda.djvm.rules.implementation
 
-import net.corda.djvm.references.ClassRepresentation
+import net.corda.djvm.references.ImmutableClass
 import net.corda.djvm.rules.ClassRule
 import net.corda.djvm.validation.RuleContext
 import org.objectweb.asm.Opcodes.*
@@ -10,7 +10,7 @@ import org.objectweb.asm.Opcodes.*
  */
 object DisallowUnsupportedApiVersions : ClassRule() {
 
-    override fun validate(context: RuleContext, clazz: ClassRepresentation) = context.validate {
+    override fun validate(context: RuleContext, clazz: ImmutableClass) = context.validate {
         fail("Unsupported Java API version '${versionString(clazz.apiVersion)}'") given
                 (clazz.apiVersion !in supportedVersions)
     }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StaticConstantRemover.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StaticConstantRemover.kt
@@ -4,7 +4,7 @@ import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.DJVM_NAME
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.MemberDefinitionProvider
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 
 /**
  * Removes static constant objects that are initialised directly in the byte-code.
@@ -12,14 +12,14 @@ import net.corda.djvm.references.Member
  */
 object StaticConstantRemover : MemberDefinitionProvider {
 
-    override fun define(context: AnalysisRuntimeContext, member: Member): Member = when {
-        isConstantField(member) -> member.copy(body = listOf(StringFieldInitializer(member)::writeInitializer), value = null)
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
+        isConstantField(member) -> member.toMutable().copy(body = listOf(StringFieldInitializer(member)::writeInitializer), value = null)
         else -> member
     }
 
-    private fun isConstantField(member: Member): Boolean = member.value != null && member.descriptor == "Ljava/lang/String;"
+    private fun isConstantField(member: ImmutableMember): Boolean = member.value != null && member.descriptor == "Ljava/lang/String;"
 
-    class StringFieldInitializer(private val member: Member) {
+    class StringFieldInitializer(private val member: ImmutableMember) {
         fun writeInitializer(emitter: EmitterModule): Unit = with(emitter) {
             val value = member.value ?: return
             loadConstant(value)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutFinalizerMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutFinalizerMethods.kt
@@ -3,7 +3,7 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.MemberDefinitionProvider
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import java.lang.reflect.Modifier
 
 /**
@@ -11,13 +11,13 @@ import java.lang.reflect.Modifier
  */
 object StubOutFinalizerMethods : MemberDefinitionProvider {
 
-    override fun define(context: AnalysisRuntimeContext, member: Member) = when {
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
         /**
          * Discard any other method body and replace with stub that just returns.
          * Other [MemberDefinitionProvider]s are expected to append to this list
          * and not replace its contents!
          */
-        isFinalizer(member) -> member.copy(body = listOf(::writeMethodBody))
+        isFinalizer(member) -> member.toMutable().copy(body = listOf(::writeMethodBody))
         else -> member
     }
 
@@ -28,7 +28,7 @@ object StubOutFinalizerMethods : MemberDefinitionProvider {
     /**
      * No need to rewrite [Object.finalize] or [Enum.finalize]; ignore these.
      */
-    private fun isFinalizer(member: Member): Boolean
+    private fun isFinalizer(member: ImmutableMember): Boolean
         = member.memberName == "finalize" && member.descriptor == "()V"
             && !member.className.startsWith("java/lang/")
             && !Modifier.isAbstract(member.access)

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutIntrospectiveMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutIntrospectiveMethods.kt
@@ -2,29 +2,29 @@ package net.corda.djvm.rules.implementation
 
 import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.MemberDefinitionProvider
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import org.objectweb.asm.Opcodes.*
 
 /**
  * Replace internal APIs with stubs that throw exceptions. Only for non-whitelisted classes.
  */
 object StubOutIntrospectiveMethods : MemberDefinitionProvider {
-    override fun define(context: AnalysisRuntimeContext, member: Member): Member = when {
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
         member.isMethod && isConcreteApi(member) && isIntrospective(member) && !isAllowedFor(context, member)
-             -> member.copy(body = member.body + MemberRuleEnforcer(member)::forbidAPI)
+             -> member.toMutable().copy(body = member.body + MemberRuleEnforcer(member)::forbidAPI)
         else -> member
     }
 
     // The method must be public and with a Java implementation.
-    private fun isConcreteApi(member: Member): Boolean = member.access and (ACC_PUBLIC or ACC_ABSTRACT or ACC_NATIVE) == ACC_PUBLIC
+    private fun isConcreteApi(member: ImmutableMember): Boolean = member.access and (ACC_PUBLIC or ACC_ABSTRACT or ACC_NATIVE) == ACC_PUBLIC
 
-    private fun isIntrospective(member: Member): Boolean {
+    private fun isIntrospective(member: ImmutableMember): Boolean {
         return member.className.startsWith("java/lang/invoke/")
                || member.className.startsWith("sun/reflect/")
                || member.className == "sun/misc/Unsafe"
     }
 
-    private fun isAllowedFor(context: AnalysisRuntimeContext, member: Member): Boolean {
+    private fun isAllowedFor(context: AnalysisRuntimeContext, member: ImmutableMember): Boolean {
         return context.configuration.getSourceHeader(member.className).isThrowable
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutNativeMethods.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rules/implementation/StubOutNativeMethods.kt
@@ -3,7 +3,7 @@ package net.corda.djvm.rules.implementation
 import net.corda.djvm.analysis.AnalysisRuntimeContext
 import net.corda.djvm.code.EmitterModule
 import net.corda.djvm.code.MemberDefinitionProvider
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableMember
 import org.objectweb.asm.Opcodes.*
 import java.lang.reflect.Modifier
 
@@ -12,8 +12,8 @@ import java.lang.reflect.Modifier
  */
 object StubOutNativeMethods : MemberDefinitionProvider {
 
-    override fun define(context: AnalysisRuntimeContext, member: Member) = when {
-        member.isMethod && isNative(member) -> member.copy(
+    override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember = when {
+        member.isMethod && isNative(member) -> member.toMutable().copy(
             access = member.access and ACC_NATIVE.inv(),
             body = member.body + if (isForStubbing(member)) ::writeStubMethodBody else MemberRuleEnforcer(member)::forbidNativeMethod
         )
@@ -24,7 +24,7 @@ object StubOutNativeMethods : MemberDefinitionProvider {
         returnVoid()
     }
 
-    private fun isForStubbing(member: Member): Boolean = member.descriptor == "()V" && member.memberName == "registerNatives"
+    private fun isForStubbing(member: ImmutableMember): Boolean = member.descriptor == "()V" && member.memberName == "registerNatives"
 
-    private fun isNative(member: Member): Boolean = Modifier.isNative(member.access)
+    private fun isNative(member: ImmutableMember): Boolean = Modifier.isNative(member.access)
 }

--- a/djvm/src/test/kotlin/net/corda/djvm/code/ClassMutatorTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/code/ClassMutatorTest.kt
@@ -3,8 +3,8 @@ package net.corda.djvm.code
 import net.corda.djvm.SandboxType.KOTLIN
 import net.corda.djvm.TestBase
 import net.corda.djvm.analysis.AnalysisRuntimeContext
-import net.corda.djvm.references.ClassRepresentation
-import net.corda.djvm.references.Member
+import net.corda.djvm.references.ImmutableClass
+import net.corda.djvm.references.ImmutableMember
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.objectweb.asm.Opcodes.ACC_STRICT
@@ -16,9 +16,9 @@ class ClassMutatorTest : TestBase(KOTLIN) {
     fun `can mutate class definition`() {
         var hasProvidedDefinition = false
         val definitionProvider = object : ClassDefinitionProvider {
-            override fun define(context: AnalysisRuntimeContext, clazz: ClassRepresentation): ClassRepresentation {
+            override fun define(context: AnalysisRuntimeContext, clazz: ImmutableClass): ImmutableClass {
                 hasProvidedDefinition = true
-                return clazz.copy(access = clazz.access or ACC_STRICT)
+                return clazz.toMutable().copy(access = clazz.access or ACC_STRICT)
             }
         }
         val context = context
@@ -39,9 +39,9 @@ class ClassMutatorTest : TestBase(KOTLIN) {
     fun `can mutate member definition`() {
         var hasProvidedDefinition = false
         val definitionProvider = object : MemberDefinitionProvider {
-            override fun define(context: AnalysisRuntimeContext, member: Member): Member {
+            override fun define(context: AnalysisRuntimeContext, member: ImmutableMember): ImmutableMember {
                 hasProvidedDefinition = true
-                return member.copy(access = member.access or ACC_STRICT)
+                return member.toMutable().copy(access = member.access or ACC_STRICT)
             }
         }
         val context = context


### PR DESCRIPTION
Create immutable views for the `ClassRepresentation` and `Member` objects and update the `DefinitionProvider` classes to use them. This ensures that the DJVM can detect whenever a `DefinitionProvider` mutates an object by comparing the identities of the input and output.

This change merely formalises the existing behaviour, but it also allows us to optimise `ClassMutator`'s `DefinitionProvider` passes over all classes, methods and fields.