### PR TITLE
CORDA-3925: Add support for multi-release JARs of source classes.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -15,6 +15,7 @@ import net.corda.djvm.references.ClassReference
 import net.corda.djvm.source.ClassSource
 import net.corda.djvm.source.CodeLocation
 import net.corda.djvm.source.SourceClassLoader
+import net.corda.djvm.source.unversioned
 import net.corda.djvm.utilities.loggerFor
 import net.corda.djvm.validation.RuleValidator
 import org.objectweb.asm.ClassReader
@@ -585,7 +586,7 @@ class SandboxClassLoader private constructor(
         return try {
             doPrivileged(PrivilegedExceptionAction {
                 val reader = try {
-                    resource.openStream().use(::ClassReader)
+                    resource.unversioned.openStream().use(::ClassReader)
                 } catch (e: IOException) {
                     throw ClassNotFoundException("Error reading source byte-code for $qualifiedClassName: ${e.message}")
                 }


### PR DESCRIPTION
Convert any multi-release Jar URL into an unversioned one to ensure that the DJVM only selects byte-code for Java <= 8.