### PR TITLE
NOTICK: Upgrade the DJVM CLI to use the Kotlin 1.3 runtime libraries.

### DIFF
--- a/djvm/cli/build.gradle
+++ b/djvm/cli/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.github.johnrengelman.shadow'
@@ -23,6 +25,13 @@ dependencies {
 
     implementation "info.picocli:picocli:$picocli_version"
     implementation project(path: ':djvm', configuration: 'shadow')
+}
+
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        languageVersion = '1.3'
+        apiVersion = '1.3'
+    }
 }
 
 tasks.named('jar', Jar) {

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/BuildCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/BuildCommand.kt
@@ -5,9 +5,9 @@ import picocli.CommandLine.Parameters
 import java.nio.file.Path
 
 @Command(
-        name = "build",
-        description = ["Build one or more Java source files, each implementing the sandbox runnable interface " +
-                "required for execution in the deterministic sandbox."]
+    name = "build",
+    description = ["Build one or more Java source files, each implementing the sandbox runnable interface " +
+        "required for execution in the deterministic sandbox."]
 )
 @Suppress("KDocMissingDocumentation")
 class BuildCommand : CommandBase() {
@@ -21,19 +21,15 @@ class BuildCommand : CommandBase() {
         val codePath = createCodePath()
         val files = files.getFileNames { codePath.resolve(it) }
         printVerbose("Compiling ${files.joinToString(", ")}...")
-        ProcessBuilder("javac", "-cp", "tmp:$jarPath", *files).apply {
-            inheritIO()
-            environment().putAll(System.getenv())
-            start().apply {
-                waitFor()
-                return (exitValue() == 0).apply {
-                    if (this) {
-                        printInfo("Build succeeded")
-                    }
-                }
+        val process = ProcessBuilder("javac", "-cp", "tmp:$jarPath", *files).let {
+            it.inheritIO()
+            it.environment().putAll(System.getenv())
+            it.start()
+        }
+        return (process.waitFor() == 0).also { success ->
+            if (success) {
+                printInfo("Build succeeded")
             }
         }
-        return true
     }
-
 }

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CheckCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CheckCommand.kt
@@ -5,9 +5,9 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Parameters
 
 @Command(
-        name = "check",
-        description = ["Statically validate that a class or set of classes (and their dependencies) do not violate any " +
-                "constraints posed by the deterministic sandbox environment."]
+    name = "check",
+    description = ["Statically validate that a class or set of classes (and their dependencies) do not violate any " +
+        "constraints posed by the deterministic sandbox environment."]
 )
 @Suppress("KDocMissingDocumentation")
 class CheckCommand : ClassCommand() {
@@ -19,7 +19,7 @@ class CheckCommand : ClassCommand() {
     var classes: Array<String> = emptyArray()
 
     override fun printSuccess(classes: List<Class<*>>) {
-        for (clazz in classes.sortedBy { it.name }) {
+        for (clazz in classes.sortedBy(Class<*>::getName)) {
             printVerbose("Class ${clazz.name} validated")
         }
         printVerbose()

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -19,8 +19,8 @@ import java.nio.file.Paths
 abstract class ClassCommand : CommandBase() {
 
     @Option(
-            names = ["-p", "--profile"],
-            description = ["The execution profile to use (DEFAULT, UNLIMITED, DISABLE_BRANCHING or DISABLE_THROWS)."]
+        names = ["-p", "--profile"],
+        description = ["The execution profile to use (DEFAULT, UNLIMITED, DISABLE_BRANCHING or DISABLE_THROWS)."]
     )
     var profile: ExecutionProfile = ExecutionProfile.DEFAULT
 

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/CommandBase.kt
@@ -18,51 +18,52 @@ import java.util.concurrent.Callable
 abstract class CommandBase : Callable<Boolean> {
 
     @Option(
-            names = ["-l", "--level"],
-            description = ["The minimum severity level to log (TRACE, DEBUG, INFO, WARNING or ERROR."],
-            converter = [SeverityConverter::class]
+        names = ["-l", "--level"],
+        description = ["The minimum severity level to log (TRACE, DEBUG, INFO, WARNING or ERROR."],
+        converter = [SeverityConverter::class]
     )
+    @JvmField
     protected var level: Severity = Severity.WARNING
 
     @Option(
-            names = ["-q", "--quiet"],
-            description = ["Only print important messages to standard output."]
+        names = ["-q", "--quiet"],
+        description = ["Only print important messages to standard output."]
     )
     private var quiet: Boolean = false
 
     @Option(
-            names = ["-v", "--verbose"],
-            description = ["Enable verbose logging."]
+        names = ["-v", "--verbose"],
+        description = ["Enable verbose logging."]
     )
     private var verbose: Boolean = false
 
     @Option(
-            names = ["--debug"],
-            description = ["Print full stack traces upon error."]
+        names = ["--debug"],
+        description = ["Print full stack traces upon error."]
     )
     private var debug: Boolean = false
 
     @Option(
-            names = ["--colors"],
-            description = ["Use colors when printing to terminal."]
+        names = ["--colors"],
+        description = ["Use colors when printing to terminal."]
     )
     private var useColors: Boolean = false
 
     @Option(
-            names = ["--no-colors"],
-            description = ["Do not use colors when printing to terminal."]
+        names = ["--no-colors"],
+        description = ["Do not use colors when printing to terminal."]
     )
     private var useNoColors: Boolean = false
 
     @Option(
-            names = ["--compact"],
-            description = ["Print compact errors and warnings."]
+        names = ["--compact"],
+        description = ["Print compact errors and warnings."]
     )
     private var compact: Boolean = false
 
     @Option(
-            names = ["--print-origins"],
-            description = ["Print origins for errors and warnings."]
+        names = ["--print-origins"],
+        description = ["Print origins for errors and warnings."]
     )
     private var printOrigins: Boolean = false
 
@@ -128,8 +129,7 @@ abstract class CommandBase : Callable<Boolean> {
             printError()
         }
         is SandboxException -> {
-            val cause = exception.cause
-            when (cause) {
+            when (val cause = exception.cause) {
                 is SandboxClassLoadingException -> {
                     printMessages(cause.messages, cause.classOrigins)
                     printError()
@@ -163,7 +163,7 @@ abstract class CommandBase : Callable<Boolean> {
                 val message = exception.message
                 when {
                     message.isNullOrBlank() -> exception.javaClass.simpleName
-                    else -> message!!
+                    else -> message
                 }
             }
         }

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/Commands.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/Commands.kt
@@ -4,19 +4,19 @@ import picocli.CommandLine
 import picocli.CommandLine.Command
 
 @Command(
-        name = "djvm",
-        versionProvider = VersionProvider::class,
-        description = ["JVM for running programs in a deterministic sandbox."],
-        mixinStandardHelpOptions = true,
-        subcommands = [
-            BuildCommand::class,
-            CheckCommand::class,
-            InspectionCommand::class,
-            NewCommand::class,
-            RunCommand::class,
-            ShowCommand::class,
-            TreeCommand::class
-        ]
+    name = "djvm",
+    versionProvider = VersionProvider::class,
+    description = ["JVM for running programs in a deterministic sandbox."],
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        BuildCommand::class,
+        CheckCommand::class,
+        InspectionCommand::class,
+        NewCommand::class,
+        RunCommand::class,
+        ShowCommand::class,
+        TreeCommand::class
+    ]
 )
 @Suppress("KDocMissingDocumentation")
 class Commands : CommandBase() {

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/InspectionCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/InspectionCommand.kt
@@ -6,9 +6,9 @@ import picocli.CommandLine.Parameters
 import java.nio.file.Files
 
 @Command(
-        name = "inspect",
-        description = ["Inspect the transformations that are being applied to classes before they get loaded into " +
-                "the sandbox."]
+    name = "inspect",
+    description = ["Inspect the transformations that are being applied to classes before they get loaded into " +
+        "the sandbox."]
 )
 @Suppress("KDocMissingDocumentation")
 class InspectionCommand : ClassCommand() {
@@ -49,7 +49,6 @@ class InspectionCommand : ClassCommand() {
                 environment().putAll(System.getenv())
                 start().apply {
                     waitFor()
-                    exitValue()
                 }
             }
 
@@ -61,7 +60,6 @@ class InspectionCommand : ClassCommand() {
                     environment().putAll(System.getenv())
                     start().apply {
                         waitFor()
-                        exitValue()
                     }
                 }
                 Files.delete(this)
@@ -69,13 +67,12 @@ class InspectionCommand : ClassCommand() {
 
             // Generate and display the difference between the original and the transformed class
             ProcessBuilder(
-                    "git", "diff", originalClass.toString(), transformedClass.toString()
+                "git", "diff", originalClass.toString(), transformedClass.toString()
             ).apply {
                 inheritIO()
                 environment().putAll(System.getenv())
                 start().apply {
                     waitFor()
-                    exitValue()
                 }
             }
             printInfo()

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/NewCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/NewCommand.kt
@@ -5,12 +5,12 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 @Command(
-        name = "new",
-        description = ["Create one or more new Java classes implementing the sandbox runnable interface that is " +
-                "required for execution in the deterministic sandbox. Each Java file is created using a template, " +
-                "with class name derived from the provided file name."
-        ],
-        showDefaultValues = true
+    name = "new",
+    description = ["Create one or more new Java classes implementing the sandbox runnable interface that is " +
+        "required for execution in the deterministic sandbox. Each Java file is created using a template, " +
+        "with class name derived from the provided file name."
+    ],
+    showDefaultValues = true
 )
 @Suppress("KDocMissingDocumentation")
 class NewCommand : CommandBase() {
@@ -40,10 +40,10 @@ class NewCommand : CommandBase() {
                 printVerbose("Creating file '$file'...")
                 Files.newBufferedWriter(file, *openOptions(force)).use {
                     it.append(TEMPLATE
-                            .replace("[NAME]", file.baseName)
-                            .replace("[FROM]", fromType)
-                            .replace("[TO]", toType)
-                            .replace("[RETURN]", returnValue))
+                        .replace("[NAME]", file.baseName)
+                        .replace("[FROM]", fromType)
+                        .replace("[TO]", toType)
+                        .replace("[RETURN]", returnValue))
                 }
             } catch (exception: Throwable) {
                 throw Exception("Failed to create file '$file'", exception)
@@ -54,7 +54,7 @@ class NewCommand : CommandBase() {
 
     companion object {
 
-        val TEMPLATE = """
+        private val TEMPLATE = """
             |package net.corda.sandbox;
             |
             |import java.util.function.Function;

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/RunCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/RunCommand.kt
@@ -5,9 +5,9 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Parameters
 
 @Command(
-        name = "run",
-        description = ["Execute runnable in sandbox."],
-        showDefaultValues = true
+    name = "run",
+    description = ["Execute runnable in sandbox."],
+    showDefaultValues = true
 )
 @Suppress("KDocMissingDocumentation")
 class RunCommand : ClassCommand() {

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ShowCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ShowCommand.kt
@@ -6,9 +6,9 @@ import picocli.CommandLine.Parameters
 import java.nio.file.Files
 
 @Command(
-        name = "show",
-        description = ["Show the transformed version of a class as it is prepared for execution in the deterministic " +
-                "sandbox."]
+    name = "show",
+    description = ["Show the transformed version of a class as it is prepared for execution in the deterministic " +
+        "sandbox."]
 )
 @Suppress("KDocMissingDocumentation")
 class ShowCommand : ClassCommand() {
@@ -44,7 +44,6 @@ class ShowCommand : ClassCommand() {
                     environment().putAll(System.getenv())
                     start().apply {
                         waitFor()
-                        exitValue()
                     }
                 }
                 Files.delete(this)

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/TreeCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/TreeCommand.kt
@@ -4,8 +4,8 @@ import picocli.CommandLine.Command
 import java.nio.file.Files
 
 @Command(
-        name = "tree",
-        description = ["Show the hierarchy of the classes that have been created with the 'new' command."]
+    name = "tree",
+    description = ["Show the hierarchy of the classes that have been created with the 'new' command."]
 )
 @Suppress("KDocMissingDocumentation")
 class TreeCommand : CommandBase() {
@@ -24,7 +24,6 @@ class TreeCommand : CommandBase() {
             directory(path.toFile())
             start().apply {
                 waitFor()
-                exitValue()
             }
         }
         return true

--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/Utilities.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/Utilities.kt
@@ -26,9 +26,7 @@ fun Array<Path>?.getFiles(map: (Path) -> Path = { it }) = (this ?: emptyArray())
 /**
  * Get the string representation of each expanded file name in the provided array.
  */
-fun Array<Path>?.getFileNames(map: (Path) -> Path = { it }) = this.getFiles(map).map {
-    it.toString()
-}.toTypedArray()
+fun Array<Path>?.getFileNames(map: (Path) -> Path = { it }) = this.getFiles(map).map(Any::toString).toTypedArray()
 
 /**
  * Execute inlined action if the collection is empty.
@@ -69,7 +67,7 @@ fun createCodePath(): Path {
  * Return the base name of a file (i.e., its name without extension)
  */
 val Path.baseName: String
-    get() = this.fileName.toString()
+    get() = fileName.toString()
             .replaceAfterLast('.', "")
             .removeSuffix(".")
 
@@ -94,9 +92,9 @@ val userClassPath: String = System.getProperty("java.class.path")
  */
 inline fun <reified T> find(scanSpec: String): List<Class<*>> {
     return ClassGraph()
-            .whitelistPaths(scanSpec)
-            .enableAllInfo()
-            .scan()
-            .use { it.getClassesImplementing(T::class.java.name).loadClasses(T::class.java) }
-            .filter { !isAbstract(it.modifiers) && !isStatic(it.modifiers) }
+        .whitelistPaths(scanSpec)
+        .enableAllInfo()
+        .scan()
+        .use { it.getClassesImplementing(T::class.java.name).loadClasses(T::class.java) }
+        .filter { !isAbstract(it.modifiers) && !isStatic(it.modifiers) }
 }


### PR DESCRIPTION
Only the DJVM itself needs to be compiled with Kotlin 1.2. The CLI can safely be updated to use Kotlin 1.3.