### PR TITLE
NOTICK: Add ImportSupplierTask to wrap Supplier instances for importing.

### DIFF
--- a/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
+++ b/djvm/src/main/kotlin/net/corda/djvm/analysis/AnalysisConfiguration.kt
@@ -204,6 +204,7 @@ class AnalysisConfiguration private constructor(
         ).sandboxed() + setOf(
             "sandbox/BasicInput",
             "sandbox/BasicOutput",
+            "sandbox/ImportSupplierTask",
             "sandbox/ImportTask",
             "sandbox/PredicateTask",
             "sandbox/RawTask",

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ImportSupplierTaskTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ImportSupplierTaskTest.kt
@@ -1,0 +1,64 @@
+package net.corda.djvm.execution
+
+import java.io.InputStream
+import java.io.NotSerializableException
+import java.util.function.Function
+import java.util.function.Supplier
+import net.corda.djvm.SandboxType.KOTLIN
+import net.corda.djvm.TestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.fail
+
+class ImportSupplierTaskTest : TestBase(KOTLIN) {
+    companion object {
+        private const val MESSAGE = "Hello from the outside World!"
+    }
+
+    /**
+     * Test we can import a [java.io.InputStream] to be
+     * consumed inside the sandbox as [sandbox.java.io.InputStream].
+     */
+    @Test
+    fun `import stream from outside sandbox`() = sandbox {
+        val taskFactory = classLoader.createRawTaskFactory()
+        val readStream = classLoader.createSandboxFunction().apply(ReadInputStream::class.java)
+        val streamSupplier = classLoader.createForImport(
+            Supplier { classLoader.createBasicInput().apply(MESSAGE.byteInputStream()) }
+        )
+        val sandboxTask = taskFactory.apply(readStream)
+        val result = sandboxTask.apply(streamSupplier) ?: fail("Result is missing!")
+        assertEquals("sandbox.java.lang.String", result::class.java.name)
+        assertEquals(MESSAGE, result.toString())
+
+        // And check that we're handling nulls correctly too.
+        val nullSupplier = classLoader.createForImport(Supplier { null })
+        assertNull(sandboxTask.apply(nullSupplier), "Task does not handle a supplier of null.")
+        assertNull(sandboxTask.apply(null), "Task does not handle null correctly.")
+    }
+
+    class ReadInputStream : Function<Supplier<InputStream?>?, String?> {
+        override fun apply(input: Supplier<InputStream?>?): String? {
+            return input?.get()?.use {
+                String(it.readBytes())
+            }
+        }
+    }
+
+    @Test
+    fun `failing import from outside sandbox`() = sandbox {
+        val streamSupplier = classLoader.createForImport(
+            Supplier { throw NotSerializableException("Corrupt stream!") }
+        )
+        val readStream = classLoader.createSandboxFunction().apply(ReadInputStream::class.java)
+        val sandboxTask = classLoader.createRawTaskFactory().apply(readStream)
+        val ex = assertThrows<RuntimeException> { sandboxTask.apply(streamSupplier) }
+        assertThat(ex)
+            .isExactlyInstanceOf(RuntimeException::class.java)
+            .hasMessage("java.io.NotSerializableException -> Corrupt stream!")
+            .hasStackTraceContaining("sandbox.ImportSupplierTask")
+    }
+}

--- a/djvm/src/test/kotlin/net/corda/djvm/execution/ImportTaskTest.kt
+++ b/djvm/src/test/kotlin/net/corda/djvm/execution/ImportTaskTest.kt
@@ -28,13 +28,12 @@ class ImportTaskTest : TestBase(KOTLIN) {
         val createStream = classLoader.createForImport(
             CreateInputStream().andThen(classLoader.createBasicInput())
         )
-        val pipelineTask = taskFactory.apply(createStream)
-            .andThen(taskFactory.apply(readStream))
+        val pipelineTask = createStream.andThen(taskFactory.apply(readStream))
         val result = pipelineTask.apply(MESSAGE) ?: fail("Result is missing!")
         assertEquals("sandbox.java.lang.String", result::class.java.name)
         assertEquals(MESSAGE, result.toString())
 
-        // And check that we're handling nulls correctly too.
+        // And check that we're handling nulls correctly too.
         assertNull(pipelineTask.apply(null), "Pipeline does not handle null correctly.")
     }
 
@@ -57,8 +56,7 @@ class ImportTaskTest : TestBase(KOTLIN) {
         val importTask = classLoader.createForImport(
             ShowFailingInputStream().andThen(classLoader.createBasicInput())
         )
-        val sandboxTask = classLoader.createRawTaskFactory().apply(importTask)
-        val ex = assertThrows<RuntimeException> { sandboxTask.apply(MESSAGE.byteInputStream()) }
+        val ex = assertThrows<RuntimeException> { importTask.apply(MESSAGE.byteInputStream()) }
         assertThat(ex)
             .isExactlyInstanceOf(RuntimeException::class.java)
             .hasMessage("java.io.NotSerializableException -> Corrupt stream!")


### PR DESCRIPTION
The idea is that suppliers can provide sandbox objects that have been created outside the sandbox via other means, and so make it easier to build complex structures inside the sandbox.