### PR TITLE
NOTICK: Upgrade Gradle Enterprise plugin 3.4.1 -> 3.6.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'biz.aQute.bnd.builder' version bnd_plugin_version
         id 'com.jfrog.artifactory' version artifactory_plugin_version
         id 'org.owasp.dependencycheck' version '5.3.2.1'
-        id 'com.gradle.enterprise' version '3.4.1'
+        id 'com.gradle.enterprise' version '3.6'
     }
 }
 


### PR DESCRIPTION
The Enterprise plugin allows us to perform build scans.