### PR TITLE
NOTICK: Update configuration for shadow plugin.

### DIFF
--- a/djvm/bootstrap/build.gradle
+++ b/djvm/bootstrap/build.gradle
@@ -2,10 +2,15 @@ plugins {
     id 'base'
 }
 
+configurations {
+    bootstrap
+    it.'default'.extendsFrom bootstrap
+}
+
 /*
  * Configure this module's default configuration with the
  * shaded DJVM jar and its correct transitive dependencies.
  */
 dependencies {
-    'default' project(path: ':djvm', configuration: 'shadow')
+    bootstrap project(path: ':djvm', configuration: 'shadow')
 }

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -81,7 +81,8 @@ tasks.named('javadoc', Javadoc) {
 }
 
 def shadowJar = tasks.named('shadowJar', Jar) {
-    classifier ''
+    archiveBaseName = 'corda-djvm'
+    archiveClassifier = ''
     reproducibleFileOrder = true
     relocate 'org.objectweb.asm', 'djvm.org.objectweb.asm'
 
@@ -213,7 +214,7 @@ publish {
     dependenciesFrom(configurations.shadow) {
         defaultScope = 'compile'
     }
-    name = 'corda-djvm'
+    name = shadowJar.flatMap { it.archiveBaseName }
 }
 
 idea {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ deterministic_rt_version=1.0-RC02
 
 corda_version=4.6-SNAPSHOT
 corda_plugins_version=5.0.11
+shadow_plugin_version=5.2.0
 
 asm_version=8.0.1
 assertj_version=3.16.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.jvm' version kotlin_version
         id 'net.corda.plugins.publish-utils' version corda_plugins_version
         id 'net.corda.plugins.api-scanner' version corda_plugins_version
-        id 'com.github.johnrengelman.shadow' version '5.2.0'
+        id 'com.github.johnrengelman.shadow' version shadow_plugin_version
         id 'com.jfrog.artifactory' version '4.16.1'
         id 'com.jfrog.bintray' version '1.8.5'
         id 'org.owasp.dependencycheck' version '5.3.2.1'


### PR DESCRIPTION
Use `ShadowJar.archiveClassifier` now that it behaves correctly. This will make the Gradle build more consistent.