### PR TITLE
CORDA-3927: Extend annotation support to include fields.

### DIFF
--- a/djvm-example/src/main/kotlin/com/example/testing/BadKotlinTask.kt
+++ b/djvm-example/src/main/kotlin/com/example/testing/BadKotlinTask.kt
@@ -4,6 +4,6 @@ import java.util.function.Function
 
 class BadKotlinTask : Function<String, Long> {
     override fun apply(input: String): Long {
-        return javaClass.getField(input).getLong(this)
+        return javaClass.getDeclaredField(input).getLong(this)
     }
 }

--- a/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
+++ b/djvm-example/src/main/scala/com/example/testing/BadScalaTask.scala
@@ -3,5 +3,5 @@ package com.example.testing
 import java.util.function.Function
 
 final class BadScalaTask extends Function[String, Long] {
-    override def apply(input: String): Long = getClass().getField(input).getLong(this)
+    override def apply(input: String): Long = getClass().getDeclaredField(input).getLong(this)
 }

--- a/djvm-example/src/test/kotlin/com/example/testing/KotlinSandboxTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/KotlinSandboxTest.kt
@@ -22,6 +22,6 @@ class KotlinSandboxTest : TestBase(KOTLIN) {
             taskFactory.create(BadKotlinTask::class.java).apply("field")
         }
         assertThat(exception)
-            .hasMessageContaining("Disallowed reference to API; java.lang.Class.getField(String)")
+            .hasMessageContaining("Disallowed reference to API; java.lang.Class.getDeclaredField(String)")
     }
 }

--- a/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
+++ b/djvm-example/src/test/kotlin/com/example/testing/ScalaSandboxTest.kt
@@ -33,6 +33,6 @@ class ScalaSandboxTest : TestBase(KOTLIN) {
             taskFactory.create(BadScalaTask::class.java).apply("name")
         }
         assertThat(ex)
-            .hasMessageContaining("Disallowed reference to API; java.lang.Class.getField(String)")
+            .hasMessageContaining("Disallowed reference to API; java.lang.Class.getDeclaredField(String)")
     }
 }

