### PR TITLE
NOTICK: Update CLI to pass null as unused input parameter into user function.

### DIFF
--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -56,7 +56,7 @@ abstract class ClassCommand : CommandBase() {
 
     private lateinit var classLoader: SourceClassLoader
 
-    protected lateinit var executor: SandboxExecutor<Any, Any>
+    protected lateinit var executor: SandboxExecutor<Any?, Any?>
         private set
 
     abstract fun processClasses(classes: List<Class<*>>)

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/RunCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/RunCommand.kt
@@ -26,7 +26,7 @@ class RunCommand : ClassCommand() {
                 return
             }
             printInfo("Running class ${clazz.name}...")
-            executor.run(ClassSource.fromClassName(clazz.name), Any()).apply {
+            executor.run(ClassSource.fromClassName(clazz.name), null).apply {
                 printResult(result)
                 printCosts(costs)
             }


### PR DESCRIPTION
The CLI tool allows a user to transform a Java class into sandbox code as follows:
```
$ djvm build <class-name>
$ djvm run <class-name>
```
where `<class-name>` is the name of a class that implements `java.util.function.Function<?, ?>`. The only input value which can safely be passed into all implementations of `Function<T,R>.apply(T)` is `null`.