### PR TITLE
NOTICK: Prefer Class.forName() over ClassLoader.loadClass().

### DIFF
--- a/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
+++ b/djvm/cli/src/main/kotlin/net/corda/djvm/tools/cli/ClassCommand.kt
@@ -154,7 +154,7 @@ abstract class ClassCommand : CommandBase() {
 
     private fun lookUpClass(className: String): Class<*> {
         return try {
-            classLoader.loadClass(className)
+            Class.forName(className, false, classLoader)
         } catch (exception: NoClassDefFoundError) {
             val reference = exception.message?.let {
                 "referenced class ${classModule.getFormattedClassName(it)} in "

--- a/djvm/src/main/java/sandbox/java/lang/DJVMClassLoader.java
+++ b/djvm/src/main/java/sandbox/java/lang/DJVMClassLoader.java
@@ -59,6 +59,6 @@ public final class DJVMClassLoader {
 
     @NotNull
     public static Class<?> loadClass(@NotNull ClassLoader classLoader, String className) throws ClassNotFoundException {
-        return classLoader.loadClass(DJVM.toSandbox(className));
+        return Class.forName(DJVM.toSandbox(className), false, classLoader);
     }
 }

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/Predicates.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/Predicates.kt
@@ -20,8 +20,8 @@ import java.util.function.Predicate
     NoSuchMethodException::class
 )
 fun SandboxClassLoader.createRawPredicateFactory(): Function<in Any, out Predicate<in Any?>> {
-    val taskClass = loadClass("sandbox.PredicateTask")
-    val predicateClass = loadClass("sandbox.java.util.function.Predicate")
+    val taskClass = Class.forName("sandbox.PredicateTask", false, this)
+    val predicateClass = Class.forName("sandbox.java.util.function.Predicate", false, this)
     val constructor = try {
         doPrivileged(PrivilegedExceptionAction {
             @Suppress("unchecked_cast")

--- a/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/rewiring/SandboxClassLoader.kt
@@ -172,7 +172,7 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class
     )
     private fun createBasicTask(taskName: String): Function<in Any?, out Any?> {
-        val taskClass = loadClass(taskName)
+        val taskClass = Class.forName(taskName, false, this)
         @Suppress("unchecked_cast")
         val task = try {
             doPrivileged(PrivilegedExceptionAction { taskClass.getDeclaredConstructor() })
@@ -248,8 +248,8 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class
     )
     private fun createTaskFactory(taskName: String): Function<in Any, out Function<in Any?, out Any?>> {
-        val taskClass = loadClass(taskName)
-        val functionClass = loadClass("sandbox.java.util.function.Function")
+        val taskClass = Class.forName(taskName, false, this)
+        val functionClass = Class.forName("sandbox.java.util.function.Function", false, this)
         val constructor = try {
             doPrivileged(PrivilegedExceptionAction {
                 @Suppress("unchecked_cast")
@@ -308,7 +308,7 @@ class SandboxClassLoader private constructor(
         NoSuchMethodException::class
     )
     fun <T> createForImport(task: Function<in T, out Any?>): Function<in T, out Any?> {
-        val taskClass = loadClass("sandbox.ImportTask")
+        val taskClass = Class.forName("sandbox.ImportTask", false, this)
         @Suppress("unchecked_cast")
         return try {
             doPrivileged(PrivilegedExceptionAction { taskClass.getDeclaredConstructor(Function::class.java) })
@@ -341,7 +341,7 @@ class SandboxClassLoader private constructor(
     }
 
     private fun loadClassForSandbox(className: String): Class<*> {
-        return loadClass(resolveName(className))
+        return Class.forName(resolveName(className), false, this)
     }
 
     @Throws(ClassNotFoundException::class)
@@ -528,7 +528,7 @@ class SandboxClassLoader private constructor(
         // Try to define the transformed class.
         val clazz: Class<*> = try {
             when {
-                classResolver.isWhitelistedClass(sourceName.asResourcePath) -> supportingClassLoader.loadClass(sourceName)
+                classResolver.isWhitelistedClass(sourceName.asResourcePath) -> Class.forName(sourceName, false, supportingClassLoader)
                 else -> defineClass(resolvedName, byteCode)
             }
         } catch (exception: SecurityException) {

--- a/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
+++ b/djvm/src/main/kotlin/sandbox/java/lang/DJVM.kt
@@ -761,7 +761,7 @@ fun getBundle(baseName: String, locale: Locale, control: ResourceBundle.Control)
 private fun loadResourceBundle(control: ResourceBundle.Control, key: DJVMResourceKey): ResourceBundle {
     val bundleName = control.toBundleName(key.baseName, key.locale)
     val bundle = try {
-        val bundleClass = systemClassLoader.loadClass(toSandbox(bundleName.toString()))
+        val bundleClass = Class.forName(toSandbox(bundleName.toString()), false, systemClassLoader)
         if (ResourceBundle::class.java.isAssignableFrom(bundleClass)) {
             (bundleClass.getDeclaredConstructor().newInstance() as ResourceBundle).also {
                 it.init(key.baseName, key.locale)

--- a/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectTest.java
+++ b/djvm/src/test/java/net/corda/djvm/execution/SandboxObjectTest.java
@@ -29,7 +29,7 @@ class SandboxObjectTest extends TestBase {
         sandbox(ctx -> {
             try {
                 SandboxClassLoader classLoader = ctx.getClassLoader();
-                Class<?> sandboxParentClass = classLoader.loadClass("sandbox.java.lang.Object");
+                Class<?> sandboxParentClass = Class.forName("sandbox.java.lang.Object", false, classLoader);
                 Class<?> sandboxClass = classLoader.toSandboxClass(BaseObject.class);
                 assertAll(
                     () -> assertEquals("sandbox.com.example.testing.BaseObject", sandboxClass.getName()),
@@ -54,7 +54,7 @@ class SandboxObjectTest extends TestBase {
         sandbox(ctx -> {
             try {
                 SandboxClassLoader classLoader = ctx.getClassLoader();
-                Class<?> sandboxParentClass = classLoader.loadClass("sandbox.java.lang.Object");
+                Class<?> sandboxParentClass = Class.forName("sandbox.java.lang.Object", false, classLoader);
                 Class<?> sandboxClass = classLoader.toSandboxClass(GenericObject.class);
                 assertAll(
                     () -> assertEquals("sandbox.com.example.testing.GenericObject", sandboxClass.getName()),
@@ -79,7 +79,7 @@ class SandboxObjectTest extends TestBase {
         sandbox(ctx -> {
             try {
                 SandboxClassLoader classLoader = ctx.getClassLoader();
-                Class<?> sandboxParentClass = classLoader.loadClass("sandbox.com.example.testing.GenericObject");
+                Class<?> sandboxParentClass = Class.forName("sandbox.com.example.testing.GenericObject", false, classLoader);
                 Class<?> sandboxClass = classLoader.toSandboxClass(ConcreteObject.class);
                 assertAll(
                     () -> assertEquals("sandbox.com.example.testing.ConcreteObject", sandboxClass.getName()),


### PR DESCRIPTION
Java recommends loading classes via `Class.forName()` rather than `ClassLoader.loadClass()` because `Class.forName()` can return an already-loaded class without taking any locks. Sandboxes are single-threaded, so this change will be most significant when loading the shared white-listed classes. The rest is just "good practice".