### PR TITLE
CORDA-3923: Remove all static fields from synthetic annotation classes.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/code/SyntheticAnnotationFactory.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/SyntheticAnnotationFactory.kt
@@ -4,6 +4,7 @@ import net.corda.djvm.analysis.AnalysisConfiguration
 import net.corda.djvm.analysis.ClassAndMemberVisitor.Companion.API_VERSION
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Type
 import org.objectweb.asm.TypePath
@@ -51,6 +52,11 @@ class SyntheticAnnotationFactory(
     }
 
     /**
+     * Drop all fields. This synthetic annotation will not use them.
+     */
+    override fun visitField(access: Int, name: String, descriptor: String, signature: String?, value: Any?): FieldVisitor? = null
+
+    /**
      * Drop these annotations because we aren't handling them - yet?
      */
     override fun visitTypeAnnotation(typeRef: Int, typePath: TypePath?, descriptor: String, visible: Boolean): AnnotationVisitor? = null
@@ -62,6 +68,11 @@ class SyntheticAnnotationFactory(
         signature: String?,
         exceptions: Array<out String>?
     ): MethodVisitor? {
+        if (name == CLASS_CONSTRUCTOR_NAME) {
+            // Drop any class initializer function.
+            return null
+        }
+
         val methodDescriptor = remapper.mapMethodDesc(descriptor)
         val mappedSignature = if (signature != null && methodDescriptor == "()Ljava/lang/Class;") {
             /*

--- a/djvm/src/test/java/net/corda/djvm/JavaAnnotationWithField.java
+++ b/djvm/src/test/java/net/corda/djvm/JavaAnnotationWithField.java
@@ -1,0 +1,35 @@
+package net.corda.djvm;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Arrays.asList;
+
+/*
+ * @sandbox.java.lang.annotation.Target$1DJVM({"TYPE", "CONSTRUCTOR", "METHOD", "FIELD", "PACKAGE})
+ * @sandbox.java.lang.annotation.Retention$1DJVM("RUNTIME")
+ * @Documented
+ * @Inherited
+ * interface sandbox.JavaAnnotationWithField {
+ *     sandbox.java.util.List<String> data = asList(DJVM.intern("Hello"), DJVM.intern("Sandbox"));
+ * }
+ *
+ * @Target({TYPE, CONSTRUCTOR, METHOD, FIELD, PACKAGE})
+ * @Retention(RUNTIME)
+ * @Documented
+ * @Inherited
+ * @interface sandbox.JavaAnnotation$1DJVM {
+ * }
+ */
+@Target({TYPE, CONSTRUCTOR, METHOD, FIELD, PACKAGE})
+@Retention(RUNTIME)
+@Documented
+@Inherited
+public @interface JavaAnnotationWithField {
+    List<String> data = asList("Hello", "Sandbox");
+}

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaClassTest.java
@@ -4,6 +4,7 @@ import net.corda.djvm.JavaAnnotation;
 import net.corda.djvm.JavaLabel;
 import net.corda.djvm.JavaLabels;
 import net.corda.djvm.JavaNestedAnnotations;
+import net.corda.djvm.JavaAnnotationWithField;
 import net.corda.djvm.TestBase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -292,6 +293,24 @@ class AnnotatedJavaClassTest extends TestBase {
         });
     }
 
+    @Test
+    void testAnnotationWithField() {
+        sandbox(ctx -> {
+            try {
+                Class<?> sandboxClass = loadClass(ctx, UserJavaAnnotationFieldData.class.getName()).getType();
+                @SuppressWarnings("unchecked")
+                Class<? extends Annotation> sandboxAnnotation
+                    = (Class<? extends Annotation>) loadClass(ctx, "sandbox.net.corda.djvm.JavaAnnotationWithField$1DJVM").getType();
+                Annotation annotationValue = sandboxClass.getAnnotation(sandboxAnnotation);
+                assertThat(annotationValue).isNotNull();
+                assertThat(annotationValue.toString())
+                    .isEqualTo("@sandbox.net.corda.djvm.JavaAnnotationWithField$1DJVM()");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
     static boolean isForSandbox(@NotNull Annotation annotation) {
         return annotation.annotationType().getName().startsWith("sandbox.");
     }
@@ -326,4 +345,8 @@ class AnnotatedJavaClassTest extends TestBase {
     @SuppressWarnings("WeakerAccess")
     @JavaLabel(name = "Child")
     static class InheritingJavaData extends BaseJavaData {}
+
+    @SuppressWarnings("WeakerAccess")
+    @JavaAnnotationWithField
+    static class UserJavaAnnotationFieldData {}
 }

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotationProxyJavaTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotationProxyJavaTest.java
@@ -4,6 +4,7 @@ import net.corda.djvm.JavaAnnotation;
 import net.corda.djvm.JavaAnnotationClassData;
 import net.corda.djvm.JavaAnnotationData;
 import net.corda.djvm.JavaAnnotationImpl;
+import net.corda.djvm.JavaAnnotationWithField;
 import net.corda.djvm.JavaInvisible;
 import net.corda.djvm.JavaLabel;
 import net.corda.djvm.JavaLabels;
@@ -655,6 +656,27 @@ class AnnotationProxyJavaTest extends TestBase {
         }
     }
 
+    @Test
+    void testAnnotationWithFieldInsideSandbox() {
+        sandbox(ctx -> {
+            try {
+                TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
+                String[] result = WithJava.run(taskFactory, ReadJavaAnnotationField.class, null);
+                assertThat(result).containsExactly("Hello", "Sandbox");
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    public static class ReadJavaAnnotationField implements Function<String, String[]> {
+        @Override
+        public String[] apply(String unused) {
+            JavaAnnotationWithField value = UserJavaAnnotationFieldData.class.getAnnotation(JavaAnnotationWithField.class);
+            return value == null ? null : value.data.toArray(new String[0]);
+        }
+    }
+
     @SuppressWarnings("WeakerAccess")
     @JavaAnnotation(MESSAGE)
     static class Data1 {}
@@ -742,4 +764,8 @@ class AnnotationProxyJavaTest extends TestBase {
     @SuppressWarnings("WeakerAccess")
     @JavaLabel(name = "Child")
     static class InheritingJavaData extends BaseJavaData {}
+
+    @SuppressWarnings("WeakerAccess")
+    @JavaAnnotationWithField
+    static class UserJavaAnnotationFieldData {}
 }


### PR DESCRIPTION
Annotations are interfaces, and so can also have `public static final` fields. These fields need to be deleted from the sandbox's synthetic `$1DJVM` annotations, along with any `<clinit>` function which initialises them.