### PR TITLE
NOTICK: Don't publish Gradle metadata. "Keep it simple, stupid!"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ subprojects {
                     '--illegal-access=warn'
         }
     }
+
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        enabled = false
+    }
 }
 
 bintrayConfig {


### PR DESCRIPTION
Gradle 6.x seems to have started publishing Gradle metadata by default. I certainly didn't ask for that, and I don't believe anyone else did either, so turn it _OFF_ until someone actually does.