--- a/djvm/secure/src/main/java/com/example/testing/GetAnnotationsOfMethodParameter.java
+++ b/djvm/secure/src/main/java/com/example/testing/GetAnnotationsOfMethodParameter.java
@@ -6,10 +6,10 @@ import java.util.function.Function;
 
 public class GetAnnotationsOfMethodParameter implements Function<String, String[][]> {
     @Override
-    public String[][] apply(String unused) {
+    public String[][] apply(String methodName) {
         Parameter[] parameters;
         try {
-            parameters = UserMethodClass.class.getMethod("action", Long.TYPE).getParameters();
+            parameters = UserMethodClass.class.getMethod(methodName, Long.TYPE).getParameters();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/djvm/secure/src/main/java/com/example/testing/GetJavaFieldAnnotations.java
+++ b/djvm/secure/src/main/java/com/example/testing/GetJavaFieldAnnotations.java
@@ -1,0 +1,26 @@
+package com.example.testing;
+
+import java.lang.reflect.Field;
+import java.util.function.Function;
+
+import static com.example.testing.AnnotationUtils.toStringArray;
+
+public class GetJavaFieldAnnotations implements Function<String, String[]> {
+    @Override
+    public String[] apply(String fieldName) {
+        Field element;
+        try {
+            element = UserFieldData.class.getField(fieldName);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        return toStringArray(element.getDeclaredAnnotations());
+    }
+}
+
+@SuppressWarnings("unused")
+class UserFieldData {
+    @JavaAnnotation(Label.TWO)
+    @JavaTag("Lunacy")
+    public String data;
+}

--- a/djvm/secure/src/main/java/com/example/testing/GetJavaMethodAnnotations.java
+++ b/djvm/secure/src/main/java/com/example/testing/GetJavaMethodAnnotations.java
@@ -7,10 +7,10 @@ import static com.example.testing.AnnotationUtils.toStringArray;
 
 public class GetJavaMethodAnnotations implements Function<String, String[]> {
     @Override
-    public String[] apply(String s) {
+    public String[] apply(String methodName) {
         Method action;
         try {
-            action = UserMethodData.class.getMethod("action");
+            action = UserMethodData.class.getMethod(methodName);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -18,7 +18,7 @@ public class GetJavaMethodAnnotations implements Function<String, String[]> {
     }
 }
 
-@SuppressWarnings({"unused", "WeakerAccess"})
+@SuppressWarnings("unused")
 class UserMethodData {
     @JavaAnnotation(Label.ONE)
     @JavaTag("Madness")

--- a/djvm/secure/src/main/java/com/example/testing/GetJavaMethodParameterAnnotations.java
+++ b/djvm/secure/src/main/java/com/example/testing/GetJavaMethodParameterAnnotations.java
@@ -4,12 +4,12 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.function.Function;
 
-public class GetMethodParameterAnnotations implements Function<String, String[][]> {
+public class GetJavaMethodParameterAnnotations implements Function<String, String[][]> {
     @Override
-    public String[][] apply(String unused) {
+    public String[][] apply(String methodName) {
         Annotation[][] annotations;
         try {
-            annotations = UserMethodClass.class.getMethod("action", Long.TYPE).getParameterAnnotations();
+            annotations = UserMethodClass.class.getMethod(methodName, Long.TYPE).getParameterAnnotations();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/djvm/secure/src/test/java/com/example/testing/JavaAnnotationsTest.java
+++ b/djvm/secure/src/test/java/com/example/testing/JavaAnnotationsTest.java
@@ -80,14 +80,30 @@ class JavaAnnotationsTest extends TestBase {
     }
 
     @Test
-    void testDeclaredMethodAnnotations() {
+    void testJavaMethodAnnotations() {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                String[] annotations = WithJava.run(taskFactory, GetJavaMethodAnnotations.class, null);
+                String[] annotations = WithJava.run(taskFactory, GetJavaMethodAnnotations.class, "action");
                 assertThat(annotations).containsExactly(
                     "@sandbox.com.example.testing.JavaAnnotation(value=ONE)",
                     "@sandbox.com.example.testing.JavaTag(value=Madness)"
+                );
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void testJavaFieldAnnotations() {
+        sandbox(ctx -> {
+            try {
+                TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
+                String[] annotations = WithJava.run(taskFactory, GetJavaFieldAnnotations.class, "data");
+                assertThat(annotations).containsExactly(
+                    "@sandbox.com.example.testing.JavaAnnotation(value=TWO)",
+                    "@sandbox.com.example.testing.JavaTag(value=Lunacy)"
                 );
             } catch (Exception e) {
                 fail(e);

--- a/djvm/secure/src/test/java/com/example/testing/JavaMethodAnnotationsTest.java
+++ b/djvm/secure/src/test/java/com/example/testing/JavaMethodAnnotationsTest.java
@@ -12,7 +12,7 @@ class JavaMethodAnnotationsTest extends TestBase {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                String[][] result = WithJava.run(taskFactory, GetMethodParameterAnnotations.class, null);
+                String[][] result = WithJava.run(taskFactory, GetJavaMethodParameterAnnotations.class, "action");
                 assertThat(result).hasSize(1);
                 assertThat(result[0]).containsExactly(
                     "@sandbox.com.example.testing.JavaParameters(value=[" +
@@ -30,7 +30,7 @@ class JavaMethodAnnotationsTest extends TestBase {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                String[][] result = WithJava.run(taskFactory, GetAnnotationsOfMethodParameter.class, null);
+                String[][] result = WithJava.run(taskFactory, GetAnnotationsOfMethodParameter.class, "action");
                 assertThat(result).hasSize(1);
                 assertThat(result[0]).containsExactly(
                     "@sandbox.com.example.testing.JavaParameters(value=[" +

--- a/djvm/src/main/java/net/corda/djvm/code/AnnotationTransformer.java
+++ b/djvm/src/main/java/net/corda/djvm/code/AnnotationTransformer.java
@@ -14,7 +14,7 @@ import static net.corda.djvm.analysis.SyntheticResolver.getDJVMSyntheticDescript
 class AnnotationTransformer extends AnnotationVisitor {
     private final AnalysisConfiguration configuration;
 
-    AnnotationTransformer(int api, AnnotationVisitor av, AnalysisConfiguration configuration) {
+    AnnotationTransformer(int api, @NotNull AnnotationVisitor av, AnalysisConfiguration configuration) {
         super(api, av);
         this.configuration = configuration;
     }

--- a/djvm/src/main/java/sandbox/java/lang/reflect/DJVM.java
+++ b/djvm/src/main/java/sandbox/java/lang/reflect/DJVM.java
@@ -16,13 +16,13 @@ public final class DJVM {
      * we can control instead.
      * @see System#identityHashCode(java.lang.Object)
      */
-    private static final int ANNOTATION_HASH_OFFSET = 0xaced_c0de;
+    private static final int REFLECTION_HASH_OFFSET = 0xaced_c0de;
     private static final Map<java.lang.Integer, java.lang.Integer> hashCodes = new HashMap<>();
-    private static int annotationCounter;
+    private static int reflectionCounter;
 
     static int hashCodeFor(int jvmHashCode) {
         return hashCodes.computeIfAbsent(
-            jvmHashCode, hash -> ++annotationCounter + ANNOTATION_HASH_OFFSET
+            jvmHashCode, hash -> ++reflectionCounter + REFLECTION_HASH_OFFSET
         );
     }
 

--- a/djvm/src/main/java/sandbox/java/lang/reflect/Field.java
+++ b/djvm/src/main/java/sandbox/java/lang/reflect/Field.java
@@ -76,72 +76,72 @@ public final class Field extends AccessibleObject implements Member {
         throw sandbox.java.lang.DJVM.failApi(named("getGenericType()"));
     }
 
-    public java.lang.Object get(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("get(Object)"));
+    public java.lang.Object get(java.lang.Object obj) throws IllegalAccessException {
+        return field.get(obj);
     }
 
     public void set(java.lang.Object obj, java.lang.Object value) {
         throw sandbox.java.lang.DJVM.failApi(named("set(Object, Object)"));
     }
 
-    public boolean getBoolean(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getBoolean(Object)"));
+    public boolean getBoolean(java.lang.Object obj) throws IllegalAccessException {
+        return field.getBoolean(obj);
     }
 
     public void setBoolean(java.lang.Object obj, boolean z) {
         throw sandbox.java.lang.DJVM.failApi(named("setBoolean(Object, boolean)"));
     }
 
-    public byte getByte(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getByte(Object)"));
+    public byte getByte(java.lang.Object obj) throws IllegalAccessException {
+        return field.getByte(obj);
     }
 
     public void setByte(java.lang.Object obj, byte b) {
         throw sandbox.java.lang.DJVM.failApi(named("setByte(Object, byte)"));
     }
 
-    public char getChar(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getChar(Object)"));
+    public char getChar(java.lang.Object obj) throws IllegalAccessException {
+        return field.getChar(obj);
     }
 
     public void setChar(java.lang.Object obj, char c) {
         throw sandbox.java.lang.DJVM.failApi(named("setChar(Object, char)"));
     }
 
-    public short getShort(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getShort(Object)"));
+    public short getShort(java.lang.Object obj) throws IllegalAccessException {
+        return field.getShort(obj);
     }
 
     public void setShort(java.lang.Object obj, short s) {
         throw sandbox.java.lang.DJVM.failApi(named("setShort(Object, short)"));
     }
 
-    public int getInt(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getInt(Object)"));
+    public int getInt(java.lang.Object obj) throws IllegalAccessException {
+        return field.getInt(obj);
     }
 
     public void setInt(java.lang.Object obj, int i) {
         throw sandbox.java.lang.DJVM.failApi(named("setInt(Object, int)"));
     }
 
-    public long getLong(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getLong(Object)"));
+    public long getLong(java.lang.Object obj) throws IllegalAccessException {
+        return field.getLong(obj);
     }
 
     public void setLong(java.lang.Object obj, long l) {
         throw sandbox.java.lang.DJVM.failApi(named("setLong(Object, long)"));
     }
 
-    public float getFloat(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getFloat(Object)"));
+    public float getFloat(java.lang.Object obj) throws IllegalAccessException {
+        return field.getFloat(obj);
     }
 
     public void setFloat(java.lang.Object obj, float f) {
         throw sandbox.java.lang.DJVM.failApi(named("setFloat(Object, float)"));
     }
 
-    public double getDouble(java.lang.Object obj) {
-        throw sandbox.java.lang.DJVM.failApi(named("getDouble(Object)"));
+    public double getDouble(java.lang.Object obj) throws IllegalAccessException {
+        return field.getDouble(obj);
     }
 
     public void setDouble(java.lang.Object obj, double d) {

--- a/djvm/src/main/java/sandbox/java/lang/reflect/Method.java
+++ b/djvm/src/main/java/sandbox/java/lang/reflect/Method.java
@@ -4,9 +4,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import sandbox.java.lang.String;
 import sandbox.java.lang.annotation.Annotation;
+import static sandbox.java.lang.DJVM.intern;
 
 @SuppressWarnings("unused")
 public final class Method extends Executable {
+    private static final java.lang.String STRING_VALUE = "public sandbox.java.lang.String sandbox.java.lang.Object.toString()";
+    private static final java.lang.String TO_STRING = "toString";
+
     private final java.lang.reflect.Method method;
     private final String name;
     private final String stringValue;
@@ -14,9 +18,18 @@ public final class Method extends Executable {
 
     Method(@NotNull java.lang.reflect.Method method) {
         this.method = method;
-        this.name = String.toDJVM(method.getName());
-        this.stringValue = String.toDJVM(method.toString());
-        this.genericString = String.toDJVM(method.toGenericString());
+        if (isToDJVMString(method)) {
+            name = intern(TO_STRING);
+            genericString = stringValue = intern(STRING_VALUE);
+        } else {
+            name = String.toDJVM(method.getName());
+            stringValue = String.toDJVM(method.toString());
+            genericString = String.toDJVM(method.toGenericString());
+        }
+    }
+
+    private static boolean isToDJVMString(@NotNull java.lang.reflect.Method method) {
+        return "toDJVMString".equals(method.getName()) && method.getParameters().length == 0;
     }
 
     @Override

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxConfiguration.kt
@@ -131,7 +131,7 @@ class SandboxConfiguration private constructor(
         private const val CLASS_SUFFIX = ".class"
         private val INITIAL_CLASSES = setOf(
             // These classes are always present inside a sandbox.
-            OBJECT_NAME, "java/lang/StackTraceElement", THROWABLE_NAME
+            OBJECT_NAME, "java/lang/StackTraceElement", THROWABLE_NAME, "java/lang/annotation/Annotation"
         )
 
         private val log = loggerFor<SandboxConfiguration>()

--- a/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/SandboxRuntimeContext.kt
@@ -49,7 +49,7 @@ class SandboxRuntimeContext(val configuration: SandboxConfiguration) {
             action.accept(this)
         } finally {
             threadLocalContext.remove()
-            doPrivileged(PrivilegedAction { classLoader.close() })
+            doPrivileged(PrivilegedAction(classLoader::close))
         }
     }
 

--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/ClassAndMemberVisitor.kt
@@ -236,8 +236,8 @@ open class ClassAndMemberVisitor(
             val visitedClass = currentClass!!
             analysisContext.classes.add(visitedClass)
             super.visit(
-                version,
-                access,
+                visitedClass.apiVersion,
+                visitedClass.access,
                 visitedClass.name,
                 visitedClass.genericsDetails.emptyAsNull,
                 visitedClass.superClass.emptyAsNull,

--- a/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/ClassMutator.kt
@@ -78,7 +78,7 @@ class ClassMutator(
             logger.trace("Type has been mutated {}", clazz)
             setModified()
         }
-        if (clazz.access and ACC_ANNOTATION != 0) {
+        if (resultingClass.access and ACC_ANNOTATION != 0) {
             setAnnotation()
         }
         return super.visitClass(resultingClass as ClassRepresentation)

--- a/djvm/src/main/kotlin/net/corda/djvm/code/SyntheticAnnotationFactory.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/code/SyntheticAnnotationFactory.kt
@@ -38,16 +38,18 @@ class SyntheticAnnotationFactory(
              * synthetic annotations. We might need to tweak their
              * data values though.
              */
-            val av = super.visitAnnotation(descriptor, visible)
-            when (descriptor.substring(JAVA_LANG_ANNOTATION.length)) {
-                "Target;" ->TargetAnnotationMapper(api, av)
-                "Repeatable;" -> RepeatableAnnotationMapper(api, av)
-                else -> av
+            super.visitAnnotation(descriptor, visible)?.let { av ->
+                when (descriptor.substring(JAVA_LANG_ANNOTATION.length)) {
+                    "Target;" -> TargetAnnotationMapper(api, av)
+                    "Repeatable;" -> RepeatableAnnotationMapper(api, av)
+                    else -> av
+                }
             }
         } else {
             val mappedDescriptor = remapper.mapAnnotationDesc(descriptor)
-            val av = super.visitAnnotation(mappedDescriptor, visible)
-            AnnotationTransformer(api, av, configuration)
+            super.visitAnnotation(mappedDescriptor, visible)?.let { av ->
+                AnnotationTransformer(api, av, configuration)
+            }
         }
     }
 
@@ -89,12 +91,15 @@ class SyntheticAnnotationFactory(
     private inner class MethodRemapper(mv : MethodVisitor) : MethodVisitor(api, mv) {
         override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
             val mappedDescriptor = remapper.mapAnnotationDesc(descriptor)
-            val av = super.visitAnnotation(mappedDescriptor, visible)
-            return AnnotationTransformer(api, av, configuration)
+            return super.visitAnnotation(mappedDescriptor, visible)?.let { av ->
+                AnnotationTransformer(api, av, configuration)
+            }
         }
 
         override fun visitAnnotationDefault(): AnnotationVisitor? {
-            return AnnotationTransformer(api, super.visitAnnotationDefault(), configuration)
+            return super.visitAnnotationDefault()?.let { av ->
+                AnnotationTransformer(api, av, configuration)
+            }
         }
 
         /**

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -348,9 +348,7 @@ class SandboxClassLoader private constructor(
     }
 
     @Throws(ClassNotFoundException::class)
-    fun toSandboxClass(clazz: Class<*>): Class<*> {
-        return loadClassForSandbox(ClassSource.fromClassName(clazz.name))
-    }
+    fun toSandboxClass(clazz: Class<*>): Class<*> = toSandboxClass(clazz.name)
 
     @Throws(ClassNotFoundException::class)
     fun toSandboxClass(className: String): Class<*> = loadClassForSandbox(className)

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaConstructorParameterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaConstructorParameterTest.java
@@ -28,8 +28,8 @@ class AnnotatedJavaConstructorParameterTest extends TestBase {
 
         sandbox(ctx -> {
             try {
-                Class<?> sandboxClass = loadClass(ctx, UserJavaClass.class.getName()).getType();
-                Class<?> stringClass = loadClass(ctx, "sandbox.java.lang.String").getType();
+                Class<?> sandboxClass = toSandboxClass(ctx, UserJavaClass.class);
+                Class<?> stringClass = toSandboxClass(ctx, "sandbox.java.lang.String");
                 Annotation[][] parameterAnnotations = sandboxClass.getConstructor(stringClass, stringClass)
                     .getParameterAnnotations();
                 assertThat(parameterAnnotations).hasSize(2);
@@ -49,8 +49,8 @@ class AnnotatedJavaConstructorParameterTest extends TestBase {
     void testSandboxAnnotationsForConstructorParameters() {
         sandbox(ctx -> {
             try {
-                Class<?> sandboxClass = loadClass(ctx, UserJavaClass.class.getName()).getType();
-                Class<?> stringClass = loadClass(ctx, "sandbox.java.lang.String").getType();
+                 Class<?> sandboxClass = toSandboxClass(ctx, UserJavaClass.class);
+                Class<?> stringClass = toSandboxClass(ctx, "sandbox.java.lang.String");
                 Parameter[] parameters = sandboxClass.getConstructor(stringClass, stringClass).getParameters();
                 assertThat(parameters).hasSize(2);
 

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaMethodParameterTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaMethodParameterTest.java
@@ -28,8 +28,8 @@ class AnnotatedJavaMethodParameterTest extends TestBase {
 
         sandbox(ctx -> {
             try {
-                Class<?> sandboxClass = loadClass(ctx, UserJavaClass.class.getName()).getType();
-                Class<?> stringClass = loadClass(ctx, "sandbox.java.lang.String").getType();
+                Class<?> sandboxClass = toSandboxClass(ctx, UserJavaClass.class);
+                Class<?> stringClass = toSandboxClass(ctx, "sandbox.java.lang.String");
                 Annotation[][] parameterAnnotations = sandboxClass.getMethod("getData", stringClass, stringClass)
                     .getParameterAnnotations();
                 assertThat(parameterAnnotations).hasSize(2);
@@ -49,8 +49,8 @@ class AnnotatedJavaMethodParameterTest extends TestBase {
     void testSandboxAnnotationsForMethodParameters() {
         sandbox(ctx -> {
             try {
-                Class<?> sandboxClass = loadClass(ctx, UserJavaClass.class.getName()).getType();
-                Class<?> stringClass = loadClass(ctx, "sandbox.java.lang.String").getType();
+                Class<?> sandboxClass = toSandboxClass(ctx, UserJavaClass.class);
+                Class<?> stringClass = toSandboxClass(ctx, "sandbox.java.lang.String");
                 Parameter[] parameters = sandboxClass.getMethod("getData", stringClass, stringClass).getParameters();
                 assertThat(parameters).hasSize(2);
 

--- a/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaPackageTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/AnnotatedJavaPackageTest.java
@@ -19,7 +19,7 @@ class AnnotatedJavaPackageTest extends TestBase {
     void testSandboxAnnotation() {
         sandbox(ctx -> {
             try {
-                Class<?> sandboxClass = ctx.getClassLoader().toSandboxClass(HappyObject.class.getName());
+                Class<?> sandboxClass = toSandboxClass(ctx, HappyObject.class);
                 Package sandboxPackage = sandboxClass.getPackage();
                 Annotation[] annotations = sandboxPackage.getAnnotations();
                 assertThat(annotations).hasSize(1);

--- a/djvm/src/test/java/net/corda/djvm/execution/SafeJavaReflectionTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SafeJavaReflectionTest.java
@@ -6,16 +6,22 @@ import net.corda.djvm.TypedTaskFactory;
 import net.corda.djvm.WithJava;
 import net.corda.djvm.rules.RuleViolationError;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.function.Function;
 
 import static net.corda.djvm.SandboxType.JAVA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 class SafeJavaReflectionTest extends TestBase {
     SafeJavaReflectionTest() {
@@ -202,6 +208,98 @@ class SafeJavaReflectionTest extends TestBase {
         }
     }
 
+    @Test
+    void testGetMethods() {
+        sandbox(ctx -> {
+            try {
+                TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
+                String[] methodNames = WithJava.run(taskFactory, GetMethods.class, null);
+                assertThat(methodNames).containsExactlyInAnyOrder(
+                    "andThen",
+                    "apply", "apply",
+                    "compose",
+                    "equals",
+                    "getClass",
+                    "getPublicMessage",
+                    "hashCode",
+                    "notify",
+                    "notifyAll",
+                    "toString",
+                    "wait", "wait", "wait"
+                );
+            } catch(Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @SuppressWarnings("unused")
+    public static class GetMethods implements Function<String, String[]> {
+        public String getPublicMessage() {
+            return "Public Method";
+        }
+
+        protected String getProtectedMessage() {
+            return "Protected Method";
+        }
+
+        String getPackageMessage() {
+            return "Package Method";
+        }
+
+        private String getPrivateMessage() {
+            return "Private Method";
+        }
+
+        @Override
+        public String[] apply(String unused) {
+            return Arrays.stream(getClass().getMethods())
+                .map(Method::getName)
+                .toArray(String[]::new);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "toString,sandbox.java.lang.String,public sandbox.java.lang.String sandbox.java.lang.Object.toString()",
+        "hashCode,int, public int sandbox.java.lang.Object.hashCode()",
+        "notify,void,public final native void java.lang.Object.notify()",
+        "notifyAll,void,public final native void java.lang.Object.notifyAll()",
+        "wait,void,public final void java.lang.Object.wait() throws java.lang.InterruptedException"
+    })
+    void testGetMethod(String methodName, String returnType, String toStringValue) {
+        sandbox(ctx -> {
+            try {
+                TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
+                String[] results = WithJava.run(taskFactory, GetMethod.class, methodName);
+                assertThat(results).containsExactly(
+                    methodName,
+                    returnType,
+                    toStringValue
+                );
+            } catch(Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    public static class GetMethod implements Function<String, String[]> {
+        @Override
+        public String[] apply(String methodName) {
+            Method method;
+            try {
+                method = getClass().getMethod(methodName);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+            return new String[] {
+                method.getName(),
+                method.getReturnType().getName(),
+                method.toString()
+            };
+        }
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static class UserData {
         private final String data;
@@ -311,54 +409,129 @@ class SafeJavaReflectionTest extends TestBase {
     }
 
     @Test
-    void testGetField() {
+    void testGetFields() {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                RuleViolationError ex = assertThrows(RuleViolationError.class,
-                    () -> WithJava.run(taskFactory, GetField.class, "publicData")
+                String[] fieldNames = WithJava.run(taskFactory, GetFields.class, null);
+                assertThat(fieldNames).containsExactlyInAnyOrder(
+                    "publicData"
                 );
-                assertThat(ex)
-                    .hasMessage("Disallowed reference to API; java.lang.Class.getField(String)")
-                    .hasNoCause();
             } catch(Exception e) {
                 fail(e);
             }
         });
     }
 
-    public static class GetField implements Function<String, Field> {
+    public static class GetFields implements Function<String, String[]> {
         @Override
-        public Field apply(String fieldName) {
+        public String[] apply(String unused) {
+            return Arrays.stream(UserData.class.getFields())
+                .map(Field::getName)
+                .toArray(String[]::new);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "bigNumber,sandbox.java.lang.Long," + ACC_PUBLIC,
+        "CHARACTER,char," + (ACC_PUBLIC | ACC_STATIC),
+        "MESSAGE,sandbox.java.lang.String," + (ACC_PUBLIC | ACC_STATIC | ACC_FINAL),
+        "flag,boolean," + (ACC_PUBLIC | ACC_FINAL),
+        "number,int," + ACC_PUBLIC
+    })
+    void testGetField(String fieldName, String typeName, int modifiers) {
+        sandbox(ctx -> {
             try {
-                return UserData.class.getField(fieldName);
+                TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
+                Object[] results = WithJava.run(taskFactory, GetField.class, fieldName);
+                assertThat(results).containsExactly(
+                    fieldName,
+                    typeName,
+                    modifiers
+                );
+            } catch(Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @SuppressWarnings("unused")
+    public static class GetField implements Function<String, Object[]> {
+        public static final String MESSAGE = "Hello Field!";
+        public static char CHARACTER;
+        public final boolean flag = true;
+        public Long bigNumber;
+        public int number;
+
+        @Override
+        public Object[] apply(String fieldName) {
+            Field field;
+            try {
+                field = getClass().getField(fieldName);
             } catch (NoSuchFieldException e) {
                 throw new RuntimeException(e.getMessage(), e);
             }
+            return new Object[] {
+                field.getName(),
+                field.getType().getName(),
+                field.getModifiers()
+            };
         }
     }
 
     @Test
-    void tstGetFields() {
+    void testGetFieldValues() {
         sandbox(ctx -> {
             try {
                 TypedTaskFactory taskFactory = ctx.getClassLoader().createTypedTaskFactory();
-                RuleViolationError ex = assertThrows(RuleViolationError.class,
-                    () -> WithJava.run(taskFactory, GetFields.class, null)
+                Object[] results = WithJava.run(taskFactory, GetFieldValues.class, null);
+                assertThat(results).containsExactly(
+                    "Hello Field!",
+                    12345678L,
+                    123456,
+                    true,
+                    (short) 1234,
+                    (byte) 136,
+                    '\u267b',
+                    1234.56f,
+                    123456.7899d
                 );
-                assertThat(ex)
-                    .hasMessage("Disallowed reference to API; java.lang.Class.getFields()")
-                    .hasNoCause();
             } catch(Exception e) {
                 fail(e);
             }
         });
     }
 
-    public static class GetFields implements Function<String, Field[]> {
+    @SuppressWarnings("WeakerAccess")
+    public static class GetFieldValues implements Function<String, Object[]> {
+        public final String message = "Hello Field!";
+        public final long bigNumber = 12345678L;
+        public final int number = 123456;
+        public final boolean flag = true;
+        public final short littleNumber = (short) 1234;
+        public final byte tinyNumber = (byte) 136;
+        public final char character = '\u267b';
+        public final float realNumber = 1234.56f;
+        public final double bigRealNumber = 123456.7899d;
+
         @Override
-        public Field[] apply(String unused) {
-            return UserData.class.getFields();
+        public Object[] apply(String unused) {
+            try {
+                return new Object[] {
+                    GetFieldValues.class.getField("message").get(this),
+                    GetFieldValues.class.getField("bigNumber").getLong(this),
+                    GetFieldValues.class.getField("number").getInt(this),
+                    GetFieldValues.class.getField("flag").getBoolean(this),
+                    GetFieldValues.class.getField("littleNumber").getShort(this),
+                    GetFieldValues.class.getField("tinyNumber").getByte(this),
+                    GetFieldValues.class.getField("character").getChar(this),
+                    GetFieldValues.class.getField("realNumber").getFloat(this),
+                    GetFieldValues.class.getField("bigRealNumber").getDouble(this),
+                };
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
         }
     }
 

--- a/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/TestBase.kt
@@ -305,11 +305,23 @@ abstract class TestBase(type: SandboxType) {
     /**
      * Create a new instance of a class using the sandbox class loader.
      */
+    @Throws(ClassNotFoundException::class)
     inline fun <reified T : Callable> SandboxRuntimeContext.newCallable(): LoadedClass = loadClass<T>()
 
+    @Throws(ClassNotFoundException::class)
     inline fun <reified T : Any> SandboxRuntimeContext.loadClass(): LoadedClass = loadClass(T::class.jvmName)
 
+    @Throws(ClassNotFoundException::class)
     fun SandboxRuntimeContext.loadClass(className: String): LoadedClass = classLoader.loadForSandbox(className)
+
+    @Throws(ClassNotFoundException::class)
+    fun SandboxRuntimeContext.toSandboxClass(className: String): Class<*> = classLoader.toSandboxClass(className)
+
+    @Throws(ClassNotFoundException::class)
+    fun <T : Any> SandboxRuntimeContext.toSandboxClass(clazz: Class<T>): Class<*> = classLoader.toSandboxClass(clazz)
+
+    @Throws(ClassNotFoundException::class)
+    inline fun <reified T : Any> SandboxRuntimeContext.toSandboxClass(): Class<*> = toSandboxClass(T::class.java)
 
     /**
      * Run the entry-point of the loaded [Callable] class.

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/AnnotatedKotlinClassTest.kt
@@ -25,8 +25,8 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
         assertThat(UserKotlinData::class.findAnnotation<KotlinAnnotation>()).isNotNull
 
         @Suppress("unchecked_cast")
-        val sandboxAnnotation = loadClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM").type as Class<out Annotation>
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxAnnotation = toSandboxClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM") as Class<out Annotation>
+        val sandboxClass = toSandboxClass<UserKotlinData>()
 
         val annotationValue = sandboxClass.getAnnotation(sandboxAnnotation)
         assertThat(annotationValue.toString())
@@ -36,8 +36,8 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     @Test
     @Suppress("unchecked_cast")
     fun testSandboxAnnotationWithEnumValue() = sandbox {
-        val sandboxClass = loadClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM").type as Class<out Annotation>
-        val sandboxAnnotation = loadClass("sandbox.kotlin.annotation.Retention\$1DJVM").type as Class<out Annotation>
+        val sandboxClass = toSandboxClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM") as Class<out Annotation>
+        val sandboxAnnotation = toSandboxClass("sandbox.kotlin.annotation.Retention\$1DJVM") as Class<out Annotation>
 
         val retentionValue = sandboxClass.kotlin.annotations.filterIsInstance(sandboxAnnotation)
             .singleOrNull() ?: fail("No @Retention\$1DJVM annotation found")
@@ -50,8 +50,8 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     @Test
     @Suppress("unchecked_cast")
     fun testSandboxAnnotationWithEnumArrayValue() = sandbox {
-        val sandboxClass = loadClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM").type as Class<out Annotation>
-        val sandboxAnnotation = loadClass("sandbox.kotlin.annotation.Target\$1DJVM").type as Class<out Annotation>
+        val sandboxClass = toSandboxClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM") as Class<out Annotation>
+        val sandboxAnnotation = toSandboxClass("sandbox.kotlin.annotation.Target\$1DJVM") as Class<out Annotation>
 
         val targetValue = sandboxClass.kotlin.annotations.filterIsInstance(sandboxAnnotation)
             .singleOrNull() ?: fail("No @Target\$1DJVM annotation found")
@@ -63,9 +63,9 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
 
     @Test
     fun testPreservingKotlinMetadataAnnotation() = sandbox {
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxClass = toSandboxClass<UserKotlinData>()
         @Suppress("unchecked_cast")
-        val sandboxMetadataClass = loadClass("sandbox.kotlin.Metadata\$1DJVM").type as Class<out Annotation>
+        val sandboxMetadataClass = toSandboxClass("sandbox.kotlin.Metadata\$1DJVM") as Class<out Annotation>
 
         val metadata = sandboxClass.getAnnotation(kotlinMetadata)
         val sandboxMetadata = sandboxClass.getAnnotation(sandboxMetadataClass)
@@ -99,7 +99,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
 
     @Test
     fun `test sandboxed class still knows its own primary constructor`() = sandbox {
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxClass = toSandboxClass<UserKotlinData>()
         val primaryConstructor = sandboxClass.kotlin.primaryConstructor ?: fail("Primary constructor missing!")
 
         val sandboxData = with(DJVM(classLoader)) {
@@ -112,7 +112,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
 
     @Test
     fun `test reflection can fetch all annotations`() = sandbox {
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxClass = toSandboxClass<UserKotlinData>()
         val kotlinAnnotations = sandboxClass.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName
         }
@@ -135,7 +135,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     fun `test reflection can fetch all stitched annotations`() = sandbox(
             visibleAnnotations = setOf(KotlinAnnotation::class.java)
     ) {
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxClass = toSandboxClass<UserKotlinData>()
         val kotlinAnnotations = sandboxClass.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName
         }
@@ -159,7 +159,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     @Test
     fun `test reflection can fetch all meta-annotations`() = sandbox {
         @Suppress("unchecked_cast")
-        val sandboxAnnotation = loadClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM").type as Class<out Annotation>
+        val sandboxAnnotation = toSandboxClass("sandbox.net.corda.djvm.KotlinAnnotation\$1DJVM") as Class<out Annotation>
 
         val kotlinAnnotations = sandboxAnnotation.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName
@@ -194,7 +194,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     fun `test reflection can fetch all stitched method annotations`() = sandbox(
         visibleAnnotations = setOf(KotlinAnnotation::class.java)
     ) {
-        val sandboxClass = loadClass<UserKotlinData>().type
+        val sandboxClass = toSandboxClass<UserKotlinData>()
         val sandboxFunction = sandboxClass.kotlin.functions.single { it.name == "holdAnnotation" }
         val kotlinAnnotations = sandboxFunction.annotations.map { ann ->
             ann.annotationClass.qualifiedName
@@ -210,7 +210,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     ) {
         assertThat(UserKotlinLabel::class.findAnnotation<KotlinLabel>()).isNotNull
 
-        val sandboxClass = loadClass<UserKotlinLabel>().type
+        val sandboxClass = toSandboxClass<UserKotlinLabel>()
         val annotations = sandboxClass.kotlin.annotations.groupByTo(LinkedHashMap()) { ann ->
             ann.annotationClass.qualifiedName?.startsWith("sandbox.")
         }
@@ -230,7 +230,7 @@ class AnnotatedKotlinClassTest : TestBase(KOTLIN) {
     @Test
     fun `test reflection can fetch repeatable`() = sandbox {
         @Suppress("unchecked_cast")
-        val sandboxAnnotation = loadClass<KotlinLabel>().type as Class<out Annotation>
+        val sandboxAnnotation = toSandboxClass<KotlinLabel>() as Class<out Annotation>
 
         val kotlinAnnotations = sandboxAnnotation.kotlin.annotations.map { ann ->
             ann.annotationClass.qualifiedName


### PR DESCRIPTION
Apply the sandbox's annotation byte-code model to `Field` annotations, and allow sandboxed code to read them from public fields.

Also take the opportunity to tidy up the annotation tests, and make the intention of some of the Kotlin lambdas clearer.