### PR TITLE
NOTICK: Update Gradle usage,

### DIFF
--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 
-    sandboxTesting sourceSets.getByName('main').runtimeClasspath
+    sandboxTesting sourceSets.main.runtimeClasspath
     sandboxTesting "net.corda:corda-deserializers-djvm:$corda_version"
     sandboxTesting "org.slf4j:slf4j-nop:$slf4j_version"
 }

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
 
     // The DJVM will need this classpath to run the unit tests.
-    sandboxTesting files(sourceSets.getByName("test").output)
+    sandboxTesting files(sourceSets.test.output)
     sandboxTesting "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     sandboxTesting "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
@@ -226,9 +226,9 @@ tasks.withType(Test).configureEach {
 }
 
 artifacts {
-    archives bundle.flatMap { it.archiveFile }
-    bundles bundle.flatMap { it.archiveFile }
-    publish bundle.flatMap { it.archiveFile }
+    archives bundle
+    bundles bundle
+    publish bundle
 }
 
 scanApi {

--- a/djvm/cli/build.gradle
+++ b/djvm/cli/build.gradle
@@ -67,8 +67,8 @@ def shadowZip = tasks.register('shadowZip', Zip) {
 }
 
 artifacts {
-    archives shadowZip.flatMap { it.archiveFile }
-    publish shadowZip.flatMap { it.archiveFile }
+    archives shadowZip
+    publish shadowZip
 }
 
 publish {

--- a/djvm/osgi/build.gradle
+++ b/djvm/osgi/build.gradle
@@ -133,7 +133,7 @@ tasks.named('check') {
 }
 
 artifacts {
-    archives testBundle.flatMap { it.archiveFile }
+    archives testBundle
 }
 
 publish {

--- a/djvm/secure/build.gradle
+++ b/djvm/secure/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 
-    sandboxTesting sourceSets.getByName('main').runtimeClasspath
+    sandboxTesting sourceSets.main.runtimeClasspath
     sandboxTesting "net.corda:corda-deserializers-djvm:$corda_version"
     sandboxTesting "org.slf4j:slf4j-nop:$slf4j_version"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ artifactory_contextUrl=https://software.r3.com/artifactory
 corda_version=4.6-SNAPSHOT
 corda_plugins_version=5.0.12
 kotlin_plugin_version=1.3.72
-shadow_plugin_version=6.0.0
+shadow_plugin_version=6.1.0
 bnd_plugin_version=5.2.0
 
 asm_version=8.0.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
         id 'net.corda.plugins.api-scanner' version corda_plugins_version
         id 'com.github.johnrengelman.shadow' version shadow_plugin_version
         id 'biz.aQute.bnd.builder' version bnd_plugin_version
-        id 'com.jfrog.artifactory' version '4.17.1'
+        id 'com.jfrog.artifactory' version '4.17.2'
         id 'org.owasp.dependencycheck' version '5.3.2.1'
         id 'com.gradle.enterprise' version '3.4.1'
     }


### PR DESCRIPTION
Update the Gradle build scripts:
- Shadow plugin 6.0.0 -> 6.1.0
- Artifactory plugin: 4.17.1 -> 4.17.2
- More concise references to SourceSets.
- Use "lazy" task references in artifacts block.