### PR TITLE
NOTICK: Update Gradle scripts and resolve warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,6 @@ plugins {
     id 'base'
 }
 
-ext {
-    artifactory_contextUrl = 'https://software.r3.com/artifactory'
-}
-
 version corda_djvm_version
 
 subprojects {
@@ -64,7 +60,7 @@ subprojects {
         jvmArgs '-XX:+UseG1GC'
 
         // Corda serialization needs reflective access to these packages.
-        if (current().isJava9Compatible()) {
+        if (current().java9Compatible) {
             jvmArgs '--add-opens', 'java.base/java.io=ALL-UNNAMED',
                     '--add-opens', 'java.base/java.time=ALL-UNNAMED',
                     '--illegal-access=warn'

--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -19,10 +19,6 @@ plugins {
     id 'com.jfrog.artifactory'
 }
 
-ext {
-    artifactory_contextUrl = 'https://software.r3.com/artifactory'
-}
-
 /*
  * This is a nested and independent Gradle project,
  * and so has its own group and version.

--- a/deterministic-rt/gradle.properties
+++ b/deterministic-rt/gradle.properties
@@ -3,5 +3,7 @@ org.gradle.caching=false
 deterministic_rt_version=1.0-SNAPSHOT
 deterministic_rt_tag=deterministic/1.0
 
-artifactory_plugin_version=4.16.1
+artifactory_contextUrl=https://software.r3.com/artifactory
+
+artifactory_plugin_version=4.17.1
 proguard_version=6.1.1

--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'scala'
 }
 
-ext {
-    artifactory_contextUrl = 'https://software.r3.com/artifactory'
-}
-
 group 'com.example.djvm'
 version djvm_version
 
@@ -136,7 +132,7 @@ tasks.withType(Test).configureEach {
     systemProperty 'sandbox-libraries.path', configurations.sandboxTesting.asPath
 
     // Corda serialization needs reflective access to these packages.
-    if (current().isJava9Compatible()) {
+    if (current().java9Compatible) {
         jvmArgs '--add-opens', 'java.base/java.io=ALL-UNNAMED',
                 '--add-opens', 'java.base/java.time=ALL-UNNAMED',
                 '--illegal-access=warn'

--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -2,6 +2,8 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=false
 kotlin.incremental=true
 
+artifactory_contextUrl=https://software.r3.com/artifactory
+
 djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
 corda_version=4.6-SNAPSHOT

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -179,6 +179,15 @@ def shadowJar = tasks.named('shadowJar', Jar) {
     exclude 'sandbox/sun/util/calendar/ZoneInfoFile.class'
 }
 
+ext {
+    // Lazy property to be invoked as a bnd macro.
+    shadowJarURI = shadowJar.flatMap { jar ->
+        jar.archiveFile.map { file ->
+            file.asFile.toURI()
+        }
+    }
+}
+
 def bundle = tasks.register('bundle', Bundle) {
     from shadowJar.map { zipTree(it.archiveFile) }
 
@@ -187,7 +196,7 @@ def bundle = tasks.register('bundle', Bundle) {
     archiveClassifier = ''
 
     bnd """\
--include: "jar:${shadowJar.flatMap { it.archiveFile.map { it.asFile.toURI() } }.get()}!/META-INF/MANIFEST.MF"
+-include: "jar:\${project.shadowJarURI}!/META-INF/MANIFEST.MF"
 -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning
 Bundle-SymbolicName: net.corda.djvm
 Bundle-Name: DJVM
@@ -209,7 +218,7 @@ tasks.withType(Test).configureEach {
     systemProperty 'test.gradle.home', gradle.gradleHomeDir.toURI()
     systemProperty 'test.project.uri', projectDir.toURI()
 
-    if (current().isJava9Compatible()) {
+    if (current().java9Compatible) {
         // https://openjdk.java.net/jeps/165
         jvmArgs '-XX:+UnlockDiagnosticVMOptions',
                 "-XX:CompilerDirectivesFile=$rootDir/compiler-control.json"

--- a/djvm/osgi/build.gradle
+++ b/djvm/osgi/build.gradle
@@ -137,5 +137,5 @@ artifacts {
 }
 
 publish {
-    name jar.flatMap { it.archiveBaseName }
+    name = jar.flatMap { it.archiveBaseName }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,8 @@ kotlin.incremental=true
 corda_djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
 
+artifactory_contextUrl=https://software.r3.com/artifactory
+
 corda_version=4.6-SNAPSHOT
 corda_plugins_version=5.0.12
 kotlin_plugin_version=1.3.72


### PR DESCRIPTION
Stop relying on Gradle behaviour that will be removed in Gradle 7.0.