### PR TITLE
NOTICK: Update dependency versions and Gradle usage.

### DIFF
--- a/deterministic-rt/build.gradle
+++ b/deterministic-rt/build.gradle
@@ -209,5 +209,5 @@ publishing {
 }
 
 tasks.register('install') {
-    dependsOn publishToMavenLocal
+    dependsOn 'publishToMavenLocal'
 }

--- a/djvm-example/build.gradle
+++ b/djvm-example/build.gradle
@@ -37,8 +37,13 @@ repositories {
 }
 
 configurations {
-    jdkRt
-    sandboxTesting
+    jdkRt {
+        canBeConsumed = false
+    }
+
+    sandboxTesting {
+        canBeConsumed = false
+    }
 
     all {
         resolutionStrategy {

--- a/djvm-example/gradle.properties
+++ b/djvm-example/gradle.properties
@@ -6,12 +6,12 @@ artifactory_contextUrl=https://software.r3.com/artifactory
 
 djvm_version=1.2-SNAPSHOT
 deterministic_rt_version=1.0-RC02
-corda_version=4.8
+corda_version=4.8.1
 corda_tokens_version=1.1
 
 kotlin_version=1.3.72
 scala_version=2.13.3
 assertj_version=3.16.1
-junit_jupiter_version=5.7.0
+junit_jupiter_version=5.7.2
 log4j_version=2.13.3
-slf4j_version=1.7.30
+slf4j_version=1.7.32

--- a/djvm/build.gradle
+++ b/djvm/build.gradle
@@ -41,8 +41,15 @@ tasks.named('compileJava9Java', JavaCompile) {
 }
 
 configurations {
-    jdkRt
-    sandboxTesting
+    jdkRt {
+        canBeConsumed = false
+    }
+
+    sandboxTesting {
+        canBeConsumed = false
+    }
+
+    bundles
     shadow.extendsFrom bundles
     testImplementation.extendsFrom shadow
 }
@@ -79,7 +86,9 @@ dependencies {
     jdkRt "net.corda:deterministic-rt:$deterministic_rt_version"
 
     // The DJVM will need this classpath to run the unit tests.
-    sandboxTesting files(sourceSets.test.output)
+    sandboxTesting files(sourceSets.test.output) {
+        builtBy tasks.named('testClasses')
+    }
     sandboxTesting "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     sandboxTesting "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }

--- a/djvm/osgi/build.gradle
+++ b/djvm/osgi/build.gradle
@@ -2,6 +2,8 @@ import aQute.bnd.gradle.Bundle
 import aQute.bnd.gradle.Resolve
 import aQute.bnd.gradle.TestOSGi
 import static org.gradle.api.JavaVersion.current
+import static org.gradle.api.attributes.LibraryElements.JAR
+import static org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
 
 plugins {
     id 'org.jetbrains.kotlin.jvm'
@@ -11,8 +13,6 @@ plugins {
 }
 
 description 'OSGi extensions for DJVM'
-
-evaluationDependsOn(':djvm:secure')
 
 repositories {
     maven {
@@ -24,10 +24,20 @@ repositories {
 }
 
 configurations {
-    jdkRt
-    sandboxTesting
+    jdkRt {
+        canBeConsumed = false
+    }
+
+    sandboxTesting {
+        canBeConsumed = false
+
+        attributes {
+            attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, JAR))
+        }
+    }
 
     kotlinJar {
+        canBeConsumed = false
         transitive = false
     }
 
@@ -117,12 +127,8 @@ def resolve = tasks.register('resolve', Resolve) {
     bndrun = 'test.bndrun'
 }
 
-// Use test cases from this project, as we're only really
-// interested in the DJVM's behaviour under OSGi here.
-def secureJar = project(':djvm:secure').tasks.named('jar', Jar)
-
 def testOSGi = tasks.register('testOSGi', TestOSGi) {
-    dependsOn resolve, secureJar
+    dependsOn resolve, configurations.sandboxTesting.buildDependencies,
     bundles = files(sourceSets.test.runtimeClasspath, configurations.archives.artifacts.files)
     bndrun = 'test.bndrun'
 }

--- a/djvm/osgi/test.bndrun
+++ b/djvm/osgi/test.bndrun
@@ -55,4 +55,4 @@
 	org.apache.felix.log;version='[1.2.4,1.2.5)',\
 	org.apache.felix.logback;version='[1.0.2,1.0.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	slf4j.api;version='[1.7.30,1.7.31)'
+	slf4j.api;version='[1.7.32,1.7.33)'

--- a/djvm/secure/build.gradle
+++ b/djvm/secure/build.gradle
@@ -22,8 +22,13 @@ repositories {
 }
 
 configurations {
-    jdkRt
-    sandboxTesting
+    jdkRt {
+        canBeConsumed = false
+    }
+
+    sandboxTesting {
+        canBeConsumed = false
+    }
 
     all {
         resolutionStrategy {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ deterministic_rt_version=1.0-RC02
 
 artifactory_contextUrl=https://software.r3.com/artifactory
 
-corda_version=4.8
+corda_version=4.8.1
 corda_plugins_version=5.0.13
 kotlin_plugin_version=1.3.72
 dokka_plugin_version=1.4.32
@@ -28,10 +28,9 @@ junit_platform_version=1.7.2
 kotlin_version=1.2.71
 log4j_version=2.13.3
 picocli_version=3.9.6
-slf4j_version=1.7.30
+slf4j_version=1.7.32
 osgi_version=8.0.0
 
-osgi_component_annotations_version=1.4.0
 osgi_log_version=1.4.0
 osgi_util_function_version=1.1.0
 osgi_util_promise_version=1.1.1


### PR DESCRIPTION
Update dependencies:
- Corda 4.8 -> 4.8.1
- SLF4J 1.7.30 -> 1.7.32
- JUnit 5.7.0 -> 5.7.2

Use Gradle variant attribute to select jar artifact over classes for testing, and configure task dependencies more correctly.