### PR TITLE
NOTICK: Upgrade Corda artifacts to 4.8-SNAPSHOT for testing.

### DIFF
--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -6,7 +6,7 @@ artifactory_contextUrl=https://software.r3.com/artifactory
 
 djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
-corda_version=4.7-SNAPSHOT
+corda_version=4.8-SNAPSHOT
 corda_tokens_version=1.1
 
 kotlin_version=1.3.72

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ deterministic_rt_version=1.0-RC02
 
 artifactory_contextUrl=https://software.r3.com/artifactory
 
-corda_version=4.7-SNAPSHOT
+corda_version=4.8-SNAPSHOT
 corda_plugins_version=5.0.12
 kotlin_plugin_version=1.3.72
 shadow_plugin_version=6.1.0


### PR DESCRIPTION
Test against Corda 4.8-SNAPSHOT rather than 4.7-SNAPSHOT